### PR TITLE
Support live preview for _markbind folder files

### DIFF
--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -441,7 +441,6 @@ Note:
 - Only one navigation file can be specified in a page, and you must include its file extension.
 - There is no limit to the number of nested Dropdown menus, but each menu's height is restricted to 1000 pixels.
     - Dropdown menu content exceeding 1000 pixels in height will be cut off.
-- If you are using [live preview](userQuickStart.html#preview-your-site), you must restart the server to see updates made in the navigation file.
 
 ### Using Footers
 
@@ -476,7 +475,6 @@ After which, you must specify the file within a page's [front matter](#front-mat
 
 Note:
 - Only one footer file can be specified in the [front matter](#front-matter) per page, and you must include its file extension.
-- If you are using [live preview](userQuickStart.html#preview-your-site), you must restart the server to see updates made in the footer file.
 
 #### Defining your own inline footer
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -236,8 +236,12 @@ Page.prototype.insertFooter = function (pageData) {
   if (!footer) {
     return pageData;
   }
+  // Retrieve Markdown file contents
   const footerPath = path.join(this.rootPath, FOOTERS_FOLDER_PATH, footer);
   const footerContent = fs.readFileSync(footerPath, 'utf8');
+  // Set footer file as an includedFile
+  this.includedFiles[footerPath] = true;
+  // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
   return `${pageData}\n${nunjucks.renderString(footerContent, userDefinedVariables)}`;
@@ -255,6 +259,8 @@ Page.prototype.insertSiteNav = function (pageData) {
   // Retrieve Markdown file contents
   const siteNavPath = path.join(this.rootPath, NAVIGATION_FOLDER_PATH, siteNav);
   const siteNavContent = fs.readFileSync(siteNavPath, 'utf8');
+  // Set siteNav file as an includedFile
+  this.includedFiles[siteNavPath] = true;
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];


### PR DESCRIPTION
Specifically, it supports files within the footer and navigation folder.

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #271 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Updating site navigation or footer files did not re-render the pages that includes them.

**What changes did you make? (Give an overview)**
- Add site-nav or footer file to the Page's`this.includedFiles` during `insertFooter` or `insertSiteNav` method.
- Removed note on having to restart server to see changes in the user guide.

**Testing instructions:**
1. Run `markbind init` and `markbind serve` while having this branch checked out.
2. Make changes to `footer.md` or `site-nav.md` and check that the live preview updates accordingly.