### PR TITLE
Support reuse of boilerplate files #110

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -76,9 +76,6 @@ Parser.prototype._preprocess = function (element, context, config) {
       return element; // only keep url path for dynamic
     }
 
-    // is static include file
-    this.staticIncludeSrc.push({from: context.cwf, to: filePath});
-
     let isIncludeSrcMd = utils.getExtName(filePath) === 'md';
 
     let actualFilePath = filePath;
@@ -86,6 +83,9 @@ Parser.prototype._preprocess = function (element, context, config) {
       let boilerplateFilePath = calculateBoilerplateFilePath(filePath, config);
       actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
     }
+
+    // is static include file
+    this.staticIncludeSrc.push({from: context.cwf, to: actualFilePath});
 
     try {
       self._fileCache[actualFilePath] = self._fileCache[actualFilePath] ?

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,6 +19,9 @@ const nunjucks = require('nunjucks');
 
 const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';
+
+const BOILERPLATE_DIRECTORY_NAME = '_boilerplates';
+
 /*
  * Utils
  */
@@ -78,9 +81,14 @@ Parser.prototype._preprocess = function (element, context, config) {
 
     let isIncludeSrcMd = utils.getExtName(filePath) === 'md';
 
+    let boilerplateFilePath = calculateBoilerplateFilePath(includeSrcPath);
+    let actualFilePath = (utils.fileExists(filePath) || !utils.fileExists(boilerplateFilePath))
+                       ? filePath
+                       : boilerplateFilePath;
+
     try {
-      self._fileCache[filePath] = self._fileCache[filePath] ?
-        self._fileCache[filePath] : fs.readFileSync(filePath, 'utf8');
+      self._fileCache[actualFilePath] = self._fileCache[actualFilePath] ?
+        self._fileCache[actualFilePath] : fs.readFileSync(actualFilePath, 'utf8');
     } catch (e) {
       // Read file fail
       let missingReferenceErrorMessage = `Missing reference in: ${element.attribs[ATTRIB_CWF]}`;
@@ -96,7 +104,7 @@ Parser.prototype._preprocess = function (element, context, config) {
       element.name = 'markdown';
     }
 
-    let fileContent = self._fileCache[filePath]; // cache the file contents to save some I/O
+    let fileContent = self._fileCache[actualFilePath]; // cache the file contents to save some I/O
     delete element.attribs.src;
     delete element.attribs.inline;
 
@@ -204,7 +212,9 @@ Parser.prototype._parse = function (element, context) {
     case 'dynamic-panel': {
       let hasIsOpen = _.hasIn(element.attribs, 'isOpen');
       element.attribs.isOpen = hasIsOpen ? hasIsOpen : false;
-      if (utils.fileExists(element.attribs.src)) {
+      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
         if (element.attribs.fragment) {
@@ -220,7 +230,9 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) {
         break;
       }
-      if (utils.fileExists(element.attribs.src)) {
+      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
         if (element.attribs.fragment) {
@@ -233,7 +245,9 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) { // dynamic panel
         break;
       }
-      if (utils.fileExists(element.attribs.src)) {
+      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
         if (element.attribs.fragment) {
@@ -297,8 +311,13 @@ Parser.prototype.includeFile = function (file, config) {
       decodeEntities: true
     });
 
+    let boilerplateFilePath = calculateBoilerplateFilePath(file);
+    let actualFilePath = (utils.fileExists(file) || !utils.fileExists(boilerplateFilePath))
+                       ? file
+                       : boilerplateFilePath;
+
     // Read files
-    fs.readFile(file, (err, data) => {
+    fs.readFile(actualFilePath, (err, data) => {
       if (err) {
         reject(err);
         return;
@@ -475,6 +494,10 @@ Parser.prototype._rebaseReferenceForStaticIncludes = function (pageData, element
   let newBase = fileBase.relative;
   return nunjucks.renderString(pageData, { baseUrl: `{{hostBaseUrl}}/${newBase}` });
 };
+
+function calculateBoilerplateFilePath(filePath) {
+  return path.resolve(path.join(process.cwd(), BOILERPLATE_DIRECTORY_NAME), path.basename(filePath));
+}
 
 function calculateNewBaseUrl(filePath, root, lookUp) {
   function calculate(file, result) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -81,10 +81,11 @@ Parser.prototype._preprocess = function (element, context, config) {
 
     let isIncludeSrcMd = utils.getExtName(filePath) === 'md';
 
-    let boilerplateFilePath = calculateBoilerplateFilePath(includeSrcPath);
-    let actualFilePath = (utils.fileExists(filePath) || !utils.fileExists(boilerplateFilePath))
-                       ? filePath
-                       : boilerplateFilePath;
+    let actualFilePath = filePath;
+    if (!utils.fileExists(filePath)) {
+      let boilerplateFilePath = calculateBoilerplateFilePath(filePath, config);
+      actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
+    }
 
     try {
       self._fileCache[actualFilePath] = self._fileCache[actualFilePath] ?
@@ -186,11 +187,11 @@ Parser.prototype._preprocess = function (element, context, config) {
   return element;
 };
 
-Parser.prototype._parse = function (element, context) {
+Parser.prototype._parse = function (element, context, config) {
   let self = this;
   if (_.isArray(element)) {
     return element.map((el) => {
-      return self._parse(el, context);
+      return self._parse(el, context, config);
     });
   }
 
@@ -212,8 +213,7 @@ Parser.prototype._parse = function (element, context) {
     case 'dynamic-panel': {
       let hasIsOpen = _.hasIn(element.attribs, 'isOpen');
       element.attribs.isOpen = hasIsOpen ? hasIsOpen : false;
-      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
-      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(calculateBoilerplateFilePath(element.attribs.src, config));
       if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
@@ -230,8 +230,7 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) {
         break;
       }
-      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
-      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(calculateBoilerplateFilePath(element.attribs.src, config));
       if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
@@ -245,8 +244,7 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) { // dynamic panel
         break;
       }
-      let boilerplateFilePath = calculateBoilerplateFilePath(element.attribs.src);
-      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(boilerplateFilePath);
+      let fileExists = utils.fileExists(element.attribs.src) || utils.fileExists(calculateBoilerplateFilePath(element.attribs.src, config));
       if (fileExists) {
         let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
         element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
@@ -260,7 +258,7 @@ Parser.prototype._parse = function (element, context) {
 
     if (element.children) {
       element.children.forEach(child => {
-        self._parse(child, context);
+        self._parse(child, context, config);
       });
     }
 
@@ -311,10 +309,11 @@ Parser.prototype.includeFile = function (file, config) {
       decodeEntities: true
     });
 
-    let boilerplateFilePath = calculateBoilerplateFilePath(file);
-    let actualFilePath = (utils.fileExists(file) || !utils.fileExists(boilerplateFilePath))
-                       ? file
-                       : boilerplateFilePath;
+    let actualFilePath = file;
+    if (!utils.fileExists(file)) {
+      let boilerplateFilePath = calculateBoilerplateFilePath(file, config);
+      actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
+    }
 
     // Read files
     fs.readFile(actualFilePath, (err, data) => {
@@ -337,7 +336,7 @@ Parser.prototype.includeFile = function (file, config) {
   });
 };
 
-Parser.prototype.renderFile = function (file) {
+Parser.prototype.renderFile = function (file, config) {
   let context = {};
   context.cwf = file; // current working file
   context.mode = 'render';
@@ -348,7 +347,7 @@ Parser.prototype.renderFile = function (file) {
         return;
       }
       let nodes = dom.map(d => {
-        return this._parse(d, context);
+        return this._parse(d, context, config);
       });
       nodes.forEach(d => {
         this._trimNodes(d);
@@ -495,8 +494,9 @@ Parser.prototype._rebaseReferenceForStaticIncludes = function (pageData, element
   return nunjucks.renderString(pageData, { baseUrl: `{{hostBaseUrl}}/${newBase}` });
 };
 
-function calculateBoilerplateFilePath(filePath) {
-  return path.resolve(path.join(process.cwd(), BOILERPLATE_DIRECTORY_NAME), path.basename(filePath));
+function calculateBoilerplateFilePath(filePath, config) {
+  let base = calculateNewBaseUrl(filePath, config.rootPath, config.baseUrlMap).relative;
+  return path.resolve(base, BOILERPLATE_DIRECTORY_NAME, path.basename(filePath));
 }
 
 function calculateNewBaseUrl(filePath, root, lookUp) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -204,16 +204,12 @@ Parser.prototype._parse = function (element, context) {
     case 'dynamic-panel': {
       let hasIsOpen = _.hasIn(element.attribs, 'isOpen');
       element.attribs.isOpen = hasIsOpen ? hasIsOpen : false;
-      try {
-        if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
-          element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
-          if (element.attribs.fragment) {
-            element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
-          }
+      if (utils.fileExists(element.attribs.src)) {
+        let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
+        element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
+        if (element.attribs.fragment) {
+          element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
         }
-      } catch (e) {
-        // Pass: src is not on filesystem (invalid or remote)
       }
       element.attribs['no-close'] = 'true';
       element.attribs['no-switch'] = 'true';
@@ -224,16 +220,12 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) {
         break;
       }
-      try {
-        if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
-          element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
-          if (element.attribs.fragment) {
-            element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
-          }
+      if (utils.fileExists(element.attribs.src)) {
+        let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
+        element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
+        if (element.attribs.fragment) {
+          element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
         }
-      } catch (e) {
-        // Pass: src is not on filesystem (invalid or remote)
       }
       break;
     }
@@ -241,16 +233,12 @@ Parser.prototype._parse = function (element, context) {
       if (!_.hasIn(element.attribs, 'src')) { // dynamic panel
         break;
       }
-      try {
-        if (fs.statSync(element.attribs.src).isFile()) {
-          let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
-          element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
-          if (element.attribs.fragment) {
-            element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
-          }
+      if (utils.fileExists(element.attribs.src)) {
+        let resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(process.cwd(), element.attribs.src)));
+        element.attribs.src = path.join(resultDir, utils.setExtension(path.basename(element.attribs.src), '._include_.html'));
+        if (element.attribs.fragment) {
+          element.attribs.src = `${element.attribs.src}#${element.attribs.fragment}`; // add hash back to path
         }
-      } catch (e) {
-        // Pass: src is not on filesystem (invalid or remote)
       }
       break;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,14 @@ module.exports = {
     }
   },
 
+  fileExists: function (filePath) {
+    try {
+      return fs.statSync(filePath).isFile();
+    } catch (err) {
+      return false;
+    }
+  },
+
   getExtName: function (file) {
     let ext = file.split('.').pop();
     if (!ext || ext === file) {


### PR DESCRIPTION
Fixes #110 

If a statically/dynamically included file cannot be found, look for the file into the _boilerplates folder. The end result is location sensitive.

This is a replacement for https://github.com/MarkBind/markbind/pull/125. I checked out one of my earlier commits and created a branch from there. Can I close that issue?

**How to test**:

1. Update the local repository with code from this PR and [markbind CLI PR](https://github.com/MarkBind/markbind-cli/pull/20) .
2. In CS2103 website, create a folder _boilerplates (on the same level as common).
3. Move the full.md file from `architecture/architecturalStyles/clientServer/what/full.md` to the `_boilerplates` folder. Other similar full.md files in other architecture folders can be deleted as well.
4. Run `markbind serve` and check the affected pages. For example, the architecture page should show the correct and different content for different architectural styles.


