### PR TITLE
Search panel headings

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -165,21 +165,53 @@ Page.prototype.prepareTemplateData = function () {
 };
 
 /**
- * Records h1,h2,h3 headings into this.headings
- * @param renderedPage a page with its headings rendered
+ * Records headings inside rendered page into this.headings
  */
-Page.prototype.collectHeadings = function (renderedPage) {
-  const $ = cheerio.load(renderedPage);
+Page.prototype.collectHeadings = function () {
+  this.collectHeadingsInContent(fs.readFileSync(this.resultPath));
+};
+
+/**
+ * Records headings inside content into this.headings
+ * @param content that contains the headings
+ */
+Page.prototype.collectHeadingsInContent = function (content) {
+  let $ = cheerio.load(content);
+  $('panel').each((index, panel) => {
+    if (panel.attribs.header) {
+      this.collectHeadingsInContent(md.render(panel.attribs.header));
+    }
+  }).filter((index, panel) => panel.attribs.expanded !== undefined)
+    .each((index, panel) => {
+      if (panel.attribs.src) {
+        const src = panel.attribs.src.split('#')[0];
+        const includePath = path.resolve(this.resultPath,
+                                         path.relative(this.sourcePath,
+                                                       this.baseUrl
+                                                         ? path.relative(this.baseUrl, src)
+                                                         : src.substring(1)));
+        const includeContent = fs.readFileSync(includePath);
+        if (panel.attribs.fragment) {
+          $ = cheerio.load(includeContent);
+          this.collectHeadingsInContent($(`#${panel.attribs.fragment}`).html());
+        } else {
+          this.collectHeadingsInContent(includeContent);
+        }
+      } else {
+        this.collectHeadingsInContent($(panel).html());
+      }
+    });
+  $ = cheerio.load(content);
   if (this.headingIndexingLevel > 0) {
     let headingsSelector = 'h1';
     for (let i = 2; i <= this.headingIndexingLevel; i += 1) {
       headingsSelector += `, h${i}`;
     }
+    $('panel').remove();
     $(headingsSelector).each((i, heading) => {
       this.headings[$(heading).attr('id')] = $(heading).text();
     });
   }
-  return renderedPage;
 };
 
 /**
@@ -317,7 +349,6 @@ Page.prototype.generate = function (builtFiles) {
       .then(result => markbinder.resolveBaseUrl(result, fileConfig))
       .then(result => fs.outputFileAsync(this.tempPath, result))
       .then(() => markbinder.renderFile(this.tempPath, fileConfig))
-      .then(result => this.collectHeadings(result))
       .then((result) => {
         this.content = htmlBeautify(result, { indent_size: 2 });
 

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -522,6 +522,11 @@ Site.prototype.generatePages = function () {
   });
   return new Promise((resolve, reject) => {
     Promise.all(processingFiles)
+      .then(() => {
+        this.pages.forEach((page) => {
+          page.collectHeadings();
+        });
+      })
       .then(resolve)
       .catch(reject);
   });

--- a/test/test_site/_markbind/boilerplates/boilerTestPanel.md
+++ b/test/test_site/_markbind/boilerplates/boilerTestPanel.md
@@ -1,0 +1,1 @@
+### boilerplate test for panel heading

--- a/test/test_site/_markbind/boilerplates/folder/panelBoilerplate.md
+++ b/test/test_site/_markbind/boilerplates/folder/panelBoilerplate.md
@@ -1,0 +1,1 @@
+### heading in panel boilerplate

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -196,6 +196,23 @@ specification that specifies how the product will address the requirements. </sp
           <li>Timer – Additional fixed time restriction on the player.</li>
         </ol>
         <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+      <h1 id="panel-without-src">Panel without src</h1>
+      <panel header="## Panel without src header" expanded="">
+        <div>
+          <h3 id="panel-without-src-content-heading">panel without src content heading</h3>
+        </div>
+      </panel>
+      <h1 id="panel-with-normal-src">Panel with normal src</h1>
+      <panel header="## Panel with normal src header" src="/test_site\testPanels\PanelNormalSource._include_.html" expanded=""></panel>
+      <h1 id="panel-with-src-from-a-page-segment">Panel with src from a page segment</h1>
+      <panel header="## Panel with src from a page segment header" src="/test_site\testPanels\PanelSourceContainsSegment._include_.html#segment" expanded="" fragment="segment"></panel>
+      <h1 id="panel-with-boilerplate">Panel with boilerplate</h1>
+      <panel header="## boilerplate referencing" src="/test_site\testPanels\boilerTestPanel._include_.html" expanded=""></panel>
+      <panel header="## Referencing specified path in boilerplate" src="/test_site\testPanels\notInside._include_.html" expanded=""></panel>
+      <h1 id="nested-panel">Nested panel</h1>
+      <panel header="## Outer nested panel" src="/test_site\testPanels\NestedPanel._include_.html" expanded=""></panel>
+      <h1 id="panel-with-src-from-another-markbind-site">panel with src from another Markbind site</h1>
+      <panel header="## Panel with src from another Markbind site header" src="/test_site\sub_site\index._include_.html" expanded=""></panel>
     </div>
   </div>
 </div>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -2,6 +2,21 @@
   "pages": [
     {
       "headings": {
+        "panel-without-src-header": "Panel without src header",
+        "panel-with-normal-src-header": "Panel with normal src header",
+        "panel-with-src-from-a-page-segment-header": "Panel with src from a page segment header",
+        "boilerplate-referencing": "boilerplate referencing",
+        "referencing-specified-path-in-boilerplate": "Referencing specified path in boilerplate",
+        "outer-nested-panel": "Outer nested panel",
+        "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
+        "panel-without-src-content-heading": "panel without src content heading",
+        "panel-normal-source-content-headings": "panel normal source content headings",
+        "panel-source-segment-content-headings": "panel source segment content headings",
+        "boilerplate-test-for-panel-heading": "boilerplate test for panel heading",
+        "heading-in-panel-boilerplate": "heading in panel boilerplate",
+        "nested-panel": "Nested panel",
+        "normal-panel-content-heading": "normal panel content heading",
+        "feature-list": "Feature list",
         "navigation": "Navigation",
         "testing-site-nav": "Testing Site-Nav",
         "variables-that-reference-another-variable": "Variables that reference another variable",
@@ -16,7 +31,11 @@
         "nested-include": "Nested include",
         "html-include": "HTML include",
         "include-from-another-markbind-site": "Include from another Markbind site",
-        "feature-list": "Feature list"
+        "panel-without-src": "Panel without src",
+        "panel-with-normal-src": "Panel with normal src",
+        "panel-with-src-from-a-page-segment": "Panel with src from a page segment",
+        "panel-with-boilerplate": "Panel with boilerplate",
+        "panel-with-src-from-another-markbind-site": "panel with src from another Markbind site"
       },
       "title": "Hello World",
       "footer": "footer.md",

--- a/test/test_site/expected/sub_site/index._include_.html
+++ b/test/test_site/expected/sub_site/index._include_.html
@@ -1,0 +1,11 @@
+<p>This is a page from another Markbind site.</p>
+<h2 id="feature-list">Feature list</h2>
+<p>It is a list of features (or functionalities) grouped according to some criteria such as priority (e.g. must-have, nice-to-have, etc. ), order of delivery, object or process related (e.g. order-related, invoice-related, etc.). Here is a sample feature
+  list from Minesweeper (only a brief description has been provided to save space).</p>
+<ol>
+  <li>Basic play – Single player play.</li>
+  <li>Difficulty levels – Additional Medium and Advanced levels.</li>
+  <li>Versus play – Two players can play against each other.</li>
+  <li>Timer – Additional fixed time restriction on the player.</li>
+</ol>
+<img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">

--- a/test/test_site/expected/testPanels/NestedPanel._include_.html
+++ b/test/test_site/expected/testPanels/NestedPanel._include_.html
@@ -1,0 +1,1 @@
+<panel header="## Nested Panel" src="/test_site\testPanels\NormalPanelContent._include_.html" expanded=""></panel>

--- a/test/test_site/expected/testPanels/NormalPanelContent._include_.html
+++ b/test/test_site/expected/testPanels/NormalPanelContent._include_.html
@@ -1,0 +1,1 @@
+<h3 id="normal-panel-content-heading">normal panel content heading</h3>

--- a/test/test_site/expected/testPanels/PanelNormalSource._include_.html
+++ b/test/test_site/expected/testPanels/PanelNormalSource._include_.html
@@ -1,0 +1,1 @@
+<h3 id="panel-normal-source-content-headings">panel normal source content headings</h3>

--- a/test/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
+++ b/test/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
@@ -1,0 +1,4 @@
+<div id="segment">
+  <h3 id="panel-source-segment-content-headings">panel source segment content headings</h3>
+</div>
+<h3 id="this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data">this heading is not src of any panel, so it should not be in the search data</h3>

--- a/test/test_site/expected/testPanels/boilerTestPanel._include_.html
+++ b/test/test_site/expected/testPanels/boilerTestPanel._include_.html
@@ -1,0 +1,1 @@
+<h3 id="boilerplate-test-for-panel-heading">boilerplate test for panel heading</h3>

--- a/test/test_site/expected/testPanels/notInside._include_.html
+++ b/test/test_site/expected/testPanels/notInside._include_.html
@@ -1,0 +1,1 @@
+<h3 id="heading-in-panel-boilerplate">heading in panel boilerplate</h3>

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -38,4 +38,33 @@ siteNav: site-nav.md
 # Include from another Markbind site
 <include src="sub_site/index.md" />
 
+# Panel without src
+<panel header="## Panel without src header" expanded>
+<markdown>
+### panel without src content heading
+</markdown> 
+</panel>
+
+# Panel with normal src
+<panel header="## Panel with normal src header" src="testPanels/PanelNormalSource.md" expanded>
+</panel>    
+
+# Panel with src from a page segment
+<panel header="## Panel with src from a page segment header" src="testPanels/PanelSourceContainsSegment.md#segment" expanded>
+</panel>
+
+# Panel with boilerplate 
+<panel header="## boilerplate referencing" src="testPanels/boilerTestPanel.md"  boilerplate expanded>
+</panel>
+
+<panel header="## Referencing specified path in boilerplate" src="testPanels/notInside.md" boilerplate="folder/panelBoilerplate.md" expanded>
+</panel>
+
+# Nested panel
+<panel header="## Outer nested panel" src="testPanels/NestedPanel.md" expanded>
+</panel>
+
+# panel with src from another Markbind site
+<panel header="## Panel with src from another Markbind site header" src="sub_site/index.md" expanded>
+</panel>
 </div>

--- a/test/test_site/testPanels/NestedPanel.md
+++ b/test/test_site/testPanels/NestedPanel.md
@@ -1,0 +1,2 @@
+<panel header ="## Nested Panel" src="NormalPanelContent.md" expanded>
+</panel>

--- a/test/test_site/testPanels/NormalPanelContent.md
+++ b/test/test_site/testPanels/NormalPanelContent.md
@@ -1,0 +1,1 @@
+### normal panel content heading

--- a/test/test_site/testPanels/PanelNormalSource.md
+++ b/test/test_site/testPanels/PanelNormalSource.md
@@ -1,0 +1,1 @@
+### panel normal source content headings

--- a/test/test_site/testPanels/PanelSourceContainsSegment.md
+++ b/test/test_site/testPanels/PanelSourceContainsSegment.md
@@ -1,0 +1,6 @@
+<div id="segment">
+
+### panel source segment content headings
+</div>
+
+### this heading is not src of any panel, so it should not be in the search data  


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Relates #336 


**What is the rationale for this request?**
1. Headings in dynamic panels are not included in search result.
2. panels not expanded should not be searchable.

**What changes did you make? (Give an overview)**
collect headings from panels which are expanded.


**Testing instructions:**
1.pull https://github.com/MarkBind/vue-strap/pull/80
2. run `npm run build` in vue-strap repo
3. copy vue-strap.min.js to markbind repo
4. test on 2103 website.
eg: "pros": the pros and cons entry in the software engineer section are not indexed before(It's a panel header)
      "abstraction" : `object as abstraction` entry is there same as above.