### PR TITLE
Use a more semantic HTML tag for site navigation

### DIFF
--- a/docs/_markbind/navigation/userGuideSections.md
+++ b/docs/_markbind/navigation/userGuideSections.md
@@ -1,4 +1,4 @@
-<markdown class="website-content">
+<navigation class="website-content">
 * ## User Guide
 * [Quick Start]({{baseUrl}}/userGuide/userQuickStart.html)
 * [Developing a Site]({{baseUrl}}/userGuide/developingASite.html)
@@ -11,4 +11,4 @@
   * [Preview site on Netlify]({{baseUrl}}/userGuide/netlifyPreview.html)
 * [Components Reference]({{baseUrl}}/userGuide/components.html)
   * [Advanced Tips and Tricks]({{baseUrl}}/userGuide/components.html#advanced-tips-and-tricks)
-</markdown>
+</navigation>

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -362,11 +362,13 @@ If you would like to have a site navigation bar for your site, you may create on
 - Author your navigation layout using Markdown's unordered list syntax as shown below.
     - When you are using links (`[linkName](url)`), ensure that the url starts from the root directory <code>{<span></span>{baseUrl}}/</code> when you are referencing a page in your site. 
     e.g. <code>{<span></span>{baseUrl}}/folder1/myPage.html</code>
-    - Ensure you wrap everything in a `<markdown>` tag for MarkBind to identify the Markdown syntax.
+    - Ensure you wrap your navigation layout in a `<navigation>` tag for MarkBind to render it properly. Also, there should only be one `<navigation>` tag in your file.
+    - You may author additional HTML and Markdown content outside the `<navigation>` tag.
+    - The `<navigation>` tag is also optional, allowing you to author everything in HTML and Markdown syntax.
 
 ```html
 <!-- In _markbind/navigation/mySiteNav.md -->
-<markdown>
+<navigation>
 * [Home :house:]({{baseUrl}}/index.html)
 * Dropdown title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
   * [Dropdown link one](https://www.google.com/)
@@ -379,7 +381,7 @@ If you would like to have a site navigation bar for your site, you may create on
   * [Youtube video one](http://www.youtube.com/watch?v=lJIrF4YjHfQ)
   * Dropdown title :pencil2: <!-- Dropdown menus in are still supported inside, as long as the title is not a link -->
     * [**Nested** Dropdown link one](https://www.google.com/)
-</markdown>
+</navigation>
 ```
 
 - Specify the navigation file you have created within a page's [front matter](#front-matter) `siteNav` attribute to render it.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -257,6 +257,7 @@ Page.prototype.insertFooter = function (pageData) {
 /**
  * Inserts a site navigation bar using the file specified in the front matter
  * @param pageData, a page with its front matter collected
+ * @throws (Error) if there is more than one instance of the <navigation> tag
  */
 Page.prototype.insertSiteNav = function (pageData) {
   const { siteNav } = this.frontMatter;
@@ -274,9 +275,13 @@ Page.prototype.insertSiteNav = function (pageData) {
   const siteNavMappedData = nunjucks.renderString(siteNavContent, userDefinedVariables);
   // Convert to HTML
   const siteNavDataSelector = cheerio.load(siteNavMappedData);
-  const siteNavHtml = md.render(siteNavDataSelector('markdown').html().trim().replace(/\n\s*\n/g, '\n'));
-  const formattedSiteNav = formatSiteNav(siteNavHtml);
-  siteNavDataSelector('markdown').replaceWith(formattedSiteNav);
+  if (siteNavDataSelector('navigation').length > 1) {
+    throw new Error(`More than one <navigation> tag found in ${siteNavPath}`);
+  } else if (siteNavDataSelector('navigation').length === 1) {
+    const siteNavHtml = md.render(siteNavDataSelector('navigation').html().trim().replace(/\n\s*\n/g, '\n'));
+    const formattedSiteNav = formatSiteNav(siteNavHtml);
+    siteNavDataSelector('navigation').replaceWith(formattedSiteNav);
+  }
   // Wrap sections
   const wrappedSiteNav = `<div id="${SITE_NAV_ID}">\n${siteNavDataSelector.html()}\n</div>`;
   const wrappedPageData = `<div id="${PAGE_CONTENT_ID}">\n${pageData}\n</div>`;

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -83,9 +83,9 @@ const INDEX_MARKDOWN_DEFAULT = '<frontmatter>\n'
   + '# Hello world\n'
   + 'Welcome to your page generated with MarkBind.\n';
 
-const SITE_NAV_DEFAULT = '<markdown>\n'
+const SITE_NAV_DEFAULT = '<navigation>\n'
   + '* [Home {{glyphicon_home}}]({{baseUrl}}/index.html)\n'
-  + '</markdown>\n';
+  + '</navigation>\n';
 
 const USER_VARIABLES_DEFAULT = '<span id="example">\n'
   + 'To inject this HTML segment in your markbind files, use {{ example }} where you want to place it.\n'

--- a/test/test_site/_markbind/navigation/site-nav.md
+++ b/test/test_site/_markbind/navigation/site-nav.md
@@ -1,4 +1,4 @@
-<markdown>
+<navigation>
 * ## Navigation
 * [Home :house:]({{baseUrl}}/index.html)
 * [Open Bugs :bug:]({{baseUrl}}/bugs/index.html)
@@ -33,4 +33,4 @@
     
     * Line break item 2 :blue_book:
 
-</markdown>
+</navigation>

--- a/test/unit/utils/data.js
+++ b/test/unit/utils/data.js
@@ -61,9 +61,9 @@ module.exports.INDEX_MD_DEFAULT = '<frontmatter>\n'
   + '# Hello world\n'
   + 'Welcome to your page generated with MarkBind.\n';
 
-module.exports.SITE_NAV_MD_DEFAULT = '<markdown>\n'
+module.exports.SITE_NAV_MD_DEFAULT = '<navigation>\n'
   + '* [Home {{glyphicon_home}}]({{baseUrl}}/index.html)\n'
-  + '</markdown>\n';
+  + '</navigation>\n';
 
 module.exports.USER_VARIABLES_DEFAULT = '<span id="example">\n'
   + 'To inject this HTML segment in your markbind files, use {{ example }} where you want to place it.\n'


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #273 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like a different tag to specify site navigation layout.

**What changes did you make? (Give an overview)**
- Refactor site navigation tag instances to `<navigation>`
- Add error output for no tag and more than one `<navigation>` tag found
- Update Site Navigation section in the [user guide](https://deploy-preview-314--markbind.netlify.com/userguide/contentauthoring#site-navigation)

**Is there anything you'd like reviewers to focus on?**
- Error handling

**Testing instructions:**
- Run `markbind init` and try different tags or different number of `<navigation>` tags within `site-nav.md`
- Run `markbind serve and see if it renders properly or throws the correct error.