### PR TITLE
Fix page title prefix get repeated at every live reload

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -67,12 +67,16 @@ function unique(array) {
 }
 
 Page.prototype.prepareTemplateData = function () {
+  const prefixedTitle = this.titlePrefix
+    ? this.titlePrefix + (this.title ? TITLE_PREFIX_SEPARATOR + this.title : '')
+    : this.title;
+
   return {
     asset: this.asset,
     baseUrl: this.baseUrl,
     content: this.content,
     faviconUrl: this.faviconUrl,
-    title: this.title,
+    title: prefixedTitle,
   };
 };
 
@@ -114,9 +118,7 @@ Page.prototype.collectFrontMatter = function (includedPage) {
       title: this.title || '',
     };
   }
-  this.title = this.titlePrefix
-    ? this.titlePrefix + (this.frontMatter.title ? TITLE_PREFIX_SEPARATOR + this.frontMatter.title : '')
-    : this.frontMatter.title;
+  this.title = this.frontMatter.title;
 };
 
 /**

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -107,22 +107,16 @@ Page.prototype.collectFrontMatter = function (includedPage) {
     this.frontMatter.src = this.src;
     // Title specified in site.json will override title specified in front matter
     this.frontMatter.title = (this.title || this.frontMatter.title || '');
-    if (this.titlePrefix) {
-      this.frontMatter.title = this.frontMatter.title
-        ? this.titlePrefix + TITLE_PREFIX_SEPARATOR + this.frontMatter.title
-        : this.titlePrefix;
-    }
   } else {
     // Page is addressable but no front matter specified
-    const formattedTitle = this.titlePrefix
-      ? this.titlePrefix + (this.title ? TITLE_PREFIX_SEPARATOR + this.title : '')
-      : this.title;
     this.frontMatter = {
       src: this.src,
-      title: formattedTitle,
+      title: this.title || '',
     };
   }
-  this.title = this.frontMatter.title;
+  this.title = this.titlePrefix
+    ? this.titlePrefix + (this.frontMatter.title ? TITLE_PREFIX_SEPARATOR + this.frontMatter.title : '')
+    : this.frontMatter.title;
 };
 
 /**


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #233.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
While the website is running live through `markbind serve`, modifying a page causes the page title to re-prepend the title prefix to the title. Therefore, reloading the page three times will cause three title prefixes to appear on the page title for example.

**What changes did you make? (Give an overview)**
Moved the prefix prepending logic to the `prepareTemplateData()` function so that the title prefix only gets added in at the render stage, rather than at the page (re-)processing stage.

**Provide some example code that this change will affect:**

Before | After
---- | ----
![title - before](https://user-images.githubusercontent.com/3168908/40398938-290ebbac-5e6d-11e8-86de-cb6320e7860b.png) | ![title - after](https://user-images.githubusercontent.com/3168908/40398966-535cd196-5e6d-11e8-88a6-6e0be011d768.png)



**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. Run `markbind serve` on a website with a `titlePrefix` set (e.g. `"titlePrefix": "Prefix"`).
2. Modify the page multiple times (change, save, change, save, ...).
3. The new page should still have one title prefix (e.g. "Prefix - XXXXXX").