### PR TITLE
Exclude headings in modal in search result

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -180,6 +180,7 @@ Page.prototype.collectHeadings = function () {
  */
 Page.prototype.collectHeadingsInContent = function (content) {
   let $ = cheerio.load(content);
+  $('modal').remove();
   $('panel').each((index, panel) => {
     if (panel.attribs.header) {
       this.collectHeadingsInContent(md.render(panel.attribs.header));
@@ -210,6 +211,7 @@ Page.prototype.collectHeadingsInContent = function (content) {
     for (let i = 2; i <= this.headingIndexingLevel; i += 1) {
       headingsSelector += `, h${i}`;
     }
+    $('modal').remove();
     $('panel').remove();
     $(headingsSelector).each((i, heading) => {
       this.headings[$(heading).attr('id')] = $(heading).text();

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -215,6 +215,15 @@ specification that specifies how the product will address the requirements. </sp
       <h1 id="panel-with-src-from-another-markbind-site">panel with src from another Markbind site</h1>
       <panel header="## Panel with src from another Markbind site header" src="/test_site\sub_site\index._include_.html" expanded=""></panel>
     </div>
+    <h1 id="modal-with-panel-inside">Modal with panel inside</h1>
+    <p>
+      <trigger for="modal-with-panel">trigger</trigger>
+    </p>
+    <modal title="modal title with panel inside" id="modal-with-panel">
+      <panel header="## Panel inside modal" expanded="">
+        <h2 id="panel-content-inside-modal">Panel content inside modal</h2>
+      </panel>
+    </modal>
   </div>
 </div>
 <div id="flex-div"></div>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -35,7 +35,8 @@
         "panel-with-normal-src": "Panel with normal src",
         "panel-with-src-from-a-page-segment": "Panel with src from a page segment",
         "panel-with-boilerplate": "Panel with boilerplate",
-        "panel-with-src-from-another-markbind-site": "panel with src from another Markbind site"
+        "panel-with-src-from-another-markbind-site": "panel with src from another Markbind site",
+        "modal-with-panel-inside": "Modal with panel inside"
       },
       "title": "Hello World",
       "footer": "footer.md",

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -69,3 +69,13 @@ head: myCustomHead.md
 <panel header="## Panel with src from another Markbind site header" src="sub_site/index.md" expanded>
 </panel>
 </div>
+
+# Modal with panel inside
+<trigger for="modal-with-panel">trigger</trigger>
+
+<modal title="modal title with panel inside" id="modal-with-panel">
+  <panel header="## Panel inside modal" expanded>
+  
+  ## Panel content inside modal
+  </panel>
+</modal>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes #341 

**What is the rationale for this request?**
modals content are not shown in the page yet, so the headings inside should not be indexed

**What changes did you make? (Give an overview)**
remove modal content when collect headings

**Testing instructions:**
1. test on 2103 website: 
   eg: search `avoid` there should not be entries from project assessment page.