### PR TITLE
Record boilerplate includes separately

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -88,8 +88,10 @@ Parser.prototype._preprocess = function (element, context, config) {
       this.staticIncludeSrc.push({from: context.cwf, to: actualFilePath});
     } else {
       let boilerplateFilePath = calculateBoilerplateFilePath(filePath, config);
-      actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
-      this.boilerplateIncludeSrc.push({from: context.cwf, to: actualFilePath});
+      if (utils.fileExists(boilerplateFilePath)) {
+        actualFilePath = boilerplateFilePath;
+        this.boilerplateIncludeSrc.push({from: context.cwf, to: actualFilePath});
+      }
     }
 
     try {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -35,6 +35,7 @@ function Parser(options) {
   this._fileCache = {};
   this.dynamicIncludeSrc = [];
   this.staticIncludeSrc = [];
+  this.boilerplateIncludeSrc = [];
 }
 
 Parser.prototype.getDynamicIncludeSrc = function () {
@@ -43,6 +44,10 @@ Parser.prototype.getDynamicIncludeSrc = function () {
 
 Parser.prototype.getStaticIncludeSrc = function () {
   return _.clone(this.staticIncludeSrc);
+};
+
+Parser.prototype.getBoilerplateIncludeSrc = function () {
+  return _.clone(this.boilerplateIncludeSrc);
 };
 
 Parser.prototype._preprocess = function (element, context, config) {
@@ -79,13 +84,13 @@ Parser.prototype._preprocess = function (element, context, config) {
     let isIncludeSrcMd = utils.getExtName(filePath) === 'md';
 
     let actualFilePath = filePath;
-    if (!utils.fileExists(filePath)) {
+    if (utils.fileExists(filePath)) {
+      this.staticIncludeSrc.push({from: context.cwf, to: actualFilePath});
+    } else {
       let boilerplateFilePath = calculateBoilerplateFilePath(filePath, config);
       actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
+      this.boilerplateIncludeSrc.push({from: context.cwf, to: actualFilePath});
     }
-
-    // is static include file
-    this.staticIncludeSrc.push({from: context.cwf, to: actualFilePath});
 
     try {
       self._fileCache[actualFilePath] = self._fileCache[actualFilePath] ?
@@ -312,7 +317,10 @@ Parser.prototype.includeFile = function (file, config) {
     let actualFilePath = file;
     if (!utils.fileExists(file)) {
       let boilerplateFilePath = calculateBoilerplateFilePath(file, config);
-      actualFilePath = utils.fileExists(boilerplateFilePath) ? boilerplateFilePath : actualFilePath;
+      if (utils.fileExists(boilerplateFilePath)) {
+        actualFilePath = boilerplateFilePath;
+        this.boilerplateIncludeSrc.push({from: context.cwf, to: boilerplateFilePath});
+      }
     }
 
     // Read files


### PR DESCRIPTION
This addresses the issue where boilerplate (bp) files that are dynamically included are not reloaded.

I have separated bp includes into a separate array for both static and dynamic.
Had to separate dynamic bps from `dynamicIncludeSrc` as `resolveDependency` relies on and iterates through it to handle dynamic includes.

Follows #110,  #128, https://github.com/MarkBind/markbind-cli/pull/17, https://github.com/MarkBind/markbind-cli/pull/25