### PR TITLE
Hide site navigation bar when on mobile devices

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -185,3 +185,36 @@
         margin-left: 300px;
     }
 }
+
+/* Bootstrap extra small(xs) responsive breakpoint */
+@media screen and (max-width: 575.98px) {
+
+    #site-nav {
+        padding-right: 0;
+    }
+
+    #site-nav-btn-wrap {
+        padding: 0;
+        width: 0;
+    }
+
+    #page-content {
+        margin-left: 0;
+        padding: 0;
+    }
+
+    footer {
+        margin-left: -15px;
+    }
+
+    /* Site navigation open button toggle */
+
+    #site-nav.open {
+        border: none;
+        width: 0;
+    }
+
+    #site-nav-btn-wrap.open {
+        margin-left: 0;
+    }
+}

--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -461,7 +461,7 @@ The above Markdown content will be rendered as:
   </li>
 </ul>
 
-The site navigation bar has [responsive properties](https://www.w3schools.com/html/html_responsive.asp), and will collapse to a menu button when the screen width is smaller than 1006 pixels.
+The site navigation bar has [responsive properties](https://www.w3schools.com/html/html_responsive.asp), and will collapse to a menu button when the screen width is smaller than 992 pixels. It will then be completely hidden when the screen size is smaller than 576 pixels.
 
 You are able to use [Markdown syntax](#supported-markdown-syntax), as well as [glyphicons](#glyphicons) to author your site navigation layout.
 

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -185,3 +185,36 @@
         margin-left: 300px;
     }
 }
+
+/* Bootstrap extra small(xs) responsive breakpoint */
+@media screen and (max-width: 575.98px) {
+
+    #site-nav {
+        padding-right: 0;
+    }
+
+    #site-nav-btn-wrap {
+        padding: 0;
+        width: 0;
+    }
+
+    #page-content {
+        margin-left: 0;
+        padding: 0;
+    }
+
+    footer {
+        margin-left: -15px;
+    }
+
+    /* Site navigation open button toggle */
+
+    #site-nav.open {
+        border: none;
+        width: 0;
+    }
+
+    #site-nav-btn-wrap.open {
+        margin-left: 0;
+    }
+}


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #335 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Site navigation toggle button on mobile device takes up too much screen space.

**What changes did you make? (Give an overview)**
- Add CSS to hide site navigation at Bootstrap XS responsive breakpoint.
- Update site navigation section in the user guide.

Before | After
--- | ---
![335-site-nav-before](https://user-images.githubusercontent.com/31084833/42869735-792b0912-8aa8-11e8-9e78-38aa79c56374.PNG) | ![335-site-nav-after](https://user-images.githubusercontent.com/31084833/42869740-7e0c53f0-8aa8-11e8-80f8-d0913b0cde61.PNG)


**Is there anything you'd like reviewers to focus on?**
- Transition between medium (992px) and extra small (576px) breakpoints

**Testing instructions:**
- Use `Netlify Preview` and use responsive mode in chrome to test.
