### PR TITLE
Support user-defined variables #143

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -21,7 +21,6 @@ const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';
 
 const BOILERPLATE_DIRECTORY_NAME = '_boilerplates';
-const USER_VARIABLES_PATH = '_system/variables.md';
 
 /*
  * Utils
@@ -51,7 +50,7 @@ Parser.prototype.getBoilerplateIncludeSrc = function () {
   return _.clone(this.boilerplateIncludeSrc);
 };
 
-Parser.prototype._preprocess = function (element, context, config, userDefinedVariables) {
+Parser.prototype._preprocess = function (element, context, config) {
   let self = this;
   element.attribs = element.attribs || {};
   element.attribs[ATTRIB_CWF] = path.resolve(context.cwf);
@@ -114,6 +113,8 @@ Parser.prototype._preprocess = function (element, context, config, userDefinedVa
     }
 
     let fileContent = self._fileCache[actualFilePath]; // cache the file contents to save some I/O
+    let fileBase = path.resolve(calculateNewBaseUrl(filePath, config.rootPath, config.baseUrlMap).relative);
+    let userDefinedVariables = config.userDefinedVariablesMap[fileBase];
     fileContent = nunjucks.renderString(fileContent, userDefinedVariables);
     delete element.attribs.src;
     delete element.attribs.inline;
@@ -150,7 +151,7 @@ Parser.prototype._preprocess = function (element, context, config, userDefinedVa
     childContext.source = isIncludeSrcMd ? 'md' : 'html';
     if (element.children && element.children.length > 0) {
       element.children = element.children.map((e) => {
-        return self._preprocess(e, childContext, config, userDefinedVariables);
+        return self._preprocess(e, childContext, config);
       });
     }
   } else if (element.name === 'dynamic-panel') {
@@ -188,7 +189,7 @@ Parser.prototype._preprocess = function (element, context, config, userDefinedVa
   } else {
     if (element.children && element.children.length > 0) {
       element.children = element.children.map((e) => {
-        return self._preprocess(e, context, config, userDefinedVariables);
+        return self._preprocess(e, context, config);
       });
     }
   }
@@ -301,38 +302,10 @@ Parser.prototype._trimNodes = function (node) {
   }
 };
 
-Parser.prototype._initializeUserVariables = function(filePath, config) {
-  const userDefinedVariables = {};
-  const baseDirectoryForFile = calculateNewBaseUrl(filePath, config.rootPath, config.baseUrlMap).relative;
-  const definedVariablePath = path.resolve(baseDirectoryForFile, USER_VARIABLES_PATH);
-  let content;
-  try {
-    content = fs.readFileSync(definedVariablePath, 'utf8');
-  } catch (e) {
-    content = '';
-    this._onError(e);
-  }
-  const $ = cheerio.load(content);
-  $.root().children().each(function() {
-    const id = $(this).attr('id');
-    const html = $(this).html();
-    userDefinedVariables[id] = html;
-  });
-
-  // When userDefinedVariables is used by nunjucks in includeFile and _preprocess,
-  // baseUrl has not been calculated.
-  // This is to prevent the first nunjuck call from converting {{baseUrl}} to nothing
-  // and let the baseUrl value be injected later.
-  userDefinedVariables['baseUrl'] = '{{baseUrl}}';
-  return userDefinedVariables;
-};
-
 Parser.prototype.includeFile = function (file, config) {
   let context = {};
   context.cwf = file; // current working file
   context.mode = 'include';
-
-  const userDefinedVariables = this._initializeUserVariables(file, config);
 
   return new Promise((resolve, reject) => {
     let handler = new htmlparser.DomHandler((error, dom) => {
@@ -341,7 +314,7 @@ Parser.prototype.includeFile = function (file, config) {
         return;
       }
       let nodes = dom.map(d => {
-        return this._preprocess(d, context, config, userDefinedVariables);
+        return this._preprocess(d, context, config);
       });
       resolve(cheerio.html(nodes));
     });
@@ -366,6 +339,8 @@ Parser.prototype.includeFile = function (file, config) {
         reject(err);
         return;
       }
+      let fileBase = path.resolve(calculateNewBaseUrl(file, config.rootPath, config.baseUrlMap).relative);
+      let userDefinedVariables = config.userDefinedVariablesMap[fileBase];
       data = nunjucks.renderString(data, userDefinedVariables);
       let fileExt = utils.getExtName(file);
       if (fileExt === 'md') {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -21,6 +21,7 @@ const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';
 
 const BOILERPLATE_DIRECTORY_NAME = '_boilerplates';
+const USER_VARIABLES_PATH = '_system/variables.md';
 
 /*
  * Utils
@@ -50,7 +51,7 @@ Parser.prototype.getBoilerplateIncludeSrc = function () {
   return _.clone(this.boilerplateIncludeSrc);
 };
 
-Parser.prototype._preprocess = function (element, context, config) {
+Parser.prototype._preprocess = function (element, context, config, userDefinedVariables) {
   let self = this;
   element.attribs = element.attribs || {};
   element.attribs[ATTRIB_CWF] = path.resolve(context.cwf);
@@ -113,6 +114,7 @@ Parser.prototype._preprocess = function (element, context, config) {
     }
 
     let fileContent = self._fileCache[actualFilePath]; // cache the file contents to save some I/O
+    fileContent = nunjucks.renderString(fileContent, userDefinedVariables);
     delete element.attribs.src;
     delete element.attribs.inline;
 
@@ -148,7 +150,7 @@ Parser.prototype._preprocess = function (element, context, config) {
     childContext.source = isIncludeSrcMd ? 'md' : 'html';
     if (element.children && element.children.length > 0) {
       element.children = element.children.map((e) => {
-        return self._preprocess(e, childContext, config);
+        return self._preprocess(e, childContext, config, userDefinedVariables);
       });
     }
   } else if (element.name === 'dynamic-panel') {
@@ -186,7 +188,7 @@ Parser.prototype._preprocess = function (element, context, config) {
   } else {
     if (element.children && element.children.length > 0) {
       element.children = element.children.map((e) => {
-        return self._preprocess(e, context, config);
+        return self._preprocess(e, context, config, userDefinedVariables);
       });
     }
   }
@@ -299,10 +301,38 @@ Parser.prototype._trimNodes = function (node) {
   }
 };
 
+Parser.prototype._initializeUserVariables = function(filePath, config) {
+  const userDefinedVariables = {};
+  const baseDirectoryForFile = calculateNewBaseUrl(filePath, config.rootPath, config.baseUrlMap).relative;
+  const definedVariablePath = path.resolve(baseDirectoryForFile, USER_VARIABLES_PATH);
+  let content;
+  try {
+    content = fs.readFileSync(definedVariablePath, 'utf8');
+  } catch (e) {
+    content = '';
+    this._onError(e);
+  }
+  const $ = cheerio.load(content);
+  $.root().children().each(function() {
+    const id = $(this).attr('id');
+    const html = $(this).html();
+    userDefinedVariables[id] = html;
+  });
+
+  // When userDefinedVariables is used by nunjucks in includeFile and _preprocess,
+  // baseUrl has not been calculated.
+  // This is to prevent the first nunjuck call from converting {{baseUrl}} to nothing
+  // and let the baseUrl value be injected later.
+  userDefinedVariables['baseUrl'] = '{{baseUrl}}';
+  return userDefinedVariables;
+};
+
 Parser.prototype.includeFile = function (file, config) {
   let context = {};
   context.cwf = file; // current working file
   context.mode = 'include';
+
+  const userDefinedVariables = this._initializeUserVariables(file, config);
 
   return new Promise((resolve, reject) => {
     let handler = new htmlparser.DomHandler((error, dom) => {
@@ -311,7 +341,7 @@ Parser.prototype.includeFile = function (file, config) {
         return;
       }
       let nodes = dom.map(d => {
-        return this._preprocess(d, context, config);
+        return this._preprocess(d, context, config, userDefinedVariables);
       });
       resolve(cheerio.html(nodes));
     });
@@ -331,11 +361,12 @@ Parser.prototype.includeFile = function (file, config) {
     }
 
     // Read files
-    fs.readFile(actualFilePath, (err, data) => {
+    fs.readFile(actualFilePath, 'utf-8', (err, data) => {
       if (err) {
         reject(err);
         return;
       }
+      data = nunjucks.renderString(data, userDefinedVariables);
       let fileExt = utils.getExtName(file);
       if (fileExt === 'md') {
         context.source = 'md';


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/143

### Testing
1. Create a folder in the root `_system`.
2. Create a file `variables.md` in the folder with the content
```
<span id="year">2018</span>

<span id="options">
* yes
* no
* maybe
</span>
```
(This example works fine but sometimes they need to be protected by the markdown tags)
3. In any file in the site, use {{options}} or {{year}}

I have tested and it seems to be working.

But in `userDefinedVariables`, there is no `baseUrl` (i.e. undefined).
When I use `nunjucks.renderString` in `includeFile` and `_preprocess`  to add code fragments, it may also replace `baseUrl` with nothing. Will this affect future reference rebasing?