### PR TITLE
Support a shorter alias for <markdown> tag #136

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -186,6 +186,7 @@ Parser.prototype._parse = function (element, context) {
     }
 
     switch (element.name) {
+    case 'md':
     case 'markdown':
       element.name = 'div';
       cheerio.prototype.options.xmlMode = false;


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/136