### PR TITLE
Record missing include src

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -36,6 +36,7 @@ function Parser(options) {
   this.dynamicIncludeSrc = [];
   this.staticIncludeSrc = [];
   this.boilerplateIncludeSrc = [];
+  this.missingIncludeSrc = [];
 }
 
 Parser.prototype.getDynamicIncludeSrc = function () {
@@ -48,6 +49,10 @@ Parser.prototype.getStaticIncludeSrc = function () {
 
 Parser.prototype.getBoilerplateIncludeSrc = function () {
   return _.clone(this.boilerplateIncludeSrc);
+};
+
+Parser.prototype.getMissingIncludeSrc = function () {
+  return _.clone(this.missingIncludeSrc);
 };
 
 Parser.prototype._preprocess = function (element, context, config) {
@@ -91,6 +96,9 @@ Parser.prototype._preprocess = function (element, context, config) {
       if (utils.fileExists(boilerplateFilePath)) {
         actualFilePath = boilerplateFilePath;
         this.boilerplateIncludeSrc.push({from: context.cwf, to: actualFilePath});
+      } else { // both files are missing
+        this.missingIncludeSrc.push({from: context.cwf, to: actualFilePath});
+        this.missingIncludeSrc.push({from: context.cwf, to: boilerplateFilePath});
       }
     }
 
@@ -327,6 +335,9 @@ Parser.prototype.includeFile = function (file, config) {
       if (utils.fileExists(boilerplateFilePath)) {
         actualFilePath = boilerplateFilePath;
         this.boilerplateIncludeSrc.push({from: context.cwf, to: boilerplateFilePath});
+      } else {
+        this.missingIncludeSrc.push({from: context.cwf, to: actualFilePath});
+        this.missingIncludeSrc.push({from: context.cwf, to: boilerplateFilePath});
       }
     }
 


### PR DESCRIPTION
File A includes File B which does not exist (e.g. due to a typo).
When File B is added, in the current markbind-cli, we will rebuild all files and this will update all files including A.
If we want to only rebuild file A when B is added, we should keep missing include file sources as well.