### PR TITLE
Fix dropdown menu icon being rendered on the next line

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -267,7 +267,7 @@ Page.prototype.insertSiteNav = function (pageData) {
   const siteNavMappedData = nunjucks.renderString(siteNavContent, userDefinedVariables);
   // Convert to HTML
   const siteNavDataSelector = cheerio.load(siteNavMappedData);
-  const siteNavHtml = md.render(siteNavDataSelector('markdown').html().trim());
+  const siteNavHtml = md.render(siteNavDataSelector('markdown').html().trim().replace(/\n\s*\n/g, '\n'));
   const formattedSiteNav = formatSiteNav(siteNavHtml);
   siteNavDataSelector('markdown').replaceWith(formattedSiteNav);
   // Wrap sections

--- a/test/test_site/_markbind/navigation/site-nav.md
+++ b/test/test_site/_markbind/navigation/site-nav.md
@@ -20,4 +20,17 @@
     * Hello Doge Hello Doge :dog:
     * [**NESTED LINK** Home :house:]({{baseUrl}}/index.html)
     * More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text 
+
+* Test line break in navigation layout
+  
+  * Nested line break text :scissors:
+  
+  * [Nested line break href]({{baseUrl}}/index.html)
+  
+    * Nested Nested line break text :scissors:
+    
+  * Nested line break dropdown menu 
+    
+    * Line break item 2 :blue_book:
+
 </markdown>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -84,6 +84,29 @@
           </ul>
         </div>
       </li>
+      <li style="margin-top: 10px"><button class="dropdown-btn">Test line break in navigation layout
+ <i class="dropdown-btn-icon">
+<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
+        <div class="dropdown-container">
+          <ul style="list-style-type: none; margin-left:-1em">
+            <li style="margin-top: 10px">Nested line break text ✂️</li>
+            <li style="margin-top:10px"><a href="/test_site/index.html">Nested line break href</a>
+              <ul style="list-style-type: none; margin-left:-1em">
+                <li style="margin-top: 10px">Nested Nested line break text ✂️</li>
+              </ul>
+            </li>
+            <li style="margin-top: 10px"><button class="dropdown-btn">Nested line break dropdown menu
+ <i class="dropdown-btn-icon">
+<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
+              <div class="dropdown-container">
+                <ul style="list-style-type: none; margin-left:-1em">
+                  <li style="margin-top: 10px">Line break item 2 📘</li>
+                </ul>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </div>
   <div id="site-nav-btn-wrap">


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #309 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User used nunjucks syntax to generate site navigation list. However, there were additional unnecessary line breaks generated by `nunjucks.renderString`. 

This caused a `<p>` tag to be generated by `md.render` and create the line break between dropdown menu title and icon.

**What changes did you make? (Give an overview)**
- Add regex to remove consecutive `\n` before parsing to `md.render`.

Before |
--- |
![](https://user-images.githubusercontent.com/3168908/42367957-576b5bca-8138-11e8-9439-f2ae614e0ecc.png)

After |
--- |
![dropdown-icon-after](https://user-images.githubusercontent.com/31084833/42429223-71f1883c-836a-11e8-8872-a148b4dd71a1.PNG)


**Testing instructions:**
1. Run `markbind serve` on [CS2103 Website](https://github.com/nus-cs2103/website-base) -> Textbook menu in top navigation bar -> Table of Contents
2. Ensure the Site Navigation bar is rendered correctly.
3. Check `test_site` Site Navigation bar as well, to see that nothing breaks.