### PR TITLE
Enable horizontal scrolling for Markdown tables.

### DIFF
--- a/lib/markbind/lib/markdown-it/index.js
+++ b/lib/markbind/lib/markdown-it/index.js
@@ -34,7 +34,10 @@ markdownIt.normalizeLink = require('./normalizeLink');
 
 // fix table style
 markdownIt.renderer.rules.table_open = (tokens, idx) => {
-  return '<table class="markbind-table table table-bordered table-striped">';
+  return '<div class="table-responsive"><table class="markbind-table table table-bordered table-striped">';
+};
+markdownIt.renderer.rules.table_close = (tokens, idx) => {
+  return '</table></div>';
 };
 
 // fix emoji numbers


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #335 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently `<table>` elements are not scroll-able, which causes it to be cut-off when viewed on mobile.

**What changes did you make? (Give an overview)**
- Use Bootstrap 4's [responsive table class](https://getbootstrap.com/docs/4.1/content/tables/#responsive-tables) to wrap around Markdown tables when getting parsed with `markdown-it`.

**Testing instructions:**
- Use `Netlify Preview` and reduce your window size.
- Check that component options sub-section are scroll-able. 