### PR TITLE
Remove support for dynamic-panel and morph components

### DIFF
--- a/docs/userGuide/includingContents.md
+++ b/docs/userGuide/includingContents.md
@@ -79,12 +79,11 @@
 
     The `_markbind/boilerplates` folder in the site's root directory can be used to store repetitive files. You might have a file `structure.md` (that contains text such as `<include src="text.md">`) that needs to be used in many places. You want the `text.md` to be included to depend on the folder `structure.md` is supposed to be in. Instead of duplicating the file in different locations, you will only need a copy in the boilerplate directory — the final outcome is as if the file was present in the different locations.
 
-    To specify a boilerplate file, add `boilerplate` in the attribute for `include` or `dynamic-panel`.
+    To specify a boilerplate file, add `boilerplate` in the attribute for `include`.
 
     E.g. In `book/architecture/architecturalStyles/index.md`,
     ```html
     <include src="structure.md" boilerplate />
-    <dynamic-panel src="../structure.md" boilerplate />
     ```
 
     MarkBind will look for and use the file `/_markbind/boilerplates/structure.md`. Notice that this is the combination of the boilerplate directory and the file base name. The reference is location sensitive. If `structure.md` includes `text.md`, in the first case, it will use `book/architecture/architecturalStyles/text.md` while in the second case, it will use `book/architecture/text.md`.

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -150,6 +150,8 @@ Parser.prototype._preprocess = function (node, context, config) {
     if (isDynamic) {
       element.name = 'panel';
       element.attribs.src = filePath;
+      element.attribs['no-close'] = true;
+      element.attribs['no-switch'] = true;
       if (includeSrc.hash) {
         element.attribs.fragment = includeSrc.hash.substring(1);
       }

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -105,14 +105,14 @@ Parser.prototype._preprocess = function (node, context, config) {
   element.attribs = element.attribs || {};
   element.attribs[ATTRIB_CWF] = path.resolve(context.cwf);
 
-  const requiresSrc = ['include', 'dynamic-panel'].includes(element.name);
+  const requiresSrc = ['include'].includes(element.name);
   if (requiresSrc && _.isEmpty(element.attribs.src)) {
     const error = new Error(`Empty src attribute in ${element.name} in: ${element.attribs[ATTRIB_CWF]}`);
     this._onError(error);
     return createErrorNode(element, error);
   }
 
-  const shouldProcessSrc = ['include', 'dynamic-panel', 'panel', 'morph'].includes(element.name);
+  const shouldProcessSrc = ['include', 'panel'].includes(element.name);
   const hasSrc = _.hasIn(element.attribs, 'src');
   let isUrl;
   let includeSrc;
@@ -148,7 +148,7 @@ Parser.prototype._preprocess = function (node, context, config) {
     element.attribs[ATTRIB_INCLUDE_PATH] = filePath;
 
     if (isDynamic) {
-      element.name = 'dynamic-panel';
+      element.name = 'panel';
       element.attribs.src = filePath;
       if (includeSrc.hash) {
         element.attribs.fragment = includeSrc.hash.substring(1);
@@ -227,14 +227,7 @@ Parser.prototype._preprocess = function (node, context, config) {
     if (element.children && element.children.length > 0) {
       element.children = element.children.map(e => self._preprocess(e, childContext, config));
     }
-  } else if (element.name === 'dynamic-panel') {
-    if (!isUrl && includeSrc.hash) {
-      element.attribs.fragment = includeSrc.hash.substring(1); // save hash to fragment attribute
-    }
-    element.attribs.src = filePath;
-    this.dynamicIncludeSrc.push({ from: context.cwf, to: actualFilePath, asIfTo: filePath });
-    return element;
-  } else if ((element.name === 'morph' || element.name === 'panel') && hasSrc) {
+  } else if ((element.name === 'panel') && hasSrc) {
     if (!isUrl && includeSrc.hash) {
       element.attribs.fragment = includeSrc.hash.substring(1); // save hash to fragment attribute
     }
@@ -281,43 +274,6 @@ Parser.prototype._parse = function (node, context, config) {
     element.children = cheerio.parseHTML(md.render(cheerio.html(element.children)), true);
     cheerio.prototype.options.xmlMode = true;
     break;
-  case 'dynamic-panel': {
-    console.warn('DeprecationWarning: dynamic-panel is deprecated. Consider using panel instead.');
-    const hasIsOpen = _.hasIn(element.attribs, 'isOpen');
-    element.attribs.isOpen = hasIsOpen || false;
-    const fileExists = utils.fileExists(element.attribs.src)
-                    || utils.fileExists(calculateBoilerplateFilePath(element.attribs.boilerplate,
-                                                                     element.attribs.src, config));
-    if (fileExists) {
-      const { src, fragment } = element.attribs;
-      const resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(config.rootPath, src)));
-      const resultPath = path.join(resultDir, utils.setExtension(path.basename(src), '._include_.html'));
-      element.attribs.src = fragment ? `${resultPath}#${fragment}` : resultPath;
-    }
-    element.attribs['no-close'] = 'true';
-    element.attribs['no-switch'] = 'true';
-    element.name = 'panel';
-    delete element.attribs.boilerplate;
-    break;
-  }
-  case 'morph': {
-    // eslint-disable-next-line no-console
-    console.warn('DeprecationWarning: morph is deprecated. Consider using panel instead.');
-    if (!_.hasIn(element.attribs, 'src')) {
-      break;
-    }
-    const fileExists = utils.fileExists(element.attribs.src)
-                    || utils.fileExists(calculateBoilerplateFilePath(element.attribs.boilerplate,
-                                                                     element.attribs.src, config));
-    if (fileExists) {
-      const { src, fragment } = element.attribs;
-      const resultDir = path.dirname(path.join('{{hostBaseUrl}}', path.relative(config.rootPath, src)));
-      const resultPath = path.join(resultDir, utils.setExtension(path.basename(src), '._include_.html'));
-      element.attribs.src = fragment ? `${resultPath}#${fragment}` : resultPath;
-    }
-    delete element.attribs.boilerplate;
-    break;
-  }
   case 'panel': {
     if (!_.hasIn(element.attribs, 'src')) { // dynamic panel
       break;

--- a/test/test_site/_markbind/boilerplates/boilerTest.md
+++ b/test/test_site/_markbind/boilerplates/boilerTest.md
@@ -1,1 +1,1 @@
-<dynamic-panel src="UserStories.md" header="Boilerplate Includes" no-close />
+<panel src="UserStories.md" header="Boilerplate Includes" no-close />

--- a/test/test_site/_markbind/boilerplates/folder/inside.md
+++ b/test/test_site/_markbind/boilerplates/folder/inside.md
@@ -8,4 +8,4 @@ Also, the boilerplate file name (e.g. `inside.md`) and the file that it is suppo
 
 This file should behaves as if it is in the `requirements` folder:  
 
-<dynamic-panel header="Tested with the folllowing include" src="NonFunctionalRequirements.md" >
+<panel header="Tested with the folllowing include" src="NonFunctionalRequirements.md" >

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -129,16 +129,16 @@
       </div>
       <h1 id="dynamic-include">Dynamic include</h1>
       <p>
-        <panel src="/test_site\requirements\SpecifyingRequirements._include_.html" name="Dynamic Include" header="Dynamic Include" isOpen="false" no-close="true" no-switch="true"></panel>
+        <panel src="/test_site\requirements\SpecifyingRequirements._include_.html" name="Dynamic Include" header="Dynamic Include"></panel>
       </p>
       <h1 id="boilerplate-include">Boilerplate include</h1>
       <div name="Boilerplate Referencing">
         <p>
-          <panel src="/test_site\requirements\UserStories._include_.html" header="Boilerplate Includes" no-close="true" isOpen="false" no-switch="true"></panel>
+          <panel src="/test_site\requirements\UserStories._include_.html" header="Boilerplate Includes" no-close=""></panel>
         </p>
       </div>
       <p>
-        <panel src="/test_site\requirements\notInside._include_.html" name="Referencing specified path in boilerplate" header="Referencing specified path in boilerplate" isOpen="false" no-close="true" no-switch="true"></panel>
+        <panel src="/test_site\requirements\notInside._include_.html" name="Referencing specified path in boilerplate" header="Referencing specified path in boilerplate"></panel>
       </p>
       <h1 id="nested-include">Nested include</h1>
       <div>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -129,7 +129,7 @@
       </div>
       <h1 id="dynamic-include">Dynamic include</h1>
       <p>
-        <panel src="/test_site\requirements\SpecifyingRequirements._include_.html" name="Dynamic Include" header="Dynamic Include"></panel>
+        <panel src="/test_site\requirements\SpecifyingRequirements._include_.html" name="Dynamic Include" no-close="true" no-switch="true" header="Dynamic Include"></panel>
       </p>
       <h1 id="boilerplate-include">Boilerplate include</h1>
       <div name="Boilerplate Referencing">
@@ -138,7 +138,7 @@
         </p>
       </div>
       <p>
-        <panel src="/test_site\requirements\notInside._include_.html" name="Referencing specified path in boilerplate" header="Referencing specified path in boilerplate"></panel>
+        <panel src="/test_site\requirements\notInside._include_.html" name="Referencing specified path in boilerplate" no-close="true" no-switch="true" header="Referencing specified path in boilerplate"></panel>
       </p>
       <h1 id="nested-include">Nested include</h1>
       <div>

--- a/test/test_site/expected/requirements/notInside._include_.html
+++ b/test/test_site/expected/requirements/notInside._include_.html
@@ -3,4 +3,4 @@
 <p>Like static include, pages within the site should be able to use files located in folders within boilerplate.</p>
 <p>Also, the boilerplate file name (e.g. <code>inside.md</code>) and the file that it is supposed to act as (<code>notInside.md</code>) can be different.</p>
 <p>This file should behaves as if it is in the <code>requirements</code> folder:</p>
-<panel header="Tested with the folllowing include" src="/test_site\requirements\NonFunctionalRequirements._include_.html" isOpen="false" no-close="true" no-switch="true"></panel>
+<panel header="Tested with the folllowing include" src="/test_site\requirements\NonFunctionalRequirements._include_.html"></panel>

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -55,7 +55,7 @@ test('includeFile replaces <include> with <div>', async () => {
   expect(result).toEqual(expected);
 });
 
-test('includeFile replaces <include dynamic> with <dynamic-panel>', async () => {
+test('includeFile replaces <include dynamic> with <panel>', async () => {
   const rootPath = path.resolve('');
   const indexPath = path.resolve('index.md');
   const includePath = path.resolve('include.md');
@@ -87,7 +87,7 @@ test('includeFile replaces <include dynamic> with <dynamic-panel>', async () => 
 
   const expected = [
     '# Index',
-    `<dynamic-panel src="${includePath}" cwf="${indexPath}" include-path="${includePath}" header=""/>`,
+    `<panel src="${includePath}" cwf="${indexPath}" include-path="${includePath}" header=""/>`,
     '',
   ].join('\n');
 
@@ -117,45 +117,6 @@ test('renderFile converts markdown headers to <h1>', async () => {
 
   const expected = [
     '<h1 id="index">Index</h1>',
-    '',
-  ].join('\n');
-
-  expect(result).toEqual(expected);
-});
-
-test('renderFile updates <dynamic-panel> to closed <panel>', async () => {
-  const markbinder = new MarkBind();
-  const rootPath = path.resolve('');
-  const indexPath = path.resolve('index.md');
-  const includePath = path.resolve('include.md');
-  const index = [
-    '# Index',
-    `<dynamic-panel src="${includePath}" cwf="${indexPath}" include-path="${includePath}" header=""/>`,
-    '',
-  ].join('\n');
-
-  const include = ['# Include'].join('\n');
-
-  const json = {
-    'index.md': index,
-    'include.md': include,
-  };
-
-  fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[rootPath] = true;
-
-  const result = await markbinder.renderFile(indexPath, {
-    baseUrlMap,
-    rootPath,
-  });
-
-  const src = path.join('{{hostBaseUrl}}', 'include._include_.html');
-
-  const expected = [
-    '<h1 id="index">Index</h1>',
-    `<panel src="${src}" cwf="${indexPath}" include-path="${includePath}" `
-      + 'header="" isOpen="false" no-close="true" no-switch="true"></panel>',
     '',
   ].join('\n');
 

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -87,7 +87,8 @@ test('includeFile replaces <include dynamic> with <panel>', async () => {
 
   const expected = [
     '# Index',
-    `<panel src="${includePath}" cwf="${indexPath}" include-path="${includePath}" header=""/>`,
+    `<panel src="${includePath}" cwf="${indexPath}" include-path="${includePath}"`
+    + ' no-close="true" no-switch="true" header=""/>',
     '',
   ].join('\n');
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, migration

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #292 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Remove deprecated components support completely, for maintenance purposes.

**What changes did you make? (Give an overview)**
- Delete logic pertaining to deprecated components in `parser.js`.
- Update unit tests in `parser.test.js`.
- Update `test_site` files.
- Remove reference to `<dynamic-panel>` in `includingContents` document.

Discussion  |
--- |
Previously, having `<include src"..." dynamic>` will be converted to a `<dynamic-panel src="...">`. <br>It has been changed to render `<panel src="...">` instead, so the switch and close buttons will be shown by default. |
**Should we keep this or have the converted `<panel>` to have `no-switch` and `no-close`?** |

**Testing instructions:**
1. Checkout [this PR](https://github.com/MarkBind/vue-strap/pull/61), run `npm run build` and copy over the `vue-strap.min.js` file into this repository's asset folder
2. Run `markbind serve` in the `test_site` folder, everything should be working. 
3. Add `<morph>` or `<dynamic-panel>` inside `index.md` and they shouldn't render anything.