### PR TITLE
Ignore files for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
-src/
+__mocks__
+docs
+node_modules
+test


### PR DESCRIPTION
Fixes #194

The issue seemed to be caused by having **lib/markbind/node_modules/** because I ran `npm install` there to update **package-lock.json**.

It works when I removed that folder in the globally-installed `markbind-cli` package.

Tested this fix by using `npm pack`.

---
**.npmignore**:
```diff
- src/
+ __mocks__
+ docs
+ node_modules
+ test
```

By default, npm ignores **node_modules** — but only in the root folder.

In addition, we avoid users having to download the above folders.

Before: 25.9 MB
After: 894 KB (i.e. < 1 MB)