### PR TITLE
Scroll by navbar height after page is loaded

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -5,6 +5,7 @@ Vue.use(VueStrap);
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
     jQuery(window.location.hash)[0].scrollIntoView();
+    window.scrollBy(0, -document.body.style.paddingTop.replace('px', ''));
   }
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes #252 

**What is the rationale for this request?**
Search result shouldn't be covered by navbar.

**What changes did you make? (Give an overview)**
after page is loaded scroll window by the navbar height

**Provide some example code that this change will affect:**

**Testing instructions:**
1. 'markbind serve docs` test whether search result is covered by the navbar