### PR TITLE
Speed up live reload process

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,10 +31,15 @@ function Parser(options) {
   this._onError = this._options.errorHandler || console.error;
   this._fileCache = {};
   this.dynamicIncludeSrc = [];
+  this.staticIncludeSrc = [];
 }
 
 Parser.prototype.getDynamicIncludeSrc = function () {
   return _.clone(this.dynamicIncludeSrc);
+};
+
+Parser.prototype.getStaticIncludeSrc = function () {
+  return _.clone(this.staticIncludeSrc);
 };
 
 Parser.prototype._preprocess = function (element, context, config) {
@@ -67,6 +72,9 @@ Parser.prototype._preprocess = function (element, context, config) {
     if (isUrl) {
       return element; // only keep url path for dynamic
     }
+
+    // is static include file
+    this.staticIncludeSrc.push({from: context.cwf, to: filePath});
 
     let isIncludeSrcMd = utils.getExtName(filePath) === 'md';
 


### PR DESCRIPTION
Instead of rebuilding the entire site for a change to one file, rebuild relevant pages only.

If changed file was statically or dynamically included in page, regenerate the page.

Helps with build performance when editing sites. Related #88 

https://github.com/MarkBind/markbind-cli/pull/17

### Testing

#### Steps
1. `$ markbind serve`
2. make changes to files.
3. save _site file
4. `$ markbind build`
5. compare old _site with new _site

##### Paths tried
- admin/project-v1.5rc
- schedule/week1/index.html
- book/codeQuality/practices/useNameExplain/text.md

##### Results
![image](https://user-images.githubusercontent.com/22221132/35431088-18b3ecfe-02b6-11e8-8ad8-87a9b1e34578.png)
![image](https://user-images.githubusercontent.com/22221132/35431090-1dc3ef5a-02b6-11e8-8d3e-2da91ffd5015.png)

- These files were not rebuilt correctly in step 3 above, possibly related to #127


