### PR TITLE
Fix included front matter parsing

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -96,7 +96,7 @@ Page.prototype.collectFrontMatter = function (includedPage) {
     const frontMatterData = frontMatter.find('div').length
       ? frontMatter.find('div')[0].children[0].data
       : frontMatter[0].children[0].data;
-    const frontMatterWrapped = `${FRONT_MATTER_FENCE}\n${frontMatterData}${FRONT_MATTER_FENCE}`;
+    const frontMatterWrapped = `${FRONT_MATTER_FENCE}\n${frontMatterData}\n${FRONT_MATTER_FENCE}`;
     // Parse front matter data
     const parsedData = fm(frontMatterWrapped);
     this.frontMatter = parsedData.attributes;


### PR DESCRIPTION
This PR aims to fix the parsing of front matter that is included from other files.

```
<seg id="bst">
  <frontmatter>
    title: Binary Search Tree
    keywords: bst, avl, red-black
  </frontmatter>
</seg>
```

Using the above snippet as an example (taken from the [User Guide](https://markbind.github.io/markbind/userGuide/contentAuthoring.html)), the whitespace from the indentation before the closing `</frontmatter>` tag affects the parsing of the data and causes it not to be captured properly. By adding a newline to properly wrap the front matter, the parsing is done correctly.