### PR TITLE
Improve components reference main page

### DIFF
--- a/docs/common/header.md
+++ b/docs/common/header.md
@@ -16,7 +16,7 @@
     <li><a href="{{baseUrl}}/userGuide/ghpagesDeployment.html">◦&nbsp; Github Pages Deployment</a></li>
     <li><a href="{{baseUrl}}/userGuide/netlifyPreview.html">◦&nbsp; Preview site on Netlify</a></li>
     <li role="separator" class="divider"></li>
-    <li><a href="{{baseUrl}}/userGuide/components.html">Components</a></li>
+    <li><a href="{{baseUrl}}/userGuide/components.html">Components Reference</a></li>
   </dropdown>
   <li>
     <a href="https://github.com/MarkBind/markbind" target="_blank">

--- a/docs/userGuide/components.md
+++ b/docs/userGuide/components.md
@@ -9,6 +9,40 @@
 
 # Components Reference
 
+<include src="./components/dropdown.md" />
+<br>
+
+<include src="./components/modal.md" />
+<br>
+
+<include src="./components/navbar.md" />
+<br>
+
 <include src="./components/panel.md" />
+<br>
+
+<include src="./components/pic.md" />
+<br>
+
+<include src="./components/popover.md" />
+<br>
+
+<include src="./components/question.md" />
+<br>
+
+<include src="./components/searchbar.md" />
+<br>
+
+<include src="./components/tabs.md" />
+<br>
+
+<include src="./components/tipBox.md" />
+<br>
+
+<include src="./components/tooltip.md" />
+<br>
+
+<include src="./components/trigger.md" />
+<br>
 
 </div>

--- a/docs/userGuide/components.md
+++ b/docs/userGuide/components.md
@@ -7,7 +7,7 @@
 
 <div class="website-content">
 
-# Components
+# Components Reference
 
 <include src="./components/panel.md" />
 

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -258,7 +258,7 @@ To use a component, just type the corresponding markup in your file. For example
 </panel>
 ```
 
-For a list of supported components, refer to [VueStrap modified by MarkBind](https://markbind.github.io/vue-strap/).
+For a list of supported components, refer to the [Components Reference]({{baseUrl}}/userGuide/components.html).
 
 To make an element closeable, use `v-closeable`.
 

--- a/docs/userGuide/index.md
+++ b/docs/userGuide/index.md
@@ -11,7 +11,7 @@
 
 MarkBind enhances markdown and html documents with extra features that allow you to compose content-extensive website from document fragments at ease.
 
-MarkBind provides many useful markups (customized HTML tags) to help you create complex and interactive components with simple tags such as `<panel>` and `<popover>`. The reference for all supported customized elements could be found at [VueStrap modified by MarkBind](https://markbind.github.io/vue-strap/).
+MarkBind provides many useful markups (customized HTML tags) to help you create complex and interactive components with simple tags such as `<panel>` and `<popover>`. The reference for all supported customized elements could be found at the [Components Reference]({{baseUrl}}/userGuide/components.html).
 
 Take a look at the [quick start guide](userQuickStart.html) to start building your website with MarkBind.
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Improvements can be made w.r.t. the components reference main page.

**What changes did you make? (Give an overview)**
* Change link from vue-strap's documentation to our main page.
* Renamed page title to "Components Reference"

**Testing instructions:**
See Netlify