### PR TITLE
Site: Initialize baseUrl before user variables

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -314,6 +314,12 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
       content = '';
       logger.warn(e.message);
     }
+
+    // This is to prevent the first nunjuck call from converting {{baseUrl}} to an empty string
+    // and let the baseUrl value be injected later.
+    userDefinedVariables.baseUrl = '{{baseUrl}}';
+    this.userDefinedVariablesMap[base] = userDefinedVariables;
+
     const $ = cheerio.load(content);
     $.root().children().each(function () {
       const id = $(this).attr('id');
@@ -321,11 +327,6 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
       const html = nunjucks.renderString($(this).html(), userDefinedVariables);
       userDefinedVariables[id] = html;
     });
-
-    // This is to prevent the first nunjuck call from converting {{baseUrl}} to an empty string
-    // and let the baseUrl value be injected later.
-    userDefinedVariables.baseUrl = '{{baseUrl}}';
-    this.userDefinedVariablesMap[base] = userDefinedVariables;
   });
 };
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #261.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
If a user variable refers to `baseUrl`, the string is empty instead of the actual `baseUrl`.

**What changes did you make? (Give an overview)**
Shifted the order of the variable initialization such that baseUrl is initialized first. Thanks to @rachx for the fix suggestion.

**Provide some example code that this change will affect:**
https://github.com/yamgent/markbind-problems/tree/master/issue_261

**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. Clone https://github.com/yamgent/markbind-problems.git.
1. Navigate inside `issue_261`.
1. Run `markbind serve`.
1. The actual should match the expected.
    a. In the buggy version, the second line will render as `The baseUrl that we are using is .` (i.e. `baseUrl` does not render properly).