### PR TITLE
Update Advanced Tips and Tricks document's default slot classes

### DIFF
--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -9,7 +9,7 @@
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
   <panel expanded>
-    <p slot="header" class="panel-title">
+    <p slot="header" class="card-title">
       <i><strong>
         <span style="color:#FF0000;">R  </span>
         <span style="color:#FF7F00;">A  </span>
@@ -44,7 +44,7 @@
 
 ```html
 <panel expanded>
-  <p slot="header" class="panel-title">
+  <p slot="header" class="card-title">
     <i><strong>
       <span style="color:#FF0000;">R  </span>
       <span style="color:#FF7F00;">A  </span>
@@ -76,7 +76,7 @@
 ### Panel Slot Options
 Slot name | Default class | Notes
 --- | --- | --- 
-`header` | `panel-title` | Aligning text to the center of the panel is not possible, as the header element does not take up the entire container.
+`header` | `card-title` | Aligning text to the center of the panel is not possible, as the header element does not take up the entire container.
 
 ### Modal Slot Options
 When using slots for Modals, you need to add a single blank line before each `<modal>` tag, in order for the customization to render correctly.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #337

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
During Bootstrap 4 migration, we omitted this documentation update for changing the default class name.

**What changes did you make? (Give an overview)**
- Refactor `panel-title` to `card-title`
- ~~Update 1.9.0 Release notes~~

**Testing instructions:**
- Use `Netlify Preview` and check changes.