### PR TITLE
Add warning: body tag may cause formatting errors

### DIFF
--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -239,8 +239,14 @@ Parser.prototype._preprocess = function (node, context, config) {
     element.attribs.src = filePath;
     this.dynamicIncludeSrc.push({ from: context.cwf, to: actualFilePath, asIfTo: filePath });
     return element;
-  } else if (element.children && element.children.length > 0) {
-    element.children = element.children.map(e => self._preprocess(e, context, config));
+  } else {
+    if (element.name === 'body') {
+      // eslint-disable-next-line no-console
+      console.warn(`<body> tag found in ${element.attribs[ATTRIB_CWF]}. This may cause formatting errors.`);
+    }
+    if (element.children && element.children.length > 0) {
+      element.children = element.children.map(e => self._preprocess(e, context, config));
+    }
   }
 
   return element;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: Add warning for a potential user (author) error

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Closes #148 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

> when you create a html file in webstorm, they auto generate the formatting for you with the body tag.

> a user may be wondering why the formatting is messed up when he/she tries to include the HTML file.

Explanation: https://stackoverflow.com/questions/2035462/multiple-htmlbody-html-body-in-same-file

**What changes did you make? (Give an overview)**

- In `Parser.prototype._preprocess` if `element.name === 'body'` then `console.warn`.

Documentation seems unnecessary as this is not MarkBind-specific.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<body><p>This is a HTML document.</p></body>
```

No change in behaviour except a warning in the console.

**Is there anything you'd like reviewers to focus on?**

\-

**Testing instructions:**

- Add the example code above in **test/test_site/index.md** and run `$ markbind serve`.

There should be a warning, but MarkBind is able to build. The formatting is messed up.