### PR TITLE
baseUrl's value sometimes wrong when referencing inner website's content

### DIFF
--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -543,8 +543,8 @@ Parser.prototype._rebaseReference = function (node, foundBase) {
   });
 
   // rebase current element
-  if (element.attribs[ATTRIB_CWF]) {
-    const filePath = element.attribs[ATTRIB_CWF];
+  if (element.attribs[ATTRIB_INCLUDE_PATH]) {
+    const filePath = element.attribs[ATTRIB_INCLUDE_PATH];
     let newBase = calculateNewBaseUrls(filePath, this.rootPath, this.baseUrlMap);
     if (newBase) {
       const { relative, parent } = newBase;
@@ -552,10 +552,11 @@ Parser.prototype._rebaseReference = function (node, foundBase) {
       foundBase[parent] = relative;
     }
 
-    const bases = Object.keys(childrenBase);
+    const combinedBases = Object.assign({}, childrenBase, foundBase);
+    const bases = Object.keys(combinedBases);
     if (bases.length !== 0) {
       // need to rebase
-      newBase = childrenBase[bases[0]];
+      newBase = combinedBases[bases[0]];
       const { children } = element;
       if (children) {
         const currentBase = calculateNewBaseUrls(element.attribs[ATTRIB_CWF], this.rootPath, this.baseUrlMap);

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -564,7 +564,12 @@ Parser.prototype._rebaseReference = function (node, foundBase) {
           if (currentBase.relative !== newBase) {
             cheerio.prototype.options.xmlMode = false;
             const newBaseUrl = `{{hostBaseUrl}}/${newBase}`;
-            const rendered = nunjucks.renderString(cheerio.html(children), { baseUrl: newBaseUrl });
+            const rendered = nunjucks.renderString(cheerio.html(children), {
+              // This is to prevent the nunjuck call from converting {{hostBaseUrl}} to an empty string
+              // and let the hostBaseUrl value be injected later.
+              hostBaseUrl: '{{hostBaseUrl}}',
+              baseUrl: newBaseUrl,
+            });
             element.children = cheerio.parseHTML(rendered, true);
             cheerio.prototype.options.xmlMode = true;
           }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #262.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
When including files belonging to an inner website, the computation of `baseUrl` is wrong if the depth of the inclusion is only 1.

**What changes did you make? (Give an overview)**
Fixed the logic of the algorithm such that the computation of `baseUrl` is correct regardless of how deep the inclusion is.

**Provide some example code that this change will affect:**
https://github.com/yamgent/markbind-problems/tree/master/issue_262

**Is there anything you'd like reviewers to focus on?**
The soundness of the fix.

**Testing instructions:**
1. Clone https://github.com/yamgent/markbind-problems.git.
1. Go to `issue_262` directory.
1. Run `markbind serve`.
1. Everything should render with `This is cheese's baseUrl: /main_website/inner_site.`
   a. In the buggy version, the first entry will show `This is cheese's baseUrl: /main_website.`