### PR TITLE
Support Glyphicons in Panel and Tab headers

### DIFF
--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -1,3 +1,3 @@
 <span id="showBaseUrl">
-<code>{&#8203;{baseUrl}&#8203;}</code>
+<code>{<span></span>{baseUrl}}</code>
 </span>

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -129,15 +129,15 @@ In `_markbind/variables.md`, you can define your own variables that can be used 
 
 Each variable must have an id and the value can be any MarkBind-compliant code fragment. The id should not contain `-` and `.`. For example, `search-option` and `search.options` are not allowed.
 
-In any file in your site, you can include the variable by surrounding the variable's id with double curly braces, e.g. <code>{&#8203;{options}&#8203;}</code>
+In any file in your site, you can include the variable by surrounding the variable's id with double curly braces, e.g. <code>{<span></span>{options}}</code>
 
 ### Use Glyphicons
 
 This asset is provided by [Glyphicons](https://glyphicons.com/) via Bootstrap.
 
-MarkBind allows for the easy use of [available glyphs](https://getbootstrap.com/docs/3.3/components/#glyphicons) on your site by surrounding a glyph's name with double curly braces, e.g. <code>{&#8203;{glyphicon_hand_right}&#8203;}</code>
+MarkBind allows for the easy use of [available glyphs](https://getbootstrap.com/docs/3.3/components/#glyphicons) on your site by surrounding a glyph's name with double curly braces, e.g. <code>{<span></span>{glyphicon_hand_right}}</code>
 
-Note: Replace all instances of `-` with `_` in the glyph's name, e.g. <code>{&#8203;{glyphicon-hand-right}&#8203;}</code> becomes <code>{&#8203;{glyphicon_hand_right}&#8203;}</code>
+Note: Replace all instances of `-` with `_` in the glyph's name, e.g. <code>{<span></span>{glyphicon-hand-right}}</code> becomes <code>{<span></span>{glyphicon_hand_right}}</code>
 
 ### Use Searchbar
 

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -110,7 +110,7 @@ function getGlyphiconsMap() {
   const glyphiconsClasses = fs.readFileSync(glyphiconsPath, 'utf8').trimRight().split(/\r?\n/);
   return glyphiconsClasses.reduce((glyphiconsMap, glyphiconClass) => {
     const name = glyphiconClass.replace(/-/g, '_');
-    const html = `<span class="glyphicon ${glyphiconClass}" aria-hidden="true"></span>`;
+    const html = `<span class='glyphicon ${glyphiconClass}' aria-hidden='true'></span>`;
     // eslint-disable-next-line no-param-reassign
     glyphiconsMap[name] = html;
     return glyphiconsMap;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Follows #209 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
- Documentation bug discovered by User, where copy pasting examples from UserGuide does not work.
- Discovered another bug where using `{{GLYPH_NAME}}` in component headers doesn't work. 

**What changes did you make? (Give an overview)**
- Replaced `&#8203` invisible space within the documents to `<span></span>`
- Changed html string of glyphicons to use `'` instead of `"`

**Provide some example of changes**

Before | 
------- |  
![glyphiconbrokenheader](https://user-images.githubusercontent.com/31084833/40163064-625457c0-59e8-11e8-8d25-32c3b9e39ea7.PNG) |

After |
------|
![glyphiconinheader](https://user-images.githubusercontent.com/31084833/40163075-6bb51ba6-59e8-11e8-8d5e-5079a05857e6.PNG) |

**Source from index.md**
```html
<div id="first" stlye="width: 500px">
	<panel type="primary" header='{{glyphicon_search}} {{glyphicon_search}} {{glyphicon_search}} {{glyphicon_search}}'>
		<md>**Glyphicon works in headers now :smile:**</md>
	</panel>
</div>
```

**Is there anything you'd like reviewers to focus on?**
**NIL**

**Testing instructions:**
1. Same as #209