### PR TITLE
Add option to specify baseurl in build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ npm i -g markbind-cli
   Usage: markbind  <command>
 
 
-    Commands:
+  Options:
 
-      include [options] <file>  process all the fragment include in the given file
-      render [options] <file>   render the given file
-      init [root]               init a markbind website project
-      serve [options] [root]    build then serve a website from a directory
-      build [root] [output]     build a website
-      deploy                    deploy to Github Pages
+    -V, --version  output the version number
+    -h, --help     output usage information
 
-    Options:
 
-      -h, --help     output usage information
-      -V, --version  output the version number
+  Commands:
+
+    include [options] <file>         process all the fragment include in the given file
+    render [options] <file>          render the given file
+    init [root]                      init a markbind website project
+    serve [options] [root]           build then serve a website from a directory
+    deploy                           deploy the site to the repo's Github pages.
+    build [options] [root] [output]  build a website
+
 ```
 
 ## Documentation

--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ const htmlBeautify = require('js-beautify').html;
 const liveServer = require('live-server');
 const chokidar = require('chokidar');
 
+const _ = {};
+_.isBoolean = require('lodash/isBoolean');
+
 const logger = require('./lib/util/logger');
 const fsUtil = require('./lib/util/fsUtil');
 const Site = require('./lib/Site');
@@ -208,14 +211,18 @@ program
 
 program
   .command('build [root] [output]')
+  .option('--baseUrl [baseUrl]',
+          'optional flag which overrides baseUrl in site.json, leave argument empty for empty baseUrl')
   .description('build a website')
-  .action((root, output) => {
+  .action((root, output, options) => {
+    // if --baseUrl contains no arguments (options.baseUrl === true) then set baseUrl to empty string
+    const baseUrl = _.isBoolean(options.baseUrl) ? '' : options.baseUrl;
     const rootFolder = path.resolve(root || process.cwd());
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
     logger.logo();
     new Site(rootFolder, outputFolder)
-      .generate()
+      .generate(baseUrl)
       .then(() => {
         logger.info('Build success!');
       })

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -133,13 +133,14 @@ Site.initSite = function (rootPath) {
   });
 };
 
-Site.prototype.readSiteConfig = function () {
+Site.prototype.readSiteConfig = function (baseUrl) {
   return new Promise((resolve, reject) => {
     const siteConfigPath = path.join(this.rootPath, SITE_CONFIG_NAME);
     fs.readJsonAsync(siteConfigPath)
       .then((config) => {
         this.siteConfig = config;
-        resolve(config);
+        this.siteConfig.baseUrl = (baseUrl === undefined) ? this.siteConfig.baseUrl : baseUrl;
+        resolve(this.siteConfig);
       })
       .catch((err) => {
         reject(new Error('Failed to read the site config file \'site.json\' at'
@@ -239,13 +240,13 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
   });
 };
 
-Site.prototype.generate = function () {
+Site.prototype.generate = function (baseUrl) {
   // Create the .tmp folder for storing intermediate results.
   fs.emptydirSync(this.tempPath);
   // Clean the output folder; create it if not exist.
   fs.emptydirSync(this.outputPath);
   return new Promise((resolve, reject) => {
-    this.readSiteConfig()
+    this.readSiteConfig(baseUrl)
       .then(() => this.collectBaseUrl())
       .then(() => this.collectUserDefinedVariablesMap())
       .then(() => this.buildAssets())


### PR DESCRIPTION
Gives users command line argument to specify base url. This is useful for build for preview sites, eg: on Netlify.

Usage:

| command | what it does |
|---|---|
|`markbind build --baseurl override-base-url`| build site with baseUrl: "override-base-url"|
|`markbind build --baseurl`| build site with baseUrl: ""|

Things to note:

Option is `--baseurl` and **is** case-sensitive, was wondering if this would be better as the user can type this more quickly? Any thoughts?


