### PR TITLE
Update markbind and site-nav CSS to work well in Bootstrap 4

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -31,7 +31,8 @@ code {
     background-color: #fff;
 }
 
-@media (max-width: 767px) {
+/* Bootstrap small(sm) responsive breakpoint */
+@media (max-width: 767.98px) {
     .dropdown-menu > li > a {
         white-space: normal;
     }

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -2,6 +2,10 @@ blockquote {
     font-size: 14px;
 }
 
+code {
+    word-break: normal;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -6,10 +6,6 @@ code {
     word-break: normal;
 }
 
-pre {
-    margin-bottom: 0;
-}
-
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -6,6 +6,10 @@ code {
     word-break: normal;
 }
 
+pre {
+    margin-bottom: 0;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -8,8 +8,9 @@
 #page-content {
     flex: 1;
     margin-left: 285px;
+    overflow-x: hidden;
     padding-left: 20px;
-    padding-right: 20px;
+    padding-right: 0;
     transition: 0.4s;
     -webkit-transition: 0.4s;
 }
@@ -26,6 +27,7 @@
     position: fixed;
     transition: 0.4s;
     width: 300px;
+    z-index: 1;
     -webkit-transition: 0.4s;
 }
 
@@ -60,6 +62,7 @@
     position: fixed;
     transition: 0.4s;
     width: 0;
+    z-index: 1;
     -webkit-transition: 0.4s;
 }
 
@@ -140,7 +143,7 @@
 
 /* Responsive site navigation */
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1006px) {
 
     #site-nav {
         border: none;
@@ -171,14 +174,13 @@
         max-height: calc(100vh - 50px);
         opacity: 1;
         overflow: auto;
+        padding-bottom: 40px;
         width: 300px;
-        z-index: 1;
     }
 
     #site-nav-btn-wrap.open {
         background-color: darkslategrey;
         border: none;
         margin-left: 300px;
-        z-index: 1;
     }
 }

--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -143,7 +143,8 @@
 
 /* Responsive site navigation */
 
-@media screen and (max-width: 1006px) {
+/* Bootstrap medium(md) responsive breakpoint */
+@media screen and (max-width: 991.98px) {
 
     #site-nav {
         border: none;

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -459,7 +459,7 @@ The above Markdown content will be rendered as:
   </li>
 </ul>
 
-The site navigation bar has [responsive properties](https://www.w3schools.com/html/html_responsive.asp), and will collapse to a menu button when the screen width is smaller than 768 pixels.
+The site navigation bar has [responsive properties](https://www.w3schools.com/html/html_responsive.asp), and will collapse to a menu button when the screen width is smaller than 1006 pixels.
 
 You are able to use [Markdown syntax](#supported-markdown-syntax), as well as [glyphicons](#glyphicons) to author your site navigation layout.
 

--- a/test/test_site/_markbind/navigation/site-nav.md
+++ b/test/test_site/_markbind/navigation/site-nav.md
@@ -19,5 +19,5 @@
   * Nested Dropdown Title 
     * Hello Doge Hello Doge :dog:
     * [**NESTED LINK** Home :house:]({{baseUrl}}/index.html)
-    * More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text 
+    * Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit 
 </markdown>

--- a/test/test_site/components/header.md
+++ b/test/test_site/components/header.md
@@ -1,4 +1,4 @@
 <navbar placement="top" type="inverse">
   <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
-  <li><a href="{{baseUrl}}/bugs/index.html">Open Bugs</a></li>
+  <li><a class="nav-link" href="{{baseUrl}}/bugs/index.html">Open Bugs</a></li>
 </navbar>

--- a/test/test_site/expected/bugs/index.html
+++ b/test/test_site/expected/bugs/index.html
@@ -19,7 +19,7 @@
     <div>
   <navbar placement="top" type="inverse">
     <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
-    <li><a href="/test_site/bugs/index.html">Open Bugs</a></li>
+    <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
   </navbar>
 </div>
 <div class="website-content">

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -76,9 +76,9 @@
                 <ul style="list-style-type: none; margin-left:-1em">
                   <li style="margin-top: 10px">Hello Doge Hello Doge 🐶</li>
                   <li style="margin-top: 10px"><a href="/test_site/index.html"><strong>NESTED LINK</strong> Home 🏠</a></li>
-                  <li style="margin-top: 10px">More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long
-                    Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long Long Text More Long
-                    Long Text</li>
+                  <li style="margin-top: 10px">Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from
+                    height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text
+                    cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit</li>
                 </ul>
               </div>
             </li>
@@ -98,7 +98,7 @@
     <div>
       <navbar placement="top" type="inverse">
         <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
-        <li><a href="/test_site/bugs/index.html">Open Bugs</a></li>
+        <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
       </navbar>
     </div>
     <div class="website-content">

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -31,7 +31,8 @@ code {
     background-color: #fff;
 }
 
-@media (max-width: 767px) {
+/* Bootstrap small(sm) responsive breakpoint */
+@media (max-width: 767.98px) {
     .dropdown-menu > li > a {
         white-space: normal;
     }

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -2,6 +2,10 @@ blockquote {
     font-size: 14px;
 }
 
+code {
+    word-break: normal;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -6,10 +6,6 @@ code {
     word-break: normal;
 }
 
-pre {
-    margin-bottom: 0;
-}
-
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -6,6 +6,10 @@ code {
     word-break: normal;
 }
 
+pre {
+    margin-bottom: 0;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -8,8 +8,9 @@
 #page-content {
     flex: 1;
     margin-left: 285px;
+    overflow-x: hidden;
     padding-left: 20px;
-    padding-right: 20px;
+    padding-right: 0;
     transition: 0.4s;
     -webkit-transition: 0.4s;
 }
@@ -26,6 +27,7 @@
     position: fixed;
     transition: 0.4s;
     width: 300px;
+    z-index: 1;
     -webkit-transition: 0.4s;
 }
 
@@ -60,6 +62,7 @@
     position: fixed;
     transition: 0.4s;
     width: 0;
+    z-index: 1;
     -webkit-transition: 0.4s;
 }
 
@@ -140,7 +143,7 @@
 
 /* Responsive site navigation */
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1006px) {
 
     #site-nav {
         border: none;
@@ -171,14 +174,13 @@
         max-height: calc(100vh - 50px);
         opacity: 1;
         overflow: auto;
+        padding-bottom: 40px;
         width: 300px;
-        z-index: 1;
     }
 
     #site-nav-btn-wrap.open {
         background-color: darkslategrey;
         border: none;
         margin-left: 300px;
-        z-index: 1;
     }
 }

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -143,7 +143,8 @@
 
 /* Responsive site navigation */
 
-@media screen and (max-width: 1006px) {
+/* Bootstrap medium(md) responsive breakpoint */
+@media screen and (max-width: 991.98px) {
 
     #site-nav {
         border: none;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #325 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Rendering of certain components inside documentation was buggy due to new CSS in Bootstrap 4.

**What changes did you make? (Give an overview)**
- Override `<code>` tag's CSS to not break character from words
- Improve looks and rendering of `site-nav` elements
- Modified elements in `test_site` to look correct and have more meaningful filler text

Before |
--- |
![doesnotscale](https://user-images.githubusercontent.com/3168908/42547132-283ee042-84f3-11e8-9142-0a2151deedfe.png) |

After |
--- |
![markbind-css-after](https://user-images.githubusercontent.com/31084833/42553046-b02d4372-8511-11e8-8ea8-058ad4429ba1.PNG) |

**Is there anything you'd like reviewers to focus on?**
- Width of `#page-content` before responsive media query kicks in

**Testing instructions:**
- Ensure you have `vue-strap.min.js` built from [vue-strap migration branch](https://github.com/MarkBind/vue-strap/tree/bootstrap-migration).
- Run `markbind serve docs`, check if elements render properly in both desktop / responsive mode.
- Run `markbind serve` in `test_site` and check there as well. 
