### PR TITLE
Migrate trigger, popover, tooltip docs

### DIFF
--- a/docs/userGuide/components/popover.md
+++ b/docs/userGuide/components/popover.md
@@ -1,0 +1,129 @@
+# Popover
+
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </popover>
+  <hr>
+  <h4>Title</h4>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </popover>
+  <hr />
+  <h4>Trigger</h4>
+  <p>
+    <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
+      <button class="btn btn-default">Mouseenter</button>
+    </popover>
+    <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
+      <button class="btn btn-default">Contextmenu (right click)</button>
+    </popover>
+  </p>
+  <h4>Markdown</h4>
+  <p>
+    <popover effect="scale" title="**Emoji title** :rocket:" content="++emoji++ content :cat:">
+      <button class="btn btn-default">Hover</button>
+    </popover>
+  </p>
+  <h4>Content using slot</h4>
+  <popover effect="scale" title="**Emoji title** :rocket:">
+    <div slot="content">
+      This is a long content...
+    </div>
+    <button class="btn btn-default">Hover</button>
+  </popover>
+  <br />
+  <br />
+  <h4>Wrap Text</h4>
+  <popover header="false" content="Nice!">What do you say</popover>
+</tip-box>
+
+<tip-box border-left-color="black">
+<i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </popover>
+  <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </popover>
+  <hr>
+  <h4>Title</h4>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </popover>
+  <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </popover>
+  <hr />
+  <h4>Trigger</h4>
+  <p>
+    <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
+      <button class="btn btn-default">Mouseenter</button>
+    </popover>
+    <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
+      <button class="btn btn-default">Contextmenu (right click)</button>
+    </popover>
+  </p>
+  <h4>Markdown</h4>
+  <p>
+    <popover effect="scale" title="**Emoji title** :rocket:" content="++emoji++ content :cat:">
+      <button class="btn btn-default">Hover</button>
+    </popover>
+  </p>
+  <h4>Content using slot</h4>
+  <popover effect="scale" title="**Emoji title** :rocket:">
+    <div slot="content">
+      This is a long content...
+    </div>
+    <button class="btn btn-default">Hover</button>
+  </popover>
+  <br />
+  <br />
+  <h4>Wrap Text</h4>
+  <popover header="false" content="Nice!">What do you say</popover>
+  ```
+</tip-box>
+
+## Popover Options
+
+Name | Type | Default | Description
+---- | ---- | ------- | ------
+trigger | `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How the popover is triggered.
+effect | `String`, one of `scale` `fade` | `fade`
+title | `String`, or be markdown inline text
+content | `String`, or be markdown inline text
+header | `Boolean` | `true` |	Whether to show the header.
+placement | `String`, one of `top` `left` `right` `bottom` `top` | How to position the popover.

--- a/docs/userGuide/components/popover.md
+++ b/docs/userGuide/components/popover.md
@@ -126,4 +126,4 @@ effect | `String`, one of `scale` `fade` | `fade`
 title | `String`, or be markdown inline text
 content | `String`, or be markdown inline text
 header | `Boolean` | `true` |	Whether to show the header.
-placement | `String`, one of `top` `left` `right` `bottom` `top` | How to position the popover.
+placement | `String`, one of `top` `left` `right` `bottom` `top` || How to position the popover.

--- a/docs/userGuide/components/popover.md
+++ b/docs/userGuide/components/popover.md
@@ -126,4 +126,4 @@ effect | `String`, one of `scale` `fade` | `fade`
 title | `String`, or be markdown inline text
 content | `String`, or be markdown inline text
 header | `Boolean` | `true` |	Whether to show the header.
-placement | `String`, one of `top` `left` `right` `bottom` `top` || How to position the popover.
+placement | `String`, one of `top` `left` `right` `bottom` | `top` | How to position the popover.

--- a/docs/userGuide/components/tooltip.md
+++ b/docs/userGuide/components/tooltip.md
@@ -1,0 +1,91 @@
+# Tooltip
+
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </tooltip>
+  <hr />
+  Trigger
+  <p>
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
+      <button class="btn btn-default">Click</button>
+    </tooltip>
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
+      <button class="btn btn-default">Contextmenu (right click)</button>
+    </tooltip>
+    <br />
+    <br />
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="focus">
+      <input placeholder="Focus"></input>
+    </tooltip>
+  </p>
+  <h4>Markdown</h4>
+  <tooltip effect="scale" content="*Hello* **World**">
+    <a href="">Hover me</a>
+  </tooltip>
+  <br />
+  <br />
+  <h4>Free Text</h4>
+  <tooltip content=" coupling is the degree of interdependence between software modules; a measure of how closely
+  connected two routines or modules are; the strength of the relationships between modules."><i>coupling</i></tooltip>
+</tip-box>
+<tip-box border-left-color="black">
+<i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="top">
+    <button class="btn btn-default">Popover on top</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="left">
+    <button class="btn btn-default">Popover on left</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="right">
+    <button class="btn btn-default">Popover on right</button>
+  </tooltip>
+  <tooltip header content="Lorem ipsum dolor sit amet" placement="bottom">
+    <button class="btn btn-default">Popover on bottom</button>
+  </tooltip>
+  <hr />
+  Trigger
+  <p>
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
+      <button class="btn btn-default">Click</button>
+    </tooltip>
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
+      <button class="btn btn-default">Contextmenu (right click)</button>
+    </tooltip>
+    <br />
+    <br />
+    <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="focus">
+      <input placeholder="Focus"></input>
+    </tooltip>
+  </p>
+  <h4>Markdown</h4>
+  <tooltip effect="scale" content="*Hello* **World**">
+    <a href="">Hover me</a>
+  </tooltip>
+  <br />
+  <br />
+  <h4>Free Text</h4>
+  <tooltip content=" coupling is the degree of interdependence between software modules; a measure of how closely
+  connected two routines or modules are; the strength of the relationships between modules."><i>coupling</i></tooltip>
+  ```
+</tip-box>
+
+## Tooltip Options
+
+Name | Type | Default | Description
+---- | ---- | ------- | ------
+trigger	| `String`, one of `click` `focus` `hover` `contextmenu` | `hover` | How the tooltip is triggered.
+content | `String`
+placement | `String`, one of `top` `left` `right` `bottom` || How to position the tooltip.

--- a/docs/userGuide/components/trigger.md
+++ b/docs/userGuide/components/trigger.md
@@ -103,5 +103,5 @@ Additionally, multiple Triggers could share the same overlay by providing them w
 
 Name | Type | Default | Description
 ---- | ---- | ------- | ------
-trigger | `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How its overlay view is triggered.
+trigger | `String`, one of `click` `focus` `hover` `contextmenu` | `hover` | How its overlay view is triggered.
 for | `String`, the id for the overlay view to be shown

--- a/docs/userGuide/components/trigger.md
+++ b/docs/userGuide/components/trigger.md
@@ -1,0 +1,107 @@
+# Trigger
+
+Trigger provides more flexibility in triggering contextual overlay via Tooltip, Popover or Modal.
+
+You could embed a Trigger within the text, and define the Tooltip, Popover or Modal at a separate location, which allows for a cleaner authoring flow.
+
+Specify the `id` attribute on the Tooltip, Popover or Modal component, and use the same `id` in the `for` attribute of the Trigger to allow the Trigger to invoke the specific overlay elements.
+Additionally, multiple Triggers could share the same overlay by providing them with the same `id`.
+<br />
+
+### Using trigger for Tooltip
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  More about <trigger for="tt:trigger_id">trigger</trigger>.
+  <tooltip id="tt:trigger_id" content="This tooltip triggered by a trigger"></tooltip>
+  <br>
+  This is the same <trigger for="tt:trigger_id">trigger</trigger> as last one.
+</tip-box>
+
+<tip-box border-left-color="black">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  More about <trigger for="tt:trigger_id">trigger</trigger>.
+  <tooltip id="tt:trigger_id" content="This tooltip triggered by a trigger"></tooltip>
+  <br>
+  This is the same <trigger for="tt:trigger_id">trigger</trigger> as last one.
+  ```
+</tip-box>
+
+### Using trigger for Popover
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  More about <trigger for="pop:trigger_id">trigger</trigger>.
+  <popover id="pop:trigger_id" content="This popover is triggered by a trigger"></popover>
+  <br>
+  This is the same <trigger for="pop:trigger_id">trigger</trigger> as last one.
+</tip-box>
+
+<tip-box border-left-color="black">
+<i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  More about <trigger for="pop:trigger_id">trigger</trigger>.
+  <popover id="pop:trigger_id" content="This popover is triggered by a trigger"></popover>
+  <br>
+  This is the same <trigger for="pop:trigger_id">trigger</trigger> as last one.
+  ```
+</tip-box>
+
+### Using trigger for Modal
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  More about <trigger for="modal:trigger_id">trigger</trigger>.
+  <modal title="**Modal title** :rocket:" id="modal:trigger_id">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </modal>
+  <br>
+  This is the same <trigger for="modal:trigger_id">trigger</trigger> as last one.
+</tip-box>
+
+<tip-box border-left-color="black">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  More about <trigger for="modal:trigger_id">trigger</trigger>.
+  <modal title="**Modal title** :rocket:" id="modal:trigger_id">
+      ...
+  </modal>
+  <br>
+  This is the same <trigger for="modal:trigger_id">trigger</trigger> as last one.
+  ```
+</tip-box>
+
+### Trigger's `trigger` attribute (which defaults to `hover`) is independent of the target's.
+<tip-box border-left-color="#00B0F0">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  This is a hover <trigger for="pop:xp-user-stories">trigger</trigger>.
+  <br>
+  This is a click
+  <popover id="pop:xp-user-stories" trigger="click" content="User stories..." >
+    popover
+  </popover>.
+</tip-box>
+
+<tip-box border-left-color="black">
+  <i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
+
+  ``` html
+  This is a hover <trigger for="pop:xp-user-stories">trigger</trigger>.
+  <br>
+  This is a click
+  <popover id="pop:xp-user-stories" trigger="click" content="User stories..." >
+    popover
+  </popover>.
+  ```
+</tip-box>
+
+## Trigger Options
+
+Name | Type | Default | Description
+---- | ---- | ------- | ------
+trigger	| `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How its overlay view is triggered.
+for	| `String`, the id for the overlay view to be shown

--- a/docs/userGuide/components/trigger.md
+++ b/docs/userGuide/components/trigger.md
@@ -103,5 +103,5 @@ Additionally, multiple Triggers could share the same overlay by providing them w
 
 Name | Type | Default | Description
 ---- | ---- | ------- | ------
-trigger	| `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How its overlay view is triggered.
-for	| `String`, the id for the overlay view to be shown
+trigger | `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How its overlay view is triggered.
+for | `String`, the id for the overlay view to be shown


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

Part of #274.

What is the rationale for this request?
trigger, tooltip, popover documentation

What changes did you make? (Give an overview)
Added trigger, tooltip, popover documentation

Provide some example code that this change will affect:
NIL

Testing instructions:
1. in vue-strap pull https://github.com/MarkBind/vue-strap/pull/49
2. `npm run build` and copy paste vue-strap.min.js
3.Run markbind serve docs to see the rendered doc on 4.http://127.0.0.1:8080/markbind/userGuide/componentsReference/searchbarDoc.html