### PR TITLE
Autoscroll after the whole page is loaded

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -2,6 +2,12 @@
 
 Vue.use(VueStrap);
 
+function scrollToUrlAnchorHeading() {
+  if (window.location.hash) {
+    jQuery(window.location.hash)[0].scrollIntoView();
+  }
+}
+
 function setupSiteNav() {
   // Add event listener for site-nav-btn to toggle itself and site navigation elements.
   const siteNavBtn = document.getElementById('site-nav-btn');
@@ -29,6 +35,9 @@ function setup() {
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
+    mounted() {
+      scrollToUrlAnchorHeading();
+    },
   });
   setupSiteNav();
 }
@@ -52,6 +61,9 @@ function setupWithSearch(siteData) {
         const anchor = match.heading ? `#${match.heading.id}` : '';
         window.location = `${page}${anchor}`;
       },
+    },
+    mounted() {
+      scrollToUrlAnchorHeading();
     },
   });
   setupSiteNav();


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes #310 

**What is the rationale for this request?**
when jumping to specific headings in other pages or subsites, content is not loaded before the scrolling.
Which makes it scrolling to the wrong place. 

**What changes did you make? (Give an overview)**
scrolling after the page is loaded(use Vuejs `mounted` hook)

**Testing instructions:**
1. `markbind serve docs`
2. test the `advanced tips and tricks` link is scrolling to the correct place