### PR TITLE
Add components reference main page

### DIFF
--- a/docs/_markbind/navigation/userGuideSections.md
+++ b/docs/_markbind/navigation/userGuideSections.md
@@ -9,4 +9,5 @@
 * Deploying a Site
   * [Github Pages Deployment]({{baseUrl}}/userGuide/ghpagesDeployment.html)
   * [Preview site on Netlify]({{baseUrl}}/userGuide/netlifyPreview.html)
+* [Components Reference]({{baseUrl}}/userGuide/componentsReference/index.html)
 </markdown>

--- a/docs/common/header.md
+++ b/docs/common/header.md
@@ -15,6 +15,8 @@
     <li style="margin: 3px 20px;">Deploying a Site</li>
     <li><a href="{{baseUrl}}/userGuide/ghpagesDeployment.html">◦&nbsp; Github Pages Deployment</a></li>
     <li><a href="{{baseUrl}}/userGuide/netlifyPreview.html">◦&nbsp; Preview site on Netlify</a></li>
+    <li role="separator" class="divider"></li>
+    <li><a href="{{baseUrl}}/userGuide/componentsReference/index.html">Components Reference</a></li>
   </dropdown>
   <li>
     <a href="https://github.com/MarkBind/markbind" target="_blank">

--- a/docs/site.json
+++ b/docs/site.json
@@ -34,6 +34,10 @@
       "title": "MarkBind: User Guide - Known Problems"
     },
     {
+      "src": "userGuide/componentsReference/index.md",
+      "title": "MarkBind: User Guide - Components Reference"
+    },
+    {
       "src": "userGuide/ghpagesDeployment.md",
       "title": "MarkBind: User Guide - Github Pages Deployment"
     },

--- a/docs/userGuide/componentsReference/index.md
+++ b/docs/userGuide/componentsReference/index.md
@@ -1,0 +1,30 @@
+<frontmatter>
+  footer: userGuideFooter.md
+  siteNav: userGuideSections.md
+</frontmatter>
+
+<include src="../../common/header.md" />
+
+<div class="website-content">
+
+# Components Reference
+
+This section provides a list of MarkBind components that you may wish to use for your website.
+
+Click on any of the components below to learn more about how the component can be used, and the options available.
+
+* [Dropdown]()
+* [Image]()
+* [Modal]()
+* [Navbar]()
+* [Panel]()
+* [Popover]()
+* [Question]()
+* [Retriever]()
+* [Searchbar]()
+* [Tabs]()
+* [Tipbox]()
+* [Tooltip]()
+* [Trigger]()
+
+</div>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Part of #274.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
We are migrating documentations from vue-strap to MarkBind, we will need at least a main page to link to each of the individual components that we have.

**What changes did you make? (Give an overview)**
Added a main landing page `componentsReference.md`.

**Provide some example code that this change will affect:**
NIL

**Is there anything you'd like reviewers to focus on?**
Wordings.

**Testing instructions:**
~~Run `markbind serve docs` to see the rendered doc.~~ Just see Netlify.