### PR TITLE
Refactor 'btn-default' class and standardise component Options sub-section

### DIFF
--- a/docs/userGuide/components/popover.md
+++ b/docs/userGuide/components/popover.md
@@ -3,45 +3,45 @@
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </popover>
   <hr>
   <h4>Title</h4>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </popover>
   <hr />
   <h4>Trigger</h4>
   <p>
     <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
-      <button class="btn btn-default">Mouseenter</button>
+      <button class="btn btn-secondary">Mouseenter</button>
     </popover>
     <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
-      <button class="btn btn-default">Contextmenu (right click)</button>
+      <button class="btn btn-secondary">Contextmenu (right click)</button>
     </popover>
   </p>
   <h4>Markdown</h4>
   <p>
     <popover effect="scale" title="**Emoji title** :rocket:" content="++emoji++ content :cat:">
-      <button class="btn btn-default">Hover</button>
+      <button class="btn btn-secondary">Hover</button>
     </popover>
   </p>
   <h4>Content using slot</h4>
@@ -49,7 +49,7 @@
     <div slot="content">
       This is a long content...
     </div>
-    <button class="btn btn-default">Hover</button>
+    <button class="btn btn-secondary">Hover</button>
   </popover>
   <br />
   <br />
@@ -62,45 +62,45 @@
 
   ``` html
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </popover>
   <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </popover>
   <hr>
   <h4>Title</h4>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </popover>
   <popover effect="fade" header title="Title" content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </popover>
   <hr />
   <h4>Trigger</h4>
   <p>
     <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
-      <button class="btn btn-default">Mouseenter</button>
+      <button class="btn btn-secondary">Mouseenter</button>
     </popover>
     <popover effect="scale" title="Title" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
-      <button class="btn btn-default">Contextmenu (right click)</button>
+      <button class="btn btn-secondary">Contextmenu (right click)</button>
     </popover>
   </p>
   <h4>Markdown</h4>
   <p>
     <popover effect="scale" title="**Emoji title** :rocket:" content="++emoji++ content :cat:">
-      <button class="btn btn-default">Hover</button>
+      <button class="btn btn-secondary">Hover</button>
     </popover>
   </p>
   <h4>Content using slot</h4>
@@ -108,7 +108,7 @@
     <div slot="content">
       This is a long content...
     </div>
-    <button class="btn btn-default">Hover</button>
+    <button class="btn btn-secondary">Hover</button>
   </popover>
   <br />
   <br />
@@ -121,9 +121,9 @@
 
 Name | Type | Default | Description
 ---- | ---- | ------- | ------
-trigger | `String`, one of `click` `focus` `hover` `contextmenu` |	`hover`	| How the popover is triggered.
-effect | `String`, one of `scale` `fade` | `fade`
-title | `String`, or be markdown inline text
-content | `String`, or be markdown inline text
+trigger | `String` |	`hover`	| How the Popover is triggered.<br>Supports: `click`, `focus`, `hover`, `contextmenu`.
+effect | `String` | `fade` | Transition effect for Popover.<br>Supports: `scale`, `fade`.
+title | `String` | `''` | Popover title, supports inline markdown text.
+content | `String` | `''` | Popover content, supports inline markdown text.
 header | `Boolean` | `true` |	Whether to show the header.
-placement | `String`, one of `top` `left` `right` `bottom` | `top` | How to position the popover.
+placement | `String` | `top` | How to position the Popover.<br>Supports: `top`, `left`, `right`, `bottom`.

--- a/docs/userGuide/components/tooltip.md
+++ b/docs/userGuide/components/tooltip.md
@@ -3,25 +3,25 @@
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </tooltip>
   <hr />
   Trigger
   <p>
     <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
-      <button class="btn btn-default">Click</button>
+      <button class="btn btn-secondary">Click</button>
     </tooltip>
     <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
-      <button class="btn btn-default">Contextmenu (right click)</button>
+      <button class="btn btn-secondary">Contextmenu (right click)</button>
     </tooltip>
     <br />
     <br />
@@ -44,25 +44,25 @@
 
   ``` html
   <tooltip header content="Lorem ipsum dolor sit amet" placement="top">
-    <button class="btn btn-default">Popover on top</button>
+    <button class="btn btn-secondary">Popover on top</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="left">
-    <button class="btn btn-default">Popover on left</button>
+    <button class="btn btn-secondary">Popover on left</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="right">
-    <button class="btn btn-default">Popover on right</button>
+    <button class="btn btn-secondary">Popover on right</button>
   </tooltip>
   <tooltip header content="Lorem ipsum dolor sit amet" placement="bottom">
-    <button class="btn btn-default">Popover on bottom</button>
+    <button class="btn btn-secondary">Popover on bottom</button>
   </tooltip>
   <hr />
   Trigger
   <p>
     <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
-      <button class="btn btn-default">Click</button>
+      <button class="btn btn-secondary">Click</button>
     </tooltip>
     <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="contextmenu">
-      <button class="btn btn-default">Contextmenu (right click)</button>
+      <button class="btn btn-secondary">Contextmenu (right click)</button>
     </tooltip>
     <br />
     <br />
@@ -86,6 +86,6 @@
 
 Name | Type | Default | Description
 ---- | ---- | ------- | ------
-trigger	| `String`, one of `click` `focus` `hover` `contextmenu` | `hover` | How the tooltip is triggered.
-content | `String`
-placement | `String`, one of `top` `left` `right` `bottom` || How to position the tooltip.
+trigger	| `String` | `hover` | How the tooltip is triggered.<br>Supports: `click`, `focus`, `hover`, `contextmenu`.
+content | `String` | `''` | Text content of the tooltip.
+placement | `String` | `top` | How to position the tooltip.<br>Supports: `top`, `left`, `right`, `bottom`.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [X] Other, please explain: Migration

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #316 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
`btn-default` is deprecated in Bootstrap 4.

**What changes did you make? (Give an overview)**
- Refactor `btn-default` to `btn-secondary` 
- Standardise formatting of Options sub-section in `Popover` and `Tooltip`

**Testing instructions:**
- Ensure you have `vue-strap.min.js` built from [vue-strap migration branch](https://github.com/MarkBind/vue-strap/tree/bootstrap-migration).
- Run `markbind serve docs` and check.