### PR TITLE
Allow user to specify expansion for dropdown lists in site navigation

### DIFF
--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -435,6 +435,7 @@ If you would like to have a site navigation bar for your site, you may create on
     - Ensure you wrap your navigation layout in a `<navigation>` tag for MarkBind to render it properly. Also, there should only be one `<navigation>` tag in your file.
     - You may author additional HTML and Markdown content outside the `<navigation>` tag.
     - The `<navigation>` tag is also optional, allowing you to author everything in HTML and Markdown syntax.
+    - Use `:expanded:` keyword at the end of Dropdown titles to expand them by default. 
 
 ```html
 <!-- In _markbind/navigation/mySiteNav.md -->
@@ -442,7 +443,7 @@ If you would like to have a site navigation bar for your site, you may create on
 * [Home :house:]({{baseUrl}}/index.html)
 * Dropdown title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
   * [Dropdown link one](https://www.google.com/)
-  * Nested Dropdown title :triangular_ruler:
+  * Expanded Nested Dropdown title :triangular_ruler: :expanded: <!-- specify :expanded: to have it expand by default -->
     * [**Nested** Dropdown link one](https://www.google.com/)
     * [**Nested** Dropdown link two](https://www.google.com/)
   * [Dropdown link two](https://www.google.com/)
@@ -474,10 +475,10 @@ The above Markdown content will be rendered as:
       <ul style="list-style-type: none; margin-left:-1em">
         <li style="margin-top: 10px"><a href="https://www.google.com/">Dropdown link one</a></li>
         <li style="margin-top: 10px">
-          <button class="dropdown-btn">Nested Dropdown title 📐
-            <i class="dropdown-btn-icon">
+          <button class="dropdown-btn dropdown-btn-open">Expanded Nested Dropdown title 📐
+            <i class="dropdown-btn-icon rotate-icon">
             <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-          <div class="dropdown-container">
+          <div class="dropdown-container dropdown-container-open">
             <ul style="list-style-type: none; margin-left:-1em">
               <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></li>
               <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link two</a></li>
@@ -507,7 +508,7 @@ The above Markdown content will be rendered as:
 
 The site navigation bar has [responsive properties](https://www.w3schools.com/html/html_responsive.asp), and will collapse to a menu button when the screen width is smaller than 992 pixels. It will then be completely hidden when the screen size is smaller than 576 pixels.
 
-You are able to use [Markdown syntax](#supported-markdown-syntax), as well as [glyphicons](#glyphicons) to author your site navigation layout.
+You are able to use [Markdown syntax](#supported-markdown-syntax), [Glyphicons](#glyphicons) and [Font Awesome icons](#font-awesome-icons) to author your site navigation layout.
 
 Note:
 - Only one navigation file can be specified in a page, and you must include its file extension.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -27,6 +27,7 @@ const TITLE_PREFIX_SEPARATOR = ' - ';
 const DROPDOWN_BUTTON_ICON_HTML = '<i class="dropdown-btn-icon">\n'
   + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
   + '</i>';
+const DROPDOWN_EXPAND_KEYWORD = ':expanded:';
 const SITE_NAV_BUTTON_HTML = '<div id="site-nav-btn-wrap">\n'
   + '<div id="site-nav-btn">\n'
   + '<div class="menu-top-bar"></div>\n'
@@ -136,11 +137,24 @@ function formatSiteNav(renderedSiteNav) {
       const dropdownTitle = $(this).contents().not('ul');
       // Replace the title with the dropdown wrapper
       dropdownTitle.remove();
-      nestedList.wrap('<div class="dropdown-container"></div>');
-      $(this).prepend('<button class="dropdown-btn">'
-        + `${dropdownTitle} `
-        + `${DROPDOWN_BUTTON_ICON_HTML}\n`
-        + '</button>');
+      // Check if dropdown is expanded by default
+      if (dropdownTitle.toString().includes(DROPDOWN_EXPAND_KEYWORD)) {
+        const expandKeywordRegex = new RegExp(DROPDOWN_EXPAND_KEYWORD, 'g');
+        const dropdownTitleWithoutKeyword = dropdownTitle.toString().replace(expandKeywordRegex, '');
+        const rotatedIcon = cheerio.load(DROPDOWN_BUTTON_ICON_HTML, { xmlMode: false })('i')
+          .addClass('rotate-icon');
+        nestedList.wrap('<div class="dropdown-container dropdown-container-open"></div>');
+        $(this).prepend('<button class="dropdown-btn dropdown-btn-open">'
+          + `${dropdownTitleWithoutKeyword} `
+          + `${rotatedIcon}\n`
+          + '</button>');
+      } else {
+        nestedList.wrap('<div class="dropdown-container"></div>');
+        $(this).prepend('<button class="dropdown-btn">'
+          + `${dropdownTitle} `
+          + `${DROPDOWN_BUTTON_ICON_HTML}\n`
+          + '</button>');
+      }
       // Recursively format nested lists
       nestedList.replaceWith(formatSiteNav(nestedList.parent().html()));
     }

--- a/test/test_site/_markbind/navigation/site-nav.md
+++ b/test/test_site/_markbind/navigation/site-nav.md
@@ -3,7 +3,7 @@
 * [Home :house:]({{baseUrl}}/index.html)
 * [Open Bugs :bug:]({{baseUrl}}/bugs/index.html)
 * ### Testing Site-Nav
-* **Dropdown** {{glyphicon_search}} title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
+* **Dropdown :expanded:** {{glyphicon_search}} title :pencil2: <!-- Nested list items will be placed inside a Dropdown menu -->
   * [Dropdown link one](https://www.google.com/)
   * Nested Dropdown title :triangular_ruler:
     * [**Nested** Dropdown link one](https://www.google.com/)
@@ -12,7 +12,7 @@
 * [==Third Link== :clipboard:](https://www.google.com/)
 * Filler text [{{glyphicon_facetime_video}} Youtube :tv:](https://www.youtube.com/) filler text<!-- Using a link as a Dropdown title will not render a Dropdown menu -->
   * [The answer to everything in the universe](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
-  * ==Dropdown title== {{glyphicon_comment}} :pencil2: <!-- Dropdown menus in are still supported inside, as long as the title is not a link -->
+  * ==:expanded:Dropdown title==:expanded: {{glyphicon_comment}} :pencil2: <!-- Dropdown menus in are still supported inside, as long as the title is not a link -->
     * [**Nested** Dropdown link one](https://www.google.com/)
 * Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
   * Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -28,10 +28,10 @@
       <li style="margin-top: 10px">
         <h3 id="testing-site-nav">Testing Site-Nav</h3>
       </li>
-      <li style="margin-top: 10px"><button class="dropdown-btn"><strong>Dropdown</strong> <span class="glyphicon glyphicon-search" aria-hidden="true"></span> title ✏️ 
- <i class="dropdown-btn-icon">
+      <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open"><strong>Dropdown </strong> <span class="glyphicon glyphicon-search" aria-hidden="true"></span> title ✏️ 
+ <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-        <div class="dropdown-container">
+        <div class="dropdown-container dropdown-container-open">
           <ul style="list-style-type: none; margin-left:-1em">
             <li style="margin-top: 10px"><a href="https://www.google.com/">Dropdown link one</a></li>
             <li style="margin-top: 10px"><button class="dropdown-btn">Nested Dropdown title 📐
@@ -52,10 +52,10 @@
       <li style="margin-top:10px">Filler text <a href="https://www.youtube.com/"><span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span> Youtube 📺</a> filler text
         <ul style="list-style-type: none; margin-left:-1em">
           <li style="margin-top: 10px"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">The answer to everything in the universe</a></li>
-          <li style="margin-top: 10px"><button class="dropdown-btn"><mark>Dropdown title</mark> <span class="glyphicon glyphicon-comment" aria-hidden="true"></span> ✏️ 
- <i class="dropdown-btn-icon">
+          <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open"><mark>Dropdown title</mark> <span class="glyphicon glyphicon-comment" aria-hidden="true"></span> ✏️ 
+ <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-            <div class="dropdown-container">
+            <div class="dropdown-container dropdown-container-open">
               <ul style="list-style-type: none; margin-left:-1em">
                 <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></li>
               </ul>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #348 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to expand certain dropdown lists in site navigation by default.

**What changes did you make? (Give an overview)**
- Add alternative formatting logic for dropdown lists when detecting keyword in the title
- Update site-nav test within `test_site`
- Update Site navigation section in user guide

Before | After
--- | ---
![348-before](https://user-images.githubusercontent.com/31084833/43240350-97d878ce-90c8-11e8-9947-85590095c60d.PNG) | ![348-after](https://user-images.githubusercontent.com/31084833/43240352-9b361436-90c8-11e8-8ca4-7d531860f18e.PNG)

**Is there anything you'd like reviewers to focus on?**
- Variable naming
- Wording in user guide

**Testing instructions:**
- Checkout this PR and go to the `test_site` folder
- Run `markbind serve` and check that certain dropdown lists are expanded by default
- Modify `site-nav.md` and see the corresponding changes reflected after running `markbind serve` again
