### PR TITLE
Allow variables to reference earlier variables

### DIFF
--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -161,6 +161,29 @@ Each variable must have an id and the value can be any MarkBind-compliant code f
 
 In any file in your site, you can include the variable by surrounding the variable's id with double curly braces, e.g. <code>{<span></span>{options}}</code>
 
+Variables can refer to other variables that are declared earlier, including helpful variables provided by MarkBind.
+
+<tip-box>
+<div>
+This is allowed, MarkBind helpful variables can be used.<br>
+
+<code>\<span id="right_hand">{<span></span>{glyphicon_hand_right}}\</span></code>
+</div>
+<div>
+This is also allowed, the second variable will be assigned the contents of the first variable.
+
+<code>\<span id="first">This is the first variable.\</span></code><br>
+<code>\<span id="second">{<span></span>{first}}\</span></code><br>
+<code>\<span id="third">{<span></span>{second}}\</span></code>
+</div>
+<div>
+This is forbidden, as the fourth variable is not declared yet.
+
+<code>\<span id="third">{<span></span>{fourth}}\</span></code><br>
+<code>\<span id="fourth">This is the fourth variable.\</span></code>
+</div>
+</tip-box>
+
 ### Use Searchbar
 
 To use the searchbar, add the following markup to your file.

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -177,7 +177,7 @@ This is also allowed, the second variable will be assigned the contents of the f
 <code>\<span id="third">{<span></span>{second}}\</span></code>
 </div>
 <div>
-This is forbidden, as the fourth variable is not declared yet.
+This is forbidden, as the fourth variable is not declared yet, and will not be rendered correctly.
 
 <code>\<span id="third">{<span></span>{fourth}}\</span></code><br>
 <code>\<span id="fourth">This is the fourth variable.\</span></code>

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -184,6 +184,41 @@ This is forbidden, as the fourth variable is not declared yet, and will not be r
 </div>
 </tip-box>
 
+Note: If the variable being referenced contains HTML tags, MarkBind may escape the tags and render it literally. For example:
+
+<tip-box>
+<div>
+If we declare the variables as follow:<br>
+
+<code>\<span id="right_hand">{<span></span>{glyphicon_hand_right}}\</span></code><br>
+<code>\<span id="right_hand_2">{<span></span>{right_hand}}\</span></code>
+</div>
+<div>
+The following will be rendered:<br>
+
+{{glyphicon_hand_right}}<br>
+\<span class='glyphicon glyphicon-hand-right' aria-hidden='true'></span>
+</div>
+</tip-box>
+
+You must use the `safe` filter when using such variables:
+
+<tip-box>
+<div>
+If we use the safe filter for the second variable:<br>
+
+<code>\<span id="right_hand">{<span></span>{glyphicon_hand_right}}\</span></code><br>
+<code>\<span id="right_hand_2">{<span></span>{right_hand | safe}}\</span></code>
+</div>
+<div>
+The following will be rendered:<br>
+
+{{glyphicon_hand_right}}<br>
+{{glyphicon_hand_right}}
+</div>
+</tip-box>
+
+
 ### Use Searchbar
 
 To use the searchbar, add the following markup to your file.

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -6,6 +6,7 @@ const findUp = require('find-up');
 const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
+const nunjucks = require('nunjucks');
 const path = require('path');
 const Promise = require('bluebird');
 const walkSync = require('walk-sync');
@@ -295,7 +296,8 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
     const $ = cheerio.load(content);
     $.root().children().each(function () {
       const id = $(this).attr('id');
-      const html = $(this).html();
+      // Process the content of the variable with nunjucks, in case it refers to other variables.
+      const html = nunjucks.renderString($(this).html(), userDefinedVariables);
       userDefinedVariables[id] = html;
     });
 

--- a/test/test_site/_markbind/variables.md
+++ b/test/test_site/_markbind/variables.md
@@ -1,0 +1,4 @@
+<span id="education_icon">{{glyphicon_education}}</span>
+
+<span id="referenced_value">This variable can be referenced.</span>
+<span id="finalized_value">{{referenced_value}}</span>

--- a/test/test_site/_markbind/variables.md
+++ b/test/test_site/_markbind/variables.md
@@ -2,3 +2,8 @@
 
 <span id="referenced_value">This variable can be referenced.</span>
 <span id="finalized_value">{{referenced_value}}</span>
+
+<span id="reference_level_1">References can be several levels deep.</span>
+<span id="reference_level_2">{{reference_level_1}}</span>
+<span id="reference_level_3">{{reference_level_2}}</span>
+<span id="reference_level_4">{{reference_level_3}}</span>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -19,6 +19,9 @@
   </navbar>
 </div>
 <div class="website-content">
+  <h1 id="variables-that-reference-another-variable">Variables that reference another variable</h1>
+  <p><span class="glyphicon glyphicon-education" aria-hidden="true"></span></p>
+  <p>This variable can be referenced.</p>
   <h1 id="normal-include">Normal include</h1>
   <div>
     <h3 id="establishing-requirements">Establishing Requirements</h3>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -22,6 +22,7 @@
   <h1 id="variables-that-reference-another-variable">Variables that reference another variable</h1>
   <p><span class="glyphicon glyphicon-education" aria-hidden="true"></span></p>
   <p>This variable can be referenced.</p>
+  <p>References can be several levels deep.</p>
   <h1 id="normal-include">Normal include</h1>
   <div>
     <h3 id="establishing-requirements">Establishing Requirements</h3>

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -11,6 +11,8 @@ title: Hello World
 
 {{finalized_value}}
 
+{{reference_level_4}}
+
 # Normal include
 <include src="requirements/EstablishingRequirements.md" />
 

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -6,6 +6,11 @@ title: Hello World
 
 <div class="website-content">
 
+# Variables that reference another variable
+{{education_icon}}
+
+{{finalized_value}}
+
 # Normal include
 <include src="requirements/EstablishingRequirements.md" />
 

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -189,6 +189,32 @@ test('Site read site config for custom site config', async () => {
   expect(site.siteConfig).toEqual(customSiteJson);
 });
 
+test('Site resolves variables referencing other variables', async () => {
+  const json = {
+    'lib/asset/glyphicons.csv': '',
+    'lib/template/page.ejs': PAGE_EJS,
+    'site.json': SITE_JSON_DEFAULT,
+    '_markbind/variables.md':
+    '<span id="level1">variable</span>'
+    + '<span id="level2">{{level1}}</span>'
+    + '<span id="level3">{{level2}}</span>'
+    + '<span id="level4">{{level3}}</span>',
+  };
+  fs.vol.fromJSON(json, '');
+
+  const site = new Site('./', '_site');
+  await site.collectBaseUrl();
+  await site.collectUserDefinedVariablesMap();
+
+  const root = site.userDefinedVariablesMap[path.resolve('')];
+
+  // check all variables
+  expect(root.level1).toEqual('variable');
+  expect(root.level2).toEqual('variable');
+  expect(root.level3).toEqual('variable');
+  expect(root.level4).toEqual('variable');
+});
+
 test('Site read correct user defined variables', async () => {
   const json = {
     'lib/asset/glyphicons.csv': '',

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -191,14 +191,14 @@ test('Site read site config for custom site config', async () => {
 
 test('Site resolves variables referencing other variables', async () => {
   const json = {
-    'lib/asset/glyphicons.csv': '',
+    'lib/asset/glyphicons.csv': 'glyphicon-plus',
     'lib/template/page.ejs': PAGE_EJS,
     'site.json': SITE_JSON_DEFAULT,
     '_markbind/variables.md':
     '<span id="level1">variable</span>'
     + '<span id="level2">{{level1}}</span>'
-    + '<span id="level3">{{level2}}</span>'
-    + '<span id="level4">{{level3}}</span>',
+    + '<span id="level3">{{glyphicon_plus}}</span>'
+    + '<span id="level4">{{level3 | safe}}</span>',
   };
   fs.vol.fromJSON(json, '');
 
@@ -211,8 +211,12 @@ test('Site resolves variables referencing other variables', async () => {
   // check all variables
   expect(root.level1).toEqual('variable');
   expect(root.level2).toEqual('variable');
-  expect(root.level3).toEqual('variable');
-  expect(root.level4).toEqual('variable');
+  const expectedGlyphiconSpan = '<span class="glyphicon glyphicon-plus" aria-hidden="true"></span>'
+    .replace(/"/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  expect(root.level3).toEqual(expectedGlyphiconSpan);
+  expect(root.level4).toEqual(expectedGlyphiconSpan);
 });
 
 test('Site read correct user defined variables', async () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] New feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

This also indirectly fixes #230. However, a deliberate design consideration was made: we restrict the referencing to only allow earlier declared variables (yes, glyphicons counts as "earlier declared variables").

```html
<!-- Allowed: -->
<span id="some_icon">{{glyphicon_education}}</span>

<!-- Allowed: -->
<span id="first">This is the first variable.</span>
<span id="second">{{first}}</span> <!-- The value will be rendered correctly -->

<!-- Forbidden: -->
<span id="third">{{fourth}}</span> <!-- Nothing will be rendered -->
<span id="fourth">This variable is declared AFTER third.</span>
```

The restriction is enforced to avoid circular referencing:
```html
<!-- Without the restriction, circular referencing is possible -->
<span id="first">{{second}}</span>
<span id="second">{{first}}</span>
```

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User wants to be able to refer to glyphicons inside the content of a variable. This can be partially achieved by allowing variables to refer to earlier declared variables (glyphicons are declared internally in MarkBind before `variables.md` is parsed).

**What changes did you make? (Give an overview)**
Made nunjucks parse the contents of variables declared in `variables.md` one by one, earliest first.

**Provide some example code that this change will affect:**

```html
<div id="icon_prereq">{{glyphicon_education}}</div>
```

_Before:_ Nothing is rendered.
_After:_ The icon is rendered correctly.

-----

```html
<div id="first">First variable</div>
<div id="second">{{first}}</div>
```

When using `{{second}}`:
_Before:_ Nothing is rendered.
_After:_ The value "First variable" is shown.

**Is there anything you'd like reviewers to focus on?**
Documentation

~~The documentation sample code. Is there a way to escape the `{{}}` inside a multi-line code?~~

~~Things I tried:~~
* ~~Using `<span></span>` trick: Doesn't work, the span tag is rendered.~~
* ~~Using [`{% raw %}`](https://mozilla.github.io/nunjucks/templating.html#raw): Unfortunately this always gets overridden because we call nunjucks multiple times (last time I debug it was called twice).~~
* ~~Using `{% raw %}` twice: The temporary workaround works... until vue comes along and removes it, because it is not wrapped with [`<span v-pre>`](https://vuejs.org/v2/api/#v-pre).~~
* ~~Using `<span v-pre>`, `<markdown>`, `{% raw %}`: Doesn't work inside code snippets or just doesn't render properly.~~

**Testing instructions:**
1. Declare new variables inside `variables.md`.
```html
<span id="icon_prereq">{{glyphicon_education}}</span>
<span id="forty_two">42</span>
<span id="some_value">{{forty_two}}</span>
```
2. Use the variables in a markdown file (e.g. `index.md`):
```
{{icon_prereq}}

{{some_value}}
```
3. The icon and the value should be rendered properly:
![iconand42](https://user-images.githubusercontent.com/3168908/40339283-5f723ac8-5dac-11e8-8ab9-db94450a0d36.png)

