### PR TITLE
Multiple dynamic panels only point to source used by the first panel #70

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -192,7 +192,7 @@ Parser.prototype._parse = function (element, context) {
       this.dynamicIncludeSrc.push(element.attribs.src);
       try {
         if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.resolve('/', path.relative(process.cwd(), element.attribs.src)));
+          let resultDir = path.dirname(path.join('{{baseUrl}}', path.relative(process.cwd(), element.attribs.src)));
           element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
           if (element.attribs.fragment) {
             element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
@@ -213,7 +213,7 @@ Parser.prototype._parse = function (element, context) {
       this.dynamicIncludeSrc.push(element.attribs.src);
       try {
         if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.resolve('/', path.relative(process.cwd(), element.attribs.src)));
+          let resultDir = path.dirname(path.join('{{baseUrl}}', path.relative(process.cwd(), element.attribs.src)));
           element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
           if (element.attribs.fragment) {
             element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
@@ -231,7 +231,7 @@ Parser.prototype._parse = function (element, context) {
       this.dynamicIncludeSrc.push(element.attribs.src);
       try {
         if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.resolve('/', path.relative(process.cwd(), element.attribs.src)));
+          let resultDir = path.dirname(path.join('{{baseUrl}}', path.relative(process.cwd(), element.attribs.src)));
           element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
           if (element.attribs.fragment) {
             element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path


### PR DESCRIPTION
Fixes Markbind/se-book#13, #70, #73

I wrongly used [`path.resolve`](https://github.com/MarkBind/markbind/commit/73722d12462f53e107337ba1c70a4e39ebe4d545#diff-3fab227e34d65fe9bb2d6ea53eec41cfR195), which has a different behavior on Windows, for a url.
Instead, the relative path should be rebased on `baseUrl`.