### PR TITLE
Add searchbar documentation

### DIFF
--- a/docs/userGuide/components.md
+++ b/docs/userGuide/components.md
@@ -9,4 +9,6 @@
 
 # Components
 
+<include src="./components/searchbar.md" />
+
 </div>

--- a/docs/userGuide/components/searchbar.md
+++ b/docs/userGuide/components/searchbar.md
@@ -1,5 +1,5 @@
-
 # Searchbar
+
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
   <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
@@ -20,4 +20,4 @@ Name | Type | Default | Description
 ---- | ---- | ------- | ------
 data | `Array` || The local data source for suggestions. Expected to be a primitive array.
 on-hit | `Function` || A callback function when you click or hit return on an item.
-placeholder | `String` || Default text shown in the searchbar.
+placeholder | `String` || 

--- a/docs/userGuide/components/searchbar.md
+++ b/docs/userGuide/components/searchbar.md
@@ -1,0 +1,23 @@
+
+# Searchbar
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
+</tip-box>
+
+<tip-box border-left-color="black">
+<i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+``` html
+<searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
+```
+</tip-box>
+<br>
+
+## Searchbar Options
+
+Name | Type | Default | Description
+---- | ---- | ------- | ------
+data | `Array` || The local data source for suggestions. Expected to be a primitive array.
+on-hit | `Function` || A callback function when you click or hit return on an item.
+placeholder | `String` || Default text shown in the searchbar.


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Documentation update

Part of #274.

What is the rationale for this request?
searchbar documentation 

What changes did you make? (Give an overview)
Added componentsReferences directory and searchbarDoc in it. 

Provide some example code that this change will affect:
NIL

Testing instructions:
Run `markbind serve docs` to see the rendered doc on http://127.0.0.1:8080/markbind/userGuide/componentsReference/searchbarDoc.html