### PR TITLE
Give a more relevant error message for empty src attribute in include #160

### DIFF
--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -8,6 +8,8 @@ _.clone = require('lodash/clone');
 _.cloneDeep = require('lodash/cloneDeep');
 _.hasIn = require('lodash/hasIn');
 _.isArray = require('lodash/isArray');
+_.isEmpty = require('lodash/isEmpty');
+_.pick = require('lodash/pick');
 
 const Promise = require('bluebird');
 
@@ -54,6 +56,11 @@ function calculateBoilerplateFilePath(filePath, config) {
   return path.resolve(base, BOILERPLATE_DIRECTORY_NAME, path.basename(filePath));
 }
 
+function createErrorNode(element, error) {
+  const errorElement = cheerio.parseHTML(utils.createErrorElement(error), true)[0];
+  return Object.assign(element, _.pick(errorElement, ['name', 'attribs', 'children']));
+}
+
 function isText(element) {
   return element.type === 'text' || element.type === 'comment';
 }
@@ -91,6 +98,11 @@ Parser.prototype._preprocess = function (node, context, config) {
   element.attribs = element.attribs || {};
   element.attribs[ATTRIB_CWF] = path.resolve(context.cwf);
   if (element.name === 'include') {
+    if (_.isEmpty(element.attribs.src)) {
+      const error = new Error(`Empty src attribute in include in: ${element.attribs[ATTRIB_CWF]}`);
+      this._onError(error);
+      return createErrorNode(element, error);
+    }
     const isInline = _.hasIn(element.attribs, 'inline');
     const isDynamic = _.hasIn(element.attribs, 'dynamic');
     const isUrl = utils.isUrl(element.attribs.src);
@@ -139,8 +151,7 @@ Parser.prototype._preprocess = function (node, context, config) {
       const missingReferenceErrorMessage = `Missing reference in: ${element.attribs[ATTRIB_CWF]}`;
       e.message += `\n${missingReferenceErrorMessage}`;
       this._onError(e);
-      element.children = cheerio.parseHTML(utils.createErrorElement(e), true);
-      return element;
+      return createErrorNode(element, e);
     }
 
     const isIncludeSrcMd = utils.getExtName(filePath) === 'md';
@@ -193,6 +204,11 @@ Parser.prototype._preprocess = function (node, context, config) {
       element.children = element.children.map(e => self._preprocess(e, childContext, config));
     }
   } else if (element.name === 'dynamic-panel') {
+    if (_.isEmpty(element.attribs.src)) {
+      const error = new Error(`Empty src attribute in dynamic include in: ${element.attribs[ATTRIB_CWF]}`);
+      this._onError(error);
+      return createErrorNode(element, error);
+    }
     const isUrl = utils.isUrl(element.attribs.src);
     let filePath;
     if (isUrl) {
@@ -209,6 +225,11 @@ Parser.prototype._preprocess = function (node, context, config) {
     this.dynamicIncludeSrc.push({ from: context.cwf, to: filePath });
     return element;
   } else if ((element.name === 'morph' || element.name === 'panel') && _.hasIn(element.attribs, 'src')) {
+    if (_.isEmpty(element.attribs.src)) {
+      const error = new Error(`Empty src attribute in panel/morph in: ${element.attribs[ATTRIB_CWF]}`);
+      this._onError(error);
+      return createErrorNode(element, error);
+    }
     const isUrl = utils.isUrl(element.attribs.src);
     let filePath;
     if (isUrl) {


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/160

If `element.attribs.src` is empty, `includeSrcPath` will be `null` and `path.resolve` will cause the build to crash with a stack trace.