### PR TITLE
Add a batch file for testing on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
     "pretest": "npm run lint",
-    "testwin": "cd test/test_site && test.sh",
+    "testwin": "cd test/test_site && test.bat",
     "test": "cd test/test_site && ./test.sh"
   },
   "devDependencies": {

--- a/test/test_site/site.json
+++ b/test/test_site/site.json
@@ -14,6 +14,7 @@
     "_site/*",
     "site.json",
     "*.md",
+    "test.bat",
     "test.sh",
     "testUtil/*",
     "expected/*"

--- a/test/test_site/test.bat
+++ b/test/test_site/test.bat
@@ -1,0 +1,13 @@
+@ECHO off
+
+node ../../index.js build
+
+node testUtil/test.js
+
+if errorlevel 1 (
+    echo Test Failed
+) else (
+    echo Test passed
+)
+
+exit /b %errorlevel%


### PR DESCRIPTION
Previously you could test on windows by running `npm run testwin` but a new window opens (i think its a bash terminal) and the error message will be displayed a split second before closing.

This pr introduces a batch file so that the test can be run without the behavior above.