### PR TITLE
Better error reporting for missing files #120

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -75,8 +75,10 @@ Parser.prototype._preprocess = function (element, context, config) {
         self._fileCache[filePath] : fs.readFileSync(filePath, 'utf8');
     } catch (e) {
       // Read file fail
+      let missingReferenceError = ` Missing reference in: ${element.attribs[ATTRIB_CWF]}`;
       this._onError(e);
-      element.children = cheerio.parseHTML(utils.createErrorElement(e), true);
+      this._onError(missingReferenceError);
+      element.children = cheerio.parseHTML(utils.createErrorElement(e, missingReferenceError), true);
       return element;
     }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -75,10 +75,10 @@ Parser.prototype._preprocess = function (element, context, config) {
         self._fileCache[filePath] : fs.readFileSync(filePath, 'utf8');
     } catch (e) {
       // Read file fail
-      let missingReferenceError = ` Missing reference in: ${element.attribs[ATTRIB_CWF]}`;
+      let missingReferenceErrorMessage = `Missing reference in: ${element.attribs[ATTRIB_CWF]}`;
+      e.message += `\n${missingReferenceErrorMessage}`;
       this._onError(e);
-      this._onError(missingReferenceError);
-      element.children = cheerio.parseHTML(utils.createErrorElement(e, missingReferenceError), true);
+      element.children = cheerio.parseHTML(utils.createErrorElement(e), true);
       return element;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ module.exports = {
     return r.test(path);
   },
 
-  createErrorElement: function (error, message = '') {
-    return `<div style="color: red">${error.message + message}</div>`;
+  createErrorElement: function (error) {
+    return `<div style="color: red">${error.message}</div>`;
   },
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ module.exports = {
     return r.test(path);
   },
 
-  createErrorElement: function (error) {
-    return `<div style="color: red">${error.message}</div>`;
+  createErrorElement: function (error, message = '') {
+    return `<div style="color: red">${error.message + message}</div>`;
   },
 };


### PR DESCRIPTION
Fixes #120 

When an included file cannot be found, report the missing referencing file in the console and the site as well.
