### PR TITLE
Update parser to allow for in-line rendering of Markdown content

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -187,6 +187,11 @@ Parser.prototype._parse = function (element, context) {
 
     switch (element.name) {
     case 'md':
+      element.name = 'span';
+      cheerio.prototype.options.xmlMode = false;
+      element.children = cheerio.parseHTML(md.renderInline(cheerio.html(element.children)), true);
+      cheerio.prototype.options.xmlMode = true;
+      break;
     case 'markdown':
       element.name = 'div';
       cheerio.prototype.options.xmlMode = false;


### PR DESCRIPTION
Resolves #132 

Content enclosed within `<markdown>` tags were being rendered as a block element, which resulted in an unintended line break being added between content as shown below:
![image](https://user-images.githubusercontent.com/251231/36012632-657c587a-0d9a-11e8-9dea-a8965b9f43af.png)

As such, this PR proposes to allow in-line rendering when the `<md>` tag is used, so that unnecessary line breaks will not be added unless the author specifically wants it. The output will then be as follows:
![image](https://user-images.githubusercontent.com/251231/36012656-a0ac65c0-0d9a-11e8-91ce-d2db1cec57fd.png)
