### PR TITLE
Patch site navigation rendering of dropdown menus

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -72,7 +72,7 @@
     display: block;
     outline: 0;
     padding: 0;
-    text-align: center;
+    text-align: left;
     text-decoration: none;
 }
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -117,12 +117,21 @@ function formatSiteNav(renderedSiteNav) {
   listItems.each(function () {
     // Tidy up the style of each list item
     $(this).attr('style', 'margin-top: 10px');
-    // Found nested list
-    if ($(this).children().first().is('ul')) {
-      const nestedList = $(this).children().first();
-      const dropdownTitle = $(this).contents().first().text();
+    // Do not render dropdown menu for list items with <a> tag
+    if ($(this).children('a').length) {
+      const nestedList = $(this).children('ul').first();
+      if (nestedList.length) {
+        // Double wrap to counter replaceWith removing <li>
+        nestedList.parent().wrap('<li style="margin-top:10px"></li>');
+        // Recursively format nested lists without dropdown wrapper
+        nestedList.parent().replaceWith(formatSiteNav(nestedList.parent().html()));
+      }
+    // Found nested list, render dropdown menu
+    } else if ($(this).children('ul').length) {
+      const nestedList = $(this).children('ul').first();
+      const dropdownTitle = $(this).contents().not('ul');
       // Replace the title with the dropdown wrapper
-      $(this).contents().first().remove();
+      dropdownTitle.remove();
       nestedList.wrap('<div class="dropdown-container"></div>');
       $(this).prepend('<button class="dropdown-btn">'
         + `${dropdownTitle} `
@@ -130,15 +139,6 @@ function formatSiteNav(renderedSiteNav) {
         + '</button>');
       // Recursively format nested lists
       nestedList.replaceWith(formatSiteNav(nestedList.parent().html()));
-    // Found element that is not a list, with nested items
-    } else if ($(this).children().length > 1) {
-      const nestedList = $(this).children().first().siblings('ul');
-      if (nestedList.length) {
-        // Double wrap to counter replaceWith removing <li>
-        nestedList.parent().wrap('<li style="margin-top:10px"></li>');
-        // Recursively format nested lists without dropdown wrapper
-        nestedList.parent().replaceWith(formatSiteNav(nestedList.parent().html()));
-      }
     }
   });
   return $.html();

--- a/test/test_site/_markbind/navigation/site-nav.md
+++ b/test/test_site/_markbind/navigation/site-nav.md
@@ -3,16 +3,16 @@
 * [Home :house:]({{baseUrl}}/index.html)
 * [Open Bugs :bug:]({{baseUrl}}/bugs/index.html)
 * ### Testing Site-Nav
-* Dropdown title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
+* **Dropdown** {{glyphicon_search}} title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
   * [Dropdown link one](https://www.google.com/)
   * Nested Dropdown title :triangular_ruler:
     * [**Nested** Dropdown link one](https://www.google.com/)
     * [**Nested** Dropdown link two](https://www.google.com/)
   * [Dropdown link two](https://www.google.com/)
 * [==Third Link== :clipboard:](https://www.google.com/)
-* [Youtube](https://www.youtube.com/) <!-- Using a link as a Dropdown title will not render a Dropdown menu -->
+* Filler text [{{glyphicon_facetime_video}} Youtube :tv:](https://www.youtube.com/) filler text<!-- Using a link as a Dropdown title will not render a Dropdown menu -->
   * [The answer to everything in the universe](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
-  * Dropdown title :pencil2: <!-- Dropdown menus in are still supported inside, as long as the title is not a link -->
+  * ==Dropdown title== {{glyphicon_comment}} :pencil2: <!-- Dropdown menus in are still supported inside, as long as the title is not a link -->
     * [**Nested** Dropdown link one](https://www.google.com/)
 * Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
   * Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -24,7 +24,8 @@
       <li style="margin-top: 10px">
         <h3 id="testing-site-nav">Testing Site-Nav</h3>
       </li>
-      <li style="margin-top: 10px"><button class="dropdown-btn">Dropdown title ✏️  <i class="dropdown-btn-icon">
+      <li style="margin-top: 10px"><button class="dropdown-btn"><strong>Dropdown</strong> <span class="glyphicon glyphicon-search" aria-hidden="true"></span> title ✏️ 
+ <i class="dropdown-btn-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
         <div class="dropdown-container">
           <ul style="list-style-type: none; margin-left:-1em">
@@ -44,10 +45,11 @@
         </div>
       </li>
       <li style="margin-top: 10px"><a href="https://www.google.com/"><mark>Third Link</mark> 📋</a></li>
-      <li style="margin-top:10px"><a href="https://www.youtube.com/">Youtube</a>
+      <li style="margin-top:10px">Filler text <a href="https://www.youtube.com/"><span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span> Youtube 📺</a> filler text
         <ul style="list-style-type: none; margin-left:-1em">
           <li style="margin-top: 10px"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">The answer to everything in the universe</a></li>
-          <li style="margin-top: 10px"><button class="dropdown-btn">Dropdown title ✏️  <i class="dropdown-btn-icon">
+          <li style="margin-top: 10px"><button class="dropdown-btn"><mark>Dropdown title</mark> <span class="glyphicon glyphicon-comment" aria-hidden="true"></span> ✏️ 
+ <i class="dropdown-btn-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
             <div class="dropdown-container">
               <ul style="list-style-type: none; margin-left:-1em">

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -72,7 +72,7 @@
     display: block;
     outline: 0;
     padding: 0;
-    text-align: center;
+    text-align: left;
     text-decoration: none;
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix


<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #272 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
- User discovered that using styled headings prevent dropdown menus from being rendered in the site navigation. 
- Also, text in dropdown menu buttons will center after being wrapped around, which may cause indentation issues.

**What changes did you make? (Give an overview)**
- Modified algorithm in `formatSiteNav` to account for styling tags in dropdown menu titles
- Modified `dropdown-btn` CSS to align text to the left.

<br>

Before | After
--- | ---
![dropdown-before](https://user-images.githubusercontent.com/31084833/42141372-579cf744-7ddb-11e8-89f4-5be438b374a9.PNG) | ![dropdown-after](https://user-images.githubusercontent.com/31084833/42141380-5e869808-7ddb-11e8-87ad-ca0346a3898f.PNG)



**Is there anything you'd like reviewers to focus on?**
- New algorithm in `formatSiteNav`

**Testing instructions:**
- Run `markbind serve` on the `test_site` folder. 
- Check that dropdown menus have been rendered for styled text titles.