### PR TITLE
Update parser trimming method to allow whitespace between elements

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -267,7 +267,7 @@ Parser.prototype._trimNodes = function (node) {
       let child = node.children[n];
       if (
         child.type === 'comment' ||
-        (child.type === 'text' && !/\S/.test(child.data))
+        (child.type === 'text' && n === node.children.length - 1 && !/\S/.test(child.data))
       ) {
         node.children.splice(n, 1);
         n--;


### PR DESCRIPTION
Resolves #90 
Resolves #119 

Previously, spaces in between Markdown elements would be trimmed by the `trimNodes` function leading to a result as shown below.

![image](https://user-images.githubusercontent.com/251231/35619349-b741e5fa-06b8-11e8-9c73-f46b6d9660c0.png)

By ignoring whitespace between these elements, content is spaced correctly as shown below.

![image](https://user-images.githubusercontent.com/251231/35619397-dc4355dc-06b8-11e8-83f9-aba8ba9e71d8.png)

