### PR TITLE
Refactor long <h4> in user guide to bold text

### DIFF
--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -2,9 +2,7 @@
 
 ## Rich formatted text in headings and titles
 
-<p style="font-size:18px;">
-  Using the normal syntax, you are only able to use markdown formatting on headings. If you would like more styling options, you can define an element within the component that acts as your heading. This is done by adding a <md>`slot`</md> attribute with the correct name to that element.
-</p>
+Using the normal syntax, you are only able to use markdown formatting on headings. If you would like more styling options, you can define an element within the component that acts as your heading. This is done by adding a <md>`slot`</md> attribute with the correct name to that element.
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>

--- a/docs/userGuide/components/modal.md
+++ b/docs/userGuide/components/modal.md
@@ -1,6 +1,6 @@
 # Modal
 
-#### Modals are to be used together with the [Trigger](#trigger) component for activation.
+**Modals are to be used together with the [Trigger](#trigger) component for activation.**
 
 ## Modal Options
 Name | type | Default | Description

--- a/docs/userGuide/components/navbar.md
+++ b/docs/userGuide/components/navbar.md
@@ -1,6 +1,6 @@
 # Navbar
 
-#### Navbar allows visitors of your website to navigate through pages easily.
+**Navbar allows visitors of your website to navigate through pages easily.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>

--- a/docs/userGuide/components/panel.md
+++ b/docs/userGuide/components/panel.md
@@ -1,6 +1,6 @@
 # Panel
 
-#### Panel is a flexible container that supports collapsing and expanding its content. It is expandable by default.
+**Panel is a flexible container that supports collapsing and expanding its content. It is expandable by default.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -20,7 +20,7 @@
 </tip-box>
 <br>
 
-#### With `minimized` attribute, panel is minimized into an inline block element. The `alt` attribute is for you to specify the minimized block header.
+**With `minimized` attribute, panel is minimized into an inline block element. The `alt` attribute is for you to specify the minimized block header.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -40,7 +40,7 @@
 </tip-box>
 <br>
 
-#### With `expanded` attribute, you can set the panels to be expanded when loaded in.
+**With `expanded` attribute, you can set the panels to be expanded when loaded in.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -60,7 +60,8 @@
 </tip-box>
 <br>
 
-#### Panel provides many types that change its appearance.
+**Panel provides many types that change its appearance.**
+
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -129,7 +130,7 @@
 </tip-box>
 <br>
 
-#### Show/Hide buttons using `no-switch` or `no-close`.
+**Show/Hide buttons using `no-switch` or `no-close`.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -161,7 +162,7 @@
 </tip-box>
 <br>
 
-#### Use markdown in the header (only inline level markdown are supported).
+**Use markdown in the header (only inline level markdown are supported).**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -181,7 +182,7 @@
 </tip-box>
 <br>
 
-#### If `src` attribute is provided, the panel will take content from the 'src' specified and add it to the Panel body.
+**If `src` attribute is provided, the panel will take content from the `src` specified and add it to the Panel body.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -197,7 +198,7 @@
 </tip-box>
 <br>
 
-#### If `popup-url` attribute is provided, a popup button will be shown. If clicked, it opens the specified url in a new window.
+**If `popup-url` attribute is provided, a popup button will be shown. If clicked, it opens the specified url in a new window.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -217,7 +218,7 @@
 </tip-box>
 <br>
 
-#### If `preload` attribute is provided, the panel body will load the HTML when the page renders instead of after being expanded.
+**If `preload` attribute is provided, the panel body will load the HTML when the page renders instead of after being expanded.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -237,7 +238,7 @@
 </tip-box>
 <br>
 
-#### You can nest Panels or other components within a Panel.
+**You can nest Panels or other components within a Panel.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>

--- a/docs/userGuide/components/pic.md
+++ b/docs/userGuide/components/pic.md
@@ -1,6 +1,6 @@
 # Pic
 
-#### Pic allows you to add captions below the image.
+**Pic allows you to add captions below the image.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>

--- a/docs/userGuide/components/question.md
+++ b/docs/userGuide/components/question.md
@@ -1,6 +1,6 @@
 # Question
 
-#### Question component consists of a question body, a hint and an answer.
+**Question component consists of a question body, a hint and an answer.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -32,7 +32,7 @@
 </tip-box>
 <br>
 
-#### If you leave the hint and answer `<div>` blank, a default hint and answer will be provided instead.
+**If you leave the hint and answer `<div>` blank, a default hint and answer will be provided instead.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -56,7 +56,7 @@
 </tip-box>
 <br>
 
-#### Use the `has-input` attribute to add a text input box for users to enter their answer.
+**Use the `has-input` attribute to add a text input box for users to enter their answer.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -80,7 +80,7 @@
 </tip-box>
 <br>
 
-#### You are able to omit the hint or answer `<div>` independently, and they will not render.
+**You are able to omit the hint or answer `<div>` independently, and they will not render.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -126,7 +126,7 @@
 </tip-box>
 <br>
 
-#### Use the minimized Panel component to create and group questions inline. 
+**Use the minimized Panel component to create and group questions inline.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -166,7 +166,7 @@
 </tip-box>
 <br>
 
-#### Questions can also be loaded in from another file using Panel's `src` attribute.
+**Questions can also be loaded in from another file using Panel's `src` attribute.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>

--- a/docs/userGuide/components/tipBox.md
+++ b/docs/userGuide/components/tipBox.md
@@ -1,10 +1,8 @@
 # TipBox
-<br>
 
-#### You can either use \<tip-box> or \<box>.
-<br>
+**You can either use \<tip-box> or \<box>.**
 
-#### TipBox comes with different built-in types.
+**TipBox comes with different built-in types.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
@@ -66,7 +64,7 @@
 </tip-box>
 <br>
 
-#### You can customize the TipBox's appearance.
+**You can customize the TipBox's appearance.**
 
 <tip-box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #335 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Heading font sizes on mobile site was too large.

**What changes did you make? (Give an overview)**
- Change long instances of `<h4>` into bold markdown text using `**`

Before | After 
--- | ---
![335-font-size-before](https://user-images.githubusercontent.com/31084833/42749484-68ff14fe-8916-11e8-8941-62022d5bb6b3.PNG) | ![335-font-size-afterv2](https://user-images.githubusercontent.com/31084833/42793155-6434ca3c-89ab-11e8-9e14-caa896d5fb65.PNG)




**Is there anything you'd like reviewers to focus on?**
- Readability of new format on mobile.

**Testing instructions:**
- Use `Netlify Preview` and reduce your window size.
- Go through the document and check the readability of the content.