### PR TITLE
Allow user to control position of content to be inserted in <head>

### DIFF
--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -385,6 +385,10 @@ While authoring your website, you may want to have your own CSS or Javascript fi
 - Author your `<style>` elements for CSS files and `<link>` elements for Javascript files using HTML as shown below.
     - Ensure that your URLs start from the root directory, by using <code>{<span></span>{baseUrl}}/</code> when you are referencing your files.
 
+- All content is inserted near the bottom of the `<head>` tag by default.
+    - Use the `<head-top>` tag to specify content that you wish to place at the top of the `<head>` tag.
+    - The `<head-top>` tag is optional, you may omit it from your head file if you do not use it. 
+
 ```css
 /* In yourCSSFolder/subfolder/myCustomStyle.css */
 p {
@@ -399,8 +403,11 @@ alert("Welcome to my website!");
 
 ```html
 <!-- In _markbind/head/compiledRef.md -->
+<head-top>  <!-- HTML within this tag will be placed first, directly after the starting <head> tag -->
+  <script src="{{baseUrl}}/yourScriptFolder/myCustomScript.js"></script>
+</head-top>
+<!-- Any content outside the <head-top> tag will default to the bottom position -->
 <link rel="stylesheet" href="{{baseUrl}}/yourCSSFolder/subfolder/myCustomStyle.css">
-<script src="{{baseUrl}}/yourScriptFolder/myCustomScript.js"></script>
 ```
 
 - Specify the head file in pages that uses it, by specifying the [front matter](#front-matter) `head` attribute.
@@ -412,8 +419,7 @@ alert("Welcome to my website!");
 </frontmatter>
 ```
 
-The head file contents will be placed near the end of the page's head tag.
-Your head file will override existing Bootstrap and MarkBind CSS styles if there is an overlap of selectors. 
+Style elements placed at the bottom will override existing Bootstrap and MarkBind CSS styles if there is an overlap of selectors. 
 
 Note:
   - You may specify raw `.js` or `.css` files as your head file if you wish to do so.

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -60,7 +60,8 @@ function Page(pageConfig) {
   this.resultPath = pageConfig.resultPath;
 
   this.frontMatter = {};
-  this.headFileReferences = '';
+  this.headFileBottomContent = '';
+  this.headFileTopContent = '';
   this.headings = {};
   this.headingIndexingLevel = pageConfig.headingIndexingLevel;
   this.includedFiles = {};
@@ -162,7 +163,8 @@ Page.prototype.prepareTemplateData = function () {
     baseUrl: this.baseUrl,
     content: this.content,
     faviconUrl: this.faviconUrl,
-    headFileReferences: this.headFileReferences,
+    headFileBottomContent: this.headFileBottomContent,
+    headFileTopContent: this.headFileTopContent,
     title: prefixedTitle,
   };
 };
@@ -328,7 +330,7 @@ Page.prototype.insertSiteNav = function (pageData) {
     + '</div>';
 };
 
-Page.prototype.collectHeadFiles = function () {
+Page.prototype.collectHeadFiles = function (baseUrl, hostBaseUrl) {
   const { head } = this.frontMatter;
   if (!head) {
     return;
@@ -340,8 +342,18 @@ Page.prototype.collectHeadFiles = function () {
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
-  const headFileMappedData = nunjucks.renderString(headFileContent, userDefinedVariables);
-  this.headFileReferences = headFileMappedData.trim();
+  const headFileMappedData = nunjucks.renderString(headFileContent, userDefinedVariables).trim();
+  // Split top and bottom contents
+  const $ = cheerio.load(headFileMappedData, { xmlMode: false });
+  if ($('head-top').length) {
+    this.headFileTopContent = nunjucks.renderString($('head-top').html(), { baseUrl, hostBaseUrl })
+      .trim()
+      .replace(/\n\s*\n/g, '\n');
+    $('head-top').remove();
+  }
+  this.headFileBottomContent = nunjucks.renderString($.html(), { baseUrl, hostBaseUrl })
+    .trim()
+    .replace(/\n\s*\n/g, '\n');
 };
 
 Page.prototype.generate = function (builtFiles) {
@@ -375,8 +387,7 @@ Page.prototype.generate = function (builtFiles) {
         const baseUrl = newBaseUrl ? `${this.baseUrl}/${newBaseUrl}` : this.baseUrl;
         const hostBaseUrl = this.baseUrl;
 
-        this.collectHeadFiles();
-        this.headFileReferences = nunjucks.renderString(this.headFileReferences, { baseUrl, hostBaseUrl });
+        this.collectHeadFiles(baseUrl, hostBaseUrl);
         this.content = nunjucks.renderString(this.content, { baseUrl, hostBaseUrl });
         return fs.outputFileAsync(this.resultPath, this.template(this.prepareTemplateData()));
       })

--- a/lib/template/page.ejs
+++ b/lib/template/page.ejs
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <%- headFileTopContent %>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,7 +13,7 @@
     <link rel="stylesheet" href="<%- asset.highlight %>">
     <link rel="stylesheet" href="<%- asset.markbind %>">
     <link rel="stylesheet" href="<%- asset.siteNavCss %>">
-    <%- headFileReferences %>
+    <%- headFileBottomContent %>
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>
 <body>

--- a/test/test_site/_markbind/head/myCustomHead.md
+++ b/test/test_site/_markbind/head/myCustomHead.md
@@ -1,1 +1,17 @@
-<script src="{{baseUrl}}\headFiles\customScript.js"></script>
+<!-- Start of bottom level head file content insertion -->
+ 
+<head-top>
+
+<!-- Start of top level head file content insertion -->
+
+<script src="{{baseUrl}}/headFiles/customScriptTop.js"></script>
+
+
+<!-- End of top level head file content insertion -->
+</head-top>
+
+<script src="{{baseUrl}}/headFiles/customScriptBottom.js"></script>
+
+
+
+<!-- End of bottom level head file content insertion

--- a/test/test_site/expected/bugs/index.html
+++ b/test/test_site/expected/bugs/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/test/test_site/expected/headFiles/customScript.js
+++ b/test/test_site/expected/headFiles/customScript.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-console
-console.info('custom script inserted into head successfully!');

--- a/test/test_site/expected/headFiles/customScriptBottom.js
+++ b/test/test_site/expected/headFiles/customScriptBottom.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('custom script inserted into bottom of head successfully!');

--- a/test/test_site/expected/headFiles/customScriptTop.js
+++ b/test/test_site/expected/headFiles/customScriptTop.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('custom script inserted into top of head successfully!');

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <!-- Start of top level head file content insertion -->
+<script src="/test_site/headFiles/customScriptTop.js"></script>
+<!-- End of top level head file content insertion -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,7 +15,9 @@
     <link rel="stylesheet" href="markbind\css\github.min.css">
     <link rel="stylesheet" href="markbind\css\markbind.css">
     <link rel="stylesheet" href="markbind\css\site-nav.css">
-    <script src="/test_site\headFiles\customScript.js"></script>
+    <!-- Start of bottom level head file content insertion -->
+<script src="/test_site/headFiles/customScriptBottom.js"></script>
+<!-- End of bottom level head file content insertion-->
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/test_site/expected/sub_site/index.html
+++ b/test/test_site/expected/sub_site/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/test/test_site/headFiles/customScript.js
+++ b/test/test_site/headFiles/customScript.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-console
-console.info('custom script inserted into head successfully!');

--- a/test/test_site/headFiles/customScriptBottom.js
+++ b/test/test_site/headFiles/customScriptBottom.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('custom script inserted into bottom of head successfully!');

--- a/test/test_site/headFiles/customScriptTop.js
+++ b/test/test_site/headFiles/customScriptTop.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('custom script inserted into top of head successfully!');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
#377 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to control the position of content placed in `<head>`

**What changes did you make? (Give an overview)**
- Introduce `<head-top>` and `<head-bottom>` tags as position specifiers.
- Changed `collectHeadFiles` method to account for position logic  and be more streamlined. 
- Update relevant section in user guide
- Updated insertion test in `test_site`

Page source of test_site |
--- |
![377-after](https://user-images.githubusercontent.com/31084833/43249470-5fd54e5a-90ed-11e8-8dbe-bbc1f4bf04c6.PNG) |


**Is there anything you'd like reviewers to focus on?**
- Wording in user guide

**Testing instructions:**
- Checkout this PR and navigate to the `test_site` folder.
- Run `markbind serve` and check console for success messages.
- Check page source to see correct insertion.