### PR TITLE
Favicon: fix missing starting slash if baseUrl is empty

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -428,12 +428,12 @@ Site.prototype.generatePages = function () {
 
   let faviconUrl;
   if (faviconPath) {
-    faviconUrl = url.join(baseUrl, faviconPath);
+    faviconUrl = url.join('/', baseUrl, faviconPath);
     if (!fs.existsSync(path.join(this.rootPath, faviconPath))) {
       logger.warn(`${faviconPath} does not exist`);
     }
   } else if (fs.existsSync(path.join(this.rootPath, FAVICON_DEFAULT_PATH))) {
-    faviconUrl = url.join(baseUrl, FAVICON_DEFAULT_PATH);
+    faviconUrl = url.join('/', baseUrl, FAVICON_DEFAULT_PATH);
   }
 
   this.pageModels = pages.map(page => this.createPageData({


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Follows https://github.com/MarkBind/markbind/pull/210#issuecomment-389815226.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

favicon is usually root-relative (e.g. `/favicon.png`), but if `baseUrl` is empty, then the code generates an incorrect path for favicon (i.e. no longer root-relative, e.g. `favicon.png`).

**What changes did you make? (Give an overview)**

When generating favicon, the first parameter to `url.join()` calls will start with '/', so that a starting slash is always added regardless of the `baseUrl` value.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
Before:

```html
<link rel="icon" href="favicon.png">
```

After:

```html
<link rel="icon" href="/favicon.png">
```

**Is there anything you'd like reviewers to focus on?**

NIL

**Testing instructions:**

1. Use the following settings for `site.json`:
```json
"baseUrl": "",
"faviconPath": "favicon.png",
```
1. Do `markbind serve`.
1. The generated html file should have the favicon URL specified with a starting `/`:
```html
<link rel="icon" href="/favicon.png">
```