### PR TITLE
Allow pages to be excluded from search

### DIFF
--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -23,7 +23,8 @@ Let's examine a typical `site.json` file:
   "pages": [
     {
       "src": "index.md",
-      "title": "Hello World"
+      "title": "Hello World",
+      "searchable": "no"
     },
     {
       "glob": "**/index.md"
@@ -45,7 +46,7 @@ Let's examine a typical `site.json` file:
 | **baseUrl** | The base url relative to your domain. Default: <code></code>&nbsp;(empty). For example, if you are using Github Pages to host your deployed website and it is published at `https://markbind.github.io/site-demo-cs2103`, then your `baseUrl` would be `/site-demo-cs2103`. You can use this variable for [specifying path reference](contentAuthoring.html#specifying-path-reference) of images and links. **You may need to change the `baseUrl` when deploying to a different repo.** |
 | **faviconPath** | The location of the favicon. Default: `favicon.ico`. If the favicon was recently changed, you may need to force-refresh to see the new image. |
 | **titlePrefix** | The prefix for all page titles. The separator <code>-</code> will be inserted by MarkBind. |
-| **pages** | An array of pages to be rendered. The `src` is the file; `title` is the page title for the generated web page. Titles specified here take priority over titles specified in the [front matter](contentAuthoring.html#front-matter) of individual pages. Alternatively, `glob` can be used to define a file pattern. If `title` is not specified in the front matter, the page will have `titlePrefix` as its title. |
+| **pages** | An array of pages to be rendered. The `src` is the file; `title` is the page title for the generated web page. Titles specified here take priority over titles specified in the [front matter](contentAuthoring.html#front-matter) of individual pages. Alternatively, `glob` can be used to define a file pattern. If `title` is not specified in the front matter, the page will have `titlePrefix` as its title. `"searchable": "no"` can be used to specify pages to be excluded from searching. If you need to exclude pages covered in both page entry and glob entry, you need to specify `"searchable": "no"` in page entry.|
 | **ignore** | An array of file patterns to be ignored. By default, MarkBind will copy all the files as assets into the output folder. The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm.com/docs/gitignore#_pattern_format). For example, `*.md` ignores all markdown source files. You may want to ignore the Git directory `.git/*`. |
 | **deploy** | The settings for [auto deployment to Github pages](ghpagesDeployment.html). The `message` is the commit message used for the deployment commit. |
 </div>

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -44,6 +44,7 @@ function Page(pageConfig) {
   this.content = pageConfig.content || '';
   this.faviconUrl = pageConfig.faviconUrl;
   this.rootPath = pageConfig.rootPath;
+  this.searchable = pageConfig.searchable;
   this.src = pageConfig.src;
   this.template = pageConfig.pageTemplate;
   this.title = pageConfig.title || '';

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -252,6 +252,7 @@ Site.prototype.createPage = function (config) {
     faviconUrl: config.faviconUrl,
     pageTemplate: this.pageTemplate,
     rootPath: this.rootPath,
+    searchable: config.searchable,
     src: config.pageSrc,
     title: config.title || '',
     titlePrefix: this.siteConfig.titlePrefix,
@@ -284,13 +285,14 @@ Site.prototype.createPage = function (config) {
  */
 Site.prototype.collectAddressablePages = function () {
   const { pages } = this.siteConfig;
-  const addressableGlobs = pages.filter(page => page.glob).map(page => page.glob);
+  const addressableGlobs = pages.filter(page => page.glob);
   this.addressablePages = pages.filter(page => page.src);
-  const globPaths = walkSync(this.rootPath, {
-    directories: false,
-    globs: addressableGlobs,
-    ignore: [BOILERPLATE_FOLDER_NAME],
-  }).map(globPath => ({ src: globPath }));
+  const globPaths = addressableGlobs.reduce((globPages, addressableGlob) =>
+    globPages.concat(walkSync(this.rootPath, {
+      directories: false,
+      globs: [addressableGlob.glob],
+      ignore: [BOILERPLATE_FOLDER_NAME],
+    }).map(globPath => ({ src: globPath, searchable: addressableGlob.searchable }))), []);
   // Add pages collected by walkSync without duplication
   this.addressablePages = _.unionWith(this.addressablePages, globPaths,
                                       ((pageA, pageB) => pageA.src === pageB.src));
@@ -489,6 +491,7 @@ Site.prototype.generatePages = function () {
     faviconUrl,
     pageSrc: page.src,
     title: page.title,
+    searchable: page.searchable !== 'no',
   }));
   this.pages.forEach((page) => {
     processingFiles.push(page.generate(builtFiles)
@@ -551,7 +554,8 @@ Site.prototype.writeSiteData = function () {
   return new Promise((resolve, reject) => {
     const siteDataPath = path.join(this.outputPath, SITE_DATA_NAME);
     const siteData = {
-      pages: this.pages.map(page => Object.assign({ headings: page.headings }, page.frontMatter)),
+      pages: this.pages.filter(page => page.searchable)
+        .map(page => Object.assign({ headings: page.headings }, page.frontMatter)),
     };
 
     fs.outputJsonAsync(siteDataPath, siteData)


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [X] Enhancement to an existing feature
• [ ] Other, please explain:

Resolves #269 

**What is the rationale for this request?**
In some websites, there is heavy duplication of content. e.g., normal text book and a printable version of a text book. should allow some pages to be excluded from search results

**What changes did you make? (Give an overview)**
allow `"searchable" : "no"` in page or glob entries. when rendering site data, filter out these pages

**Testing instructions:**
1. 2103 website: add  `"searchable" : "no"`  in `{glob: "print.md"}` entry    
before:
![image](https://user-images.githubusercontent.com/24241939/42078583-a64df24a-7baf-11e8-8a31-ecfa6e186cf9.png)
after: 
![image](https://user-images.githubusercontent.com/24241939/42078631-d7a83e7c-7baf-11e8-9d3c-1cccb6e30366.png)
no more printable entries.
website: https://nusjzx.github.io/website-base/