### PR TITLE
Replace nunjucks with mustache.js

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1,5 +1,8 @@
 const htmlBeautify = require('js-beautify').html;
 const mustache = require('mustache');
+
+mustache.escape = value => value;
+
 const fs = require('fs-extra-promise');
 const path = require('path');
 const Promise = require('bluebird');

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1,5 +1,5 @@
 const htmlBeautify = require('js-beautify').html;
-const nunjucks = require('nunjucks');
+const mustache = require('mustache');
 const fs = require('fs-extra-promise');
 const path = require('path');
 const Promise = require('bluebird');
@@ -100,7 +100,7 @@ Page.prototype.generate = function (builtFiles) {
         const baseUrl = newBaseUrl ? `${this.baseUrl}/${newBaseUrl}` : this.baseUrl;
         const hostBaseUrl = this.baseUrl;
 
-        this.content = nunjucks.renderString(this.content, { baseUrl, hostBaseUrl });
+        this.content = mustache.render(this.content, { baseUrl, hostBaseUrl });
         return fs.outputFileAsync(this.resultPath, this.template(this.prepareTemplateData()));
       })
       .then(() => {
@@ -181,7 +181,7 @@ Page.prototype.resolveDependency = function (dependency, builtFiles) {
         const baseUrl = newBaseUrl ? `${this.baseUrl}/${newBaseUrl}` : this.baseUrl;
         const hostBaseUrl = this.baseUrl;
 
-        const content = nunjucks.renderString(result, { baseUrl, hostBaseUrl });
+        const content = mustache.render(result, { baseUrl, hostBaseUrl });
         return fs.outputFileAsync(resultPath, htmlBeautify(content, { indent_size: 2 }));
       })
       .then(() => {

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -23,7 +23,7 @@ const utils = require('./utils');
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
-const nunjucks = require('nunjucks');
+const mustache = require('mustache');
 
 const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';
@@ -178,7 +178,7 @@ Parser.prototype._preprocess = function (node, context, config) {
     let fileContent = self._fileCache[actualFilePath]; // cache the file contents to save some I/O
     const fileBase = path.resolve(calculateNewBaseUrl(filePath, config.rootPath, config.baseUrlMap).relative);
     const userDefinedVariables = config.userDefinedVariablesMap[fileBase];
-    fileContent = nunjucks.renderString(fileContent, userDefinedVariables);
+    fileContent = mustache.render(fileContent, userDefinedVariables);
     delete element.attribs.boilerplate;
     delete element.attribs.src;
     delete element.attribs.inline;
@@ -390,7 +390,7 @@ Parser.prototype.includeFile = function (file, config) {
       }
       const fileBase = path.resolve(calculateNewBaseUrl(file, config.rootPath, config.baseUrlMap).relative);
       const userDefinedVariables = config.userDefinedVariablesMap[fileBase];
-      const fileContent = nunjucks.renderString(data, userDefinedVariables);
+      const fileContent = mustache.render(data, userDefinedVariables);
       const fileExt = utils.getExtName(file);
       if (fileExt === 'md') {
         context.source = 'md';
@@ -528,7 +528,7 @@ Parser.prototype._rebaseReference = function (node, foundBase) {
           if (currentBase.relative !== newBase) {
             cheerio.prototype.options.xmlMode = false;
             const newBaseUrl = `{{hostBaseUrl}}/${newBase}`;
-            const rendered = nunjucks.renderString(cheerio.html(children), { baseUrl: newBaseUrl });
+            const rendered = mustache.render(cheerio.html(children), { baseUrl: newBaseUrl });
             element.children = cheerio.parseHTML(rendered, true);
             cheerio.prototype.options.xmlMode = true;
           }
@@ -564,7 +564,7 @@ Parser.prototype._rebaseReferenceForStaticIncludes = function (pageData, element
 
   const newBase = fileBase.relative;
   const newBaseUrl = `{{hostBaseUrl}}/${newBase}`;
-  return nunjucks.renderString(pageData, { baseUrl: newBaseUrl });
+  return mustache.render(pageData, { baseUrl: newBaseUrl });
 };
 
 module.exports = Parser;

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -25,6 +25,8 @@ const path = require('path');
 const url = require('url');
 const mustache = require('mustache');
 
+mustache.escape = value => value;
+
 const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';
 

--- a/lib/markbind/package.json
+++ b/lib/markbind/package.json
@@ -27,7 +27,7 @@
     "markdown-it-table-of-contents": "^0.3.2",
     "markdown-it-task-lists": "^1.4.1",
     "markdown-it-video": "^0.4.0",
-    "nunjucks": "^3.0.0",
+    "mustache": "^2.3.0",
     "path-is-inside": "^1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "markdown-it-table-of-contents": "^0.3.2",
     "markdown-it-task-lists": "^1.4.1",
     "markdown-it-video": "^0.4.0",
-    "nunjucks": "^3.0.0",
+    "mustache": "^2.3.0",
     "path-is-inside": "^1.0.2",
     "walk-sync": "^0.3.1"
   },


### PR DESCRIPTION
Currently, we only use nunjucks to insert the values of baseUrl and user-defined variables.

nunjucks does way more than that e.g. support math operations. This makes variable names like `{{ gly-search }}` not possible as - is taken as the math minus symbol.

We can use a simpler library like mustache.js instead