### PR TITLE
Support initialisation of footer.md

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -40,3 +40,23 @@ blockquote {
         background-color: #fff;
     }
 }
+
+/* Footer */
+
+footer {
+    background-color: #f5f5f5;
+    color: dimgrey;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding: 10px 0;
+}
+
+#app {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#flex-div {
+    flex: 1;
+}

--- a/docs/_markbind/footers/userGuideSections.md
+++ b/docs/_markbind/footers/userGuideSections.md
@@ -1,0 +1,13 @@
+<footer>
+  <markdown class="website-content">
+## Sections
+- <a href="{{baseUrl}}/userGuide/userQuickStart.html">Quick Start</a>
+- <a href="{{baseUrl}}/userGuide/developingASite.html">Developing a Site</a>
+  - <a href="{{baseUrl}}/userGuide/siteConfiguration.html">Site Configuration</a>
+- <a href="{{baseUrl}}/userGuide/contentAuthoring.html">Content Authoring</a>
+  - <a href="{{baseUrl}}/userGuide/includingContents.html">Including Contents</a>
+- Deploying a Site
+  - <a href="{{baseUrl}}/userGuide/ghpagesDeployment.html">Github Pages Deployment</a>
+  - <a href="{{baseUrl}}/userGuide/netlifyPreview.html">Preview site on Netlify</a>
+  </markdown>
+</footer>

--- a/docs/common/userGuideSections.md
+++ b/docs/common/userGuideSections.md
@@ -1,9 +1,0 @@
-## Sections
-- <a href="{{baseUrl}}/userGuide/userQuickStart.html">Quick Start</a>
-- <a href="{{baseUrl}}/userGuide/developingASite.html">Developing a Site</a>
-  - <a href="{{baseUrl}}/userGuide/siteConfiguration.html">Site Configuration</a>
-- <a href="{{baseUrl}}/userGuide/contentAuthoring.html">Content Authoring</a>
-  - <a href="{{baseUrl}}/userGuide/includingContents.html">Including Contents</a>
-- Deploying a Site
-  - <a href="{{baseUrl}}/userGuide/ghpagesDeployment.html">Github Pages Deployment</a>
-  - <a href="{{baseUrl}}/userGuide/netlifyPreview.html">Preview site on Netlify</a>

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -280,6 +284,53 @@ Front matter can also be included from a separate file, just like how content ca
 
 This will result in `index.md` having the title `Binary Search Tree` and the specified keywords in order for it to be looked up through the search bar.
 
-<include src="../common/userGuideSections.md" />
+### Using Footers
+
+It is optional to put footers in your site. If you wish to do so, there are two ways that MarkBind supports.
+
+#### 1. Specifying footer file in Front Matter
+
+By default, there is a `footer.md` file created for you in `_markbind/footers`. 
+If you need additional footers for different pages, you can create footer files in the same folder and wrap the contents in a `<footer>` tag. 
+
+```html
+<!-- In _markbind/footers/myFooterFile.md -->
+<footer>
+  This is my own footer!
+</footer>
+```
+
+After which, you must specify the file within [front matter](#front-matter)'s `footer` attribute to render the footer.
+
+```html
+<!-- In the file that you want to include a footer -->
+<frontmatter>
+  footer: myFooterFile.md
+</frontmatter>
+```
+
+Note:
+- Only one footer file can be specified in the [front matter](#front-matter) per page, and you must include its file extension.
+
+#### 2. Defining your own inline footer
+
+If you would like to have a page-specific footer content, you can author one inline with the same `<footer>` tag. 
+
+```html
+# Hello world
+<p>Some text</p>
+<footer>
+  <p align="center">
+    This is my inline footer, unique to this page!
+  </p>
+</footer>
+```
+
+Note:
+- Footer file specified in [front matter](#front-matter) overrides all inline footers in the same page.
+- Inline footers need to be the last element in a page.
+- If there is more than one inline footer in a page, only the last inline footer will be rendered.
+- Footers should not be nested in other components or HTML tags. If found inside, they will be shifted outside to be rendered properly.
+- MarkBind-dependent components and includes are not supported in footers.
 
 </div>

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -15,7 +19,12 @@ $ markbind init
 
 If you wish to create the site into a new directory, you can do so by running `markbind init ./directory`
 
-After running `init`, two files will be created for you: `index.md` and `site.json`. `index.md` is where you can start writing your contents (and will be rendered as `index.html` later), and [`site.json`](#sitejson) is the configuration file used for MarkBind to build your website correctly. **A valid `site.json` file is required to build a MarkBind-driven site**.
+After running `init`, two files will be created for you: `index.md` and `site.json`. 
+
+- `index.md` is where you can start writing your contents (and will be rendered as `index.html` later). 
+- [`site.json`](#sitejson) is the configuration file used for MarkBind to build your website correctly. 
+
+**A valid `site.json` file is required to build a MarkBind-driven site**.
 
 ## Preview and serve your site using:
 
@@ -55,6 +64,5 @@ Please check more details of deployment [here](ghpagesDeployment.html).
 
 Let's take a look at this newly created `site.json`:
 <include src="siteConfiguration.md#siteConfig" />
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/docs/userGuide/ghpagesDeployment.md
+++ b/docs/userGuide/ghpagesDeployment.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -55,7 +59,5 @@ The following deployment config is available in your `site.json`'s "*deploy*" se
 
   This is the branch that will be deployed to in the remote repo.    
   (**Default**: 'gh-pages')
-
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/docs/userGuide/includingContents.md
+++ b/docs/userGuide/includingContents.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -62,6 +66,13 @@
         site.json
       some.md (it include a file in site A, <include src="./A/other.md">)
     ```
+    
+    You may reference files from external directories using the following prefixes:
+    ```
+    ./  = Current directory
+    ../ = Parent of current directory
+    ../../ = Two directories backwards
+    ```
 
 4. #### Handling repetitive boilerplate files
 
@@ -89,7 +100,5 @@
     Boilerplate files need `src` and `boilerplate` attributes. The value of `src` is compulsory — it should be where you want the included file to be if you have to duplicate it. The `boilerplate` value is optionally used to specify the path within the boilerplate folder. If unspecified, the file is assumed to be at `/_markbind/boilerplates/baseNameInSrc`. Else, MarkBind will look for the file at `/_markbind/boilerplates/value`.
     </markdown>
     </tip-box>
-
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/docs/userGuide/index.md
+++ b/docs/userGuide/index.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -10,5 +14,4 @@ MarkBind provides many useful markups (customized HTML tags) to help you create 
 
 Take a look at the [quick start guide](userQuickStart.html) to start building your website with MarkBind.
 
-<include src="../common/userGuideSections.md" />
 </div>

--- a/docs/userGuide/netlifyPreview.md
+++ b/docs/userGuide/netlifyPreview.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -69,8 +73,5 @@ Additionally when contributors make a pull request to `master`, you can preview 
 ![Preview deploy]({{baseUrl}}/images/netlifyPreview4.png)
 
 </panel>
-
-
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -44,7 +48,5 @@ Let's examine a typical `site.json` file:
 | **ignore** | Files to be ignored when building the website. By default, MarkBind will copy all the assets into the output folder. The ignore pattern follows the pattern used in [`.gitignore`](https://git-scm.com/docs/gitignore#_pattern_format). You may want to ignore all markdown source files by adding the entry `*.md`, as well as the Git working directory `.git/*`. |
 | **deploy** | Settings for the auto Github page deployment. Please refer this [doc](ghpagesDeployment.html) for more details. |
 </div>
-
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/docs/userGuide/userQuickStart.md
+++ b/docs/userGuide/userQuickStart.md
@@ -1,3 +1,7 @@
+<frontmatter>
+  footer: userGuideSections.md
+</frontmatter>
+
 <include src="../common/header.md" />
 
 <div class="website-content">
@@ -67,7 +71,12 @@ $ markbind init
 
 If you wish to create the site into a new directory, you can do so by running `markbind init ./directory`
 
-After running `init`, two files will be created for you: `index.md` and `site.json`. `index.md` is where you can start writing your contents (and will be rendered as `index.html` later), and `site.json` is the configuration file used for MarkBind to build your website correctly. **A valid `site.json` file is required to build a MarkBind-driven site**.
+After running `init`, two files will be created for you: `index.md` and `site.json`. 
+
+- `index.md` is where you can start writing your contents (and will be rendered as `index.html` later). 
+- `site.json` is the configuration file used for MarkBind to build your website correctly. 
+
+**A valid `site.json` file is required to build a MarkBind-driven site**.
 
 You may refer to this [doc](siteConfiguration.html) for more details about how you can configure the `site.json`.
 
@@ -121,7 +130,5 @@ $ markbind deploy
 By default, it will try to push everything in the generated site (default dir: `_site`) to the `gh-pages` branch of the current git working directory's remote repo.
 
 More details of deployment setting could be found in [here](ghpagesDeployment.html).
-
-<include src="../common/userGuideSections.md" />
 
 </div>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -11,6 +11,10 @@ const FsUtil = require('./util/fsUtil');
 const logger = require('./util/logger');
 const MarkBind = require('./markbind/lib/parser');
 
+const FOOTERS_FOLDER_PATH = '_markbind/footers';
+
+const FLEX_DIV_HTML = '<div id="flex-div"></div>';
+const FLEX_DIV_ID = 'flex-div';
 const FRONT_MATTER_FENCE = '---';
 const TITLE_PREFIX_SEPARATOR = ' - ';
 
@@ -60,6 +64,28 @@ function calculateNewBaseUrl(filePath, root, lookUp) {
   }
 
   return calculate(filePath, []);
+}
+
+function formatFooter(pageData) {
+  const $ = cheerio.load(pageData);
+  const footers = $('footer');
+  if (footers.length === 0) {
+    return pageData;
+  }
+  // Remove preceding footers
+  footers.slice(0, -1).remove(); // footers.not(':last').remove();
+  // Unwrap last footer
+  const lastFooter = footers.last();
+  const lastFooterParents = lastFooter.parents();
+  if (lastFooterParents.length) {
+    const lastFooterOutermostParent = lastFooterParents.last();
+    lastFooterOutermostParent.after(lastFooter);
+  }
+  // Insert flex div before last footer
+  if (lastFooter.prev().attr('id') !== FLEX_DIV_ID) {
+    $(lastFooter).before(FLEX_DIV_HTML);
+  }
+  return $.html();
 }
 
 function unique(array) {
@@ -136,6 +162,22 @@ Page.prototype.removeFrontMatter = function (includedPage) {
   return $.html();
 };
 
+/**
+ * Inserts the footer specified in front matter to the end of the page
+ * @param pageData a page with its front matter collected
+ */
+Page.prototype.insertFooter = function (pageData) {
+  const { footer } = this.frontMatter;
+  if (!footer) {
+    return pageData;
+  }
+  const footerPath = path.join(this.rootPath, FOOTERS_FOLDER_PATH, footer);
+  const footerContent = fs.readFileSync(footerPath, 'utf8');
+  const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
+  const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
+  return `${pageData}\n${nunjucks.renderString(footerContent, userDefinedVariables)}`;
+};
+
 Page.prototype.generate = function (builtFiles) {
   this.includedFiles = {};
   this.includedFiles[this.sourcePath] = true;
@@ -154,6 +196,8 @@ Page.prototype.generate = function (builtFiles) {
         this.collectFrontMatter(result);
         return this.removeFrontMatter(result);
       })
+      .then(result => this.insertFooter(result))
+      .then(result => formatFooter(result))
       .then(result => markbinder.resolveBaseUrl(result, fileConfig))
       .then(result => fs.outputFileAsync(this.tempPath, result))
       .then(() => markbinder.renderFile(this.tempPath, fileConfig))

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -30,6 +30,7 @@ const TEMPLATE_ROOT_FOLDER_NAME = 'template';
 const TEMPLATE_SITE_ASSET_FOLDER_NAME = 'markbind';
 
 const FAVICON_DEFAULT_PATH = 'favicon.ico';
+const FOOTER_PATH = '_markbind/footers/footer.md';
 const GLYPHICONS_PATH = 'asset/glyphicons.csv';
 const INDEX_MARKDOWN_FILE = 'index.md';
 const PAGE_TEMPLATE_NAME = 'page.ejs';
@@ -60,8 +61,20 @@ const SITE_CONFIG_DEFAULT = {
   },
 };
 
+const FOOTER_DEFAULT = '<footer>\n'
+  + '  <div class="text-center">\n'
+  + '    This is a dynamic height footer that supports variables {{glyphicon_tags}} '
+  + 'and markdown <md>:smile:</md>!\n'
+  + '  </div>\n'
+  + '  <!-- Support MarkBind by including this timestamp or a link to us on your landing page! -->\n'
+  + '  <div class="text-center">\n'
+  + '    {{timestamp}}\n'
+  + '  </div>\n'
+  + '</footer>\n';
+
 const INDEX_MARKDOWN_DEFAULT = '<frontmatter>\n'
-  + 'title: "Hello World"\n'
+  + '  title: "Hello World"\n'
+  + '  footer: footer.md\n'
   + '</frontmatter>\n\n'
   + '# Hello world\n'
   + 'Welcome to your page generated with MarkBind.\n';
@@ -135,6 +148,7 @@ function setExtension(filename, ext) {
 Site.initSite = function (rootPath) {
   const boilerplatePath = path.join(rootPath, BOILERPLATE_FOLDER_NAME);
   const configPath = path.join(rootPath, SITE_CONFIG_NAME);
+  const footerPath = path.join(rootPath, FOOTER_PATH);
   const indexPath = path.join(rootPath, INDEX_MARKDOWN_FILE);
   const userDefinedVariablesPath = path.join(rootPath, USER_VARIABLES_PATH);
   // TODO: log the generate info
@@ -166,6 +180,13 @@ Site.initSite = function (rootPath) {
           return Promise.resolve();
         }
         return fs.outputFileAsync(userDefinedVariablesPath, USER_VARIABLES_DEFAULT);
+      })
+      .then(() => fs.accessAsync(footerPath))
+      .catch(() => {
+        if (fs.existsSync(footerPath)) {
+          return Promise.resolve();
+        }
+        return fs.outputFileAsync(footerPath, FOOTER_DEFAULT);
       })
       .then(resolve)
       .catch(reject);

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -121,7 +121,9 @@ Parser.prototype._preprocess = function (node, context, config) {
   if (hasSrc && shouldProcessSrc) {
     isUrl = utils.isUrl(element.attribs.src);
     includeSrc = url.parse(element.attribs.src);
-    filePath = isUrl ? element.attribs.src : path.resolve(path.dirname(context.cwf), includeSrc.path);
+    filePath = isUrl
+      ? element.attribs.src
+      : path.resolve(path.dirname(context.cwf), decodeURIComponent(includeSrc.path));
     actualFilePath = filePath;
     const isBoilerplate = _.hasIn(element.attribs, 'boilerplate');
     if (isBoilerplate) {

--- a/test/test_site/_markbind/footers/footer.md
+++ b/test/test_site/_markbind/footers/footer.md
@@ -1,0 +1,5 @@
+<footer>
+  <div class="text-center">
+    This is a dynamic height footer that supports variables {{glyphicon_tags}} and markdown <md>:smile:</md>!
+  </div>
+</footer>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -84,6 +84,12 @@ specification that specifies how the product will address the requirements. </sp
     </ol>
     <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
 </div>
+<div id="flex-div"></div>
+<footer>
+  <div class="text-center">
+    This is a dynamic height footer that supports variables <span class="glyphicon glyphicon-tags" aria-hidden="true"></span> and markdown <span>😄</span>!
+  </div>
+</footer>
 </div>
 </body>
 <script src="markbind\js\vue.min.js"></script>

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -40,3 +40,23 @@ blockquote {
         background-color: #fff;
     }
 }
+
+/* Footer */
+
+footer {
+    background-color: #f5f5f5;
+    color: dimgrey;
+    margin-left: -15px;
+    margin-right: -15px;
+    padding: 10px 0;
+}
+
+#app {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#flex-div {
+    flex: 1;
+}

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -2,6 +2,7 @@
   "pages": [
     {
       "title": "Hello World",
+      "footer": "footer.md",
       "src": "index.md"
     },
     {

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -1,5 +1,6 @@
 <frontmatter>
 title: Hello World
+footer: footer.md
 </frontmatter>
 
 <include src="components/header.md" />

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -5,6 +5,7 @@ const ghpages = require('gh-pages');
 const cloneDeep = require('lodash/cloneDeep');
 
 const {
+  FOOTER_MD_DEFAULT,
   INDEX_MD_DEFAULT,
   PAGE_EJS,
   SITE_JSON_DEFAULT,
@@ -69,12 +70,15 @@ test('Site Init in existing directory generates correct assets', async () => {
 
   await Site.initSite('');
   const paths = Object.keys(fs.vol.toJSON());
-  const originalNumFiles = 1;
-  const expectedNumBuilt = 4;
+  const originalNumFiles = Object.keys(json).length;
+  const expectedNumBuilt = 5;
   expect(paths.length).toEqual(originalNumFiles + expectedNumBuilt);
 
   // _boilerplates
   expect(fs.existsSync(path.resolve('_markbind/boilerplates'))).toEqual(true);
+
+  // footer.md
+  expect(fs.readFileSync(path.resolve('_markbind/footers/footer.md'), 'utf8')).toEqual(FOOTER_MD_DEFAULT);
 
   // user defined variables
   expect(fs.readFileSync(path.resolve('_markbind/variables.md'), 'utf8')).toEqual(USER_VARIABLES_DEFAULT);
@@ -94,12 +98,16 @@ test('Site Init in directory which does not exist generates correct assets', asy
 
   await Site.initSite('newDir');
   const paths = Object.keys(fs.vol.toJSON());
-  const originalNumFiles = 1;
-  const expectedNumBuilt = 4;
+  const originalNumFiles = Object.keys(json).length;
+  const expectedNumBuilt = 5;
 
   expect(paths.length).toEqual(originalNumFiles + expectedNumBuilt);
 
   expect(fs.existsSync(path.resolve('newDir/_markbind/boilerplates'))).toEqual(true);
+
+  // footer.md
+  expect(fs.readFileSync(path.resolve('newDir/_markbind/footers/footer.md'), 'utf8'))
+    .toEqual(FOOTER_MD_DEFAULT);
 
   // user defined variables
   expect(fs.readFileSync(path.resolve('newDir/_markbind/variables.md'), 'utf8'))

--- a/test/unit/utils/data.js
+++ b/test/unit/utils/data.js
@@ -42,10 +42,23 @@ module.exports.SITE_JSON_DEFAULT = '{\n'
   + '  }\n'
   + '}\n';
 
+module.exports.FOOTER_MD_DEFAULT = '<footer>\n'
+  + '  <div class="text-center">\n'
+  + '    This is a dynamic height footer that supports variables {{glyphicon_tags}} '
+  + 'and markdown <md>:smile:</md>!\n'
+  + '  </div>\n'
+  + '  <!-- Support MarkBind by including this timestamp or a link to us on your landing page! -->\n'
+  + '  <div class="text-center">\n'
+  + '    {{timestamp}}\n'
+  + '  </div>\n'
+  + '</footer>\n';
+
 module.exports.INDEX_MD_DEFAULT = '<frontmatter>\n'
-  + 'title: "Hello World"\n'
+  + '  title: "Hello World"\n'
+  + '  footer: footer.md\n'
   + '</frontmatter>\n\n'
-  + '# Hello world\nWelcome to your page generated with MarkBind.\n';
+  + '# Hello world\n'
+  + 'Welcome to your page generated with MarkBind.\n';
 
 module.exports.USER_VARIABLES_DEFAULT = '<span id="example">\n'
   + 'To inject this HTML segment in your markbind files, use {{ example }} where you want to place it.\n'


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [X] New feature
• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #236
Fixes #241 
<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to have a default footer.md generated when initialising MarkBind.

**What changes did you make? (Give an overview)**

Functionality | Code 
--- | --- 
Generated footer.md in `_markbind/footers` directory <br>`Index.md` now specifies `footer.md` in `Front Matter` by default during `init`|  file generated in `initSite` and add default values for `footer.md`  
Support for a dynamic height footer using CSS Flexbox | To enable this, an empty `div` with the appropriate `#flex-div` CSS needs to be appended before a footer. This is done through `insertFlexDivBeforeLastFooter` , called after `insertTemplates` 
Remove duplicate footers in a single page. Due to being able to include other pages (which may contain a footer of their own) | Duplicates removed in new util function `removeDuplicateFooter`, called after `insertFlexDivBeforeLastFooter`
Ensure footers are not enclosed in any other component or html tag | Done in util function `unwrapFooter`, called after `removeDuplicateFooter`
Bug fix for #241 | `decodeURIComponent` for filePath in `_preprocess`


Demo of feature: |
--- |
**Note:** Background colours are modified to emphasise different parts of the components. It will be reverted for final review. <br><br>Green: app container which houses all generated content (appContents + footer) <br>Beige: Portion of `<div id="appContents">`, to enable dynamic height footer <br> Blue: Portion of footer, with intentional negative margins so it extends to cover the background of the app container. <br> ![footer-v2-demo](https://user-images.githubusercontent.com/31084833/40415533-ab99f236-5ead-11e8-9a6c-dea505379812.gif) <br> | 

Footer styling |
--- |
![footerstyleone](https://user-images.githubusercontent.com/31084833/40415500-932edf0e-5ead-11e8-9ad4-f353ec7b2124.PNG)

**Is there anything you'd like reviewers to focus on?**
- Default content for footer.md / index.md
- Variable / Method naming
- Updated Unit Tests
- User Guide wording 

**Testing instructions:**
1. Run `markbind init` on a blank folder.
2.  `markbind serve` should generate the footer correctly (bottom of page) despite sparse content.
3. Add long content to same page
4. Footer should be at the bottom of the page after scrolling
5. Define own custom `<footer>` in source lines. Delete `footer: footer.md` in `Front Matter` The custom footer should be the only one that renders.
6. Create another page that specifies a footer in its `Front Matter` or has a custom `<footer>`.
7. Include new page within original page. 
8. Included page should have contents generated but not its footer, on the original page.