### PR TITLE
Enhance style of code blocks in MarkBind

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -6,6 +6,15 @@ code {
     word-break: normal;
 }
 
+pre > code.hljs {
+    -webkit-background-clip: padding-box; /* for Safari */
+    background: ghostwhite;
+    background-clip: padding-box; /* for IE9+, Firefox 4+, Opera, Chrome */
+    border: 1px solid rgb(200, 200, 200);
+    border: 1px solid rgba(200, 200, 200, 0.3);
+    border-radius: 5px;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -6,6 +6,15 @@ code {
     word-break: normal;
 }
 
+pre > code.hljs {
+    -webkit-background-clip: padding-box; /* for Safari */
+    background: ghostwhite;
+    background-clip: padding-box; /* for IE9+, Firefox 4+, Opera, Chrome */
+    border: 1px solid rgb(200, 200, 200);
+    border: 1px solid rgba(200, 200, 200, 0.3);
+    border-radius: 5px;
+}
+
 .btn:active,
 .btn:focus {
     box-shadow: none !important;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #347 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Current code block styles blend in too much. 

**What changes did you make? (Give an overview)**
- Change CSS specific to code blocks

Before |
--- |
![347-before](https://user-images.githubusercontent.com/31084833/42934097-f439609c-8b78-11e8-8233-0ff8520c84f4.PNG)

After |
--- |
![347-after](https://user-images.githubusercontent.com/31084833/42934114-fc7a5fae-8b78-11e8-82e4-05ce66e421b2.PNG)


**Is there anything you'd like reviewers to focus on?**
- New style

**Testing instructions:**
- Use `Netlify Preview`