### PR TITLE
Refactor panel attribute "load-all" to "preload" 

### DIFF
--- a/docs/userGuide/components/panel.md
+++ b/docs/userGuide/components/panel.md
@@ -141,20 +141,25 @@
 </tip-box>
 <br>
 
-#### If `src` attribute is provided, the panel content is loaded dynamically from the `src` specified. To load it immediately, you can provide the `load-all` attribute. 
+#### If `src` attribute is provided, the panel content is loaded dynamically from the `src` specified. To load it immediately, you can provide the `preload` attribute. 
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
-  <panel header="Content loaded in from `src`" alt="Dynamic Loading" src="dynamic/loadContent.html#fragment" minimized></panel>
-  <panel header="Content does not have any delay" alt="Immediate loading" src="dynamic/loadContent.html#fragment" minimized load-all></panel>
+  <panel header="Content loaded in from `src`" alt="Dynamic Loading" 
+          src="dynamic/loadContent.html#fragment" minimized></panel>
+  <panel header="Content does not have any delay" alt="Immediate loading" 
+          src="dynamic/loadContent.html#fragment" minimized preload></panel>
 </tip-box>
 
 <tip-box border-left-color="black">
 <i style="font-style: normal; font-weight: bold; color: dimgray">Markup</i>
 
 ```html
-<panel header="Content loaded in from `src`" alt="Dynamic Loading" src="dynamic/loadContent.html#fragment" minimized></panel>
-<panel header="Content does not have any delay" alt="Immediate loading" src="dynamic/loadContent.html#fragment" minimized load-all></panel>
+  <panel header="Content loaded in from `src`" alt="Dynamic Loading" 
+          src="dynamic/loadContent.html#fragment" minimized></panel>
+          
+  <panel header="Content does not have any delay" alt="Immediate loading" 
+          src="dynamic/loadContent.html#fragment" minimized preload></panel>
 ```
 </tip-box>
 <br>
@@ -229,5 +234,5 @@ no-switch | `Boolean` | `false` | Whether to show the expand switch.
 bottom-switch | `Boolean` | `true` | Whether to show an expand switch at the bottom of the panel. Independent of no-switch.
 popup-url | `String` | | The url that the popup window will navigate to. The url can be absolute or relative.
 src | `String` | | The url to the remote page to be loaded as the content of the panel.
-load-all | `Boolean` | `false` | Whether the content is loaded immediately from `src`.
+preload | `Boolean` | `false` | Whether the content is loaded immediately from `src`.
 type | `String` | null | The type of color for the tab (single).<br>Supports: `default`, `primary`, `info`, `success`, `warning`, `danger`, `seamless`.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #306, requires MarkBind/vue-strap#62

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like a better attribute name for `non-dynamic` behaviour of loading content from `src` within panels.

**What changes did you make? (Give an overview)**
- Update `Panel.md` documentation

**Testing instructions:**
1. Ensure you have the updated `vue-strap.min.js` from the PR stated above.
1. View changes after running `markbind serve docs` in your repository folder.
1. Go to Panel section in `Component Reference`
1. Inspect the minimized panels for `dynamic loading` and `immediate loading`. 
1. `immediate loading` should have the fragment HTML but `dynamic loading` should not.  