### PR TITLE
Remove label wrapper for radio list

### DIFF
--- a/lib/markdown-it/markdown-it-radio-button.js
+++ b/lib/markdown-it/markdown-it-radio-button.js
@@ -1,7 +1,6 @@
 const crypto = require('crypto');
 
 var disableRadio = false;
-var useLabelWrapper = true;
 
 /**
  * Modified from https://github.com/revin/markdown-it-task-lists/blob/master/index.js
@@ -9,7 +8,6 @@ var useLabelWrapper = true;
 module.exports = function(md, options) {
   if (options) {
     disableRadio = !options.enabled;
-    useLabelWrapper = !!options.label;
   }
 
   md.core.ruler.after('inline', 'radio-lists', function(state) {
@@ -76,11 +74,6 @@ function radioify(token, TokenConstructor, radioId) {
   token.children.unshift(makeRadioButton(token, TokenConstructor, radioId));
   token.children[1].content = token.children[1].content.slice(3);
   token.content = token.content.slice(3);
-
-  if (useLabelWrapper) {
-    token.children.unshift(beginLabel(TokenConstructor));
-    token.children.push(endLabel(TokenConstructor));
-  }
 }
 
 function makeRadioButton(token, TokenConstructor, radioId) {
@@ -92,20 +85,6 @@ function makeRadioButton(token, TokenConstructor, radioId) {
     radio.content = '<input class="radio-list-input" checked="" name="' + radioId + '"' + disabledAttr + 'type="radio">';
   }
   return radio;
-}
-
-// these next two functions are kind of hacky; probably should really be a
-// true block-level token with .tag=='label'
-function beginLabel(TokenConstructor) {
-  var token = new TokenConstructor('html_inline', '', 0);
-  token.content = '<label>';
-  return token;
-}
-
-function endLabel(TokenConstructor) {
-  var token = new TokenConstructor('html_inline', '', 0);
-  token.content = '</label>';
-  return token;
 }
 
 function isInline(token) { return token.type === 'inline'; }


### PR DESCRIPTION
Would like to re-look into the issue #95 that was "resolved" recently. 

Initially I had noted that the label was causing the bold text and made changes to the css to rectify it in https://github.com/MarkBind/markbind-cli/pull/12

However I feel that the label wrapper should not be there to be consistent with task-list-items.

 `- [ ] item`
```html
<li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox"> item</li>
```

This pr removes the wrapper from the markdown-it-radio-button plugin. MCQ options will not have the default bold stlye. https://github.com/MarkBind/markbind-cli/pull/12 can be reverted as it is extraneous.

Would like to know your thoughts @acjh. Thanks!