### PR TITLE
Fix footer white space on smaller window widths

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -179,6 +179,7 @@ Page.prototype.prepareTemplateData = function () {
     faviconUrl: this.faviconUrl,
     headFileBottomContent: this.headFileBottomContent,
     headFileTopContent: this.headFileTopContent,
+    siteNav: this.frontMatter.siteNav,
     title: prefixedTitle,
   };
 };

--- a/lib/template/page.ejs
+++ b/lib/template/page.ejs
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="<%- asset.glyphicons %>" >
     <link rel="stylesheet" href="<%- asset.highlight %>">
     <link rel="stylesheet" href="<%- asset.markbind %>">
-    <link rel="stylesheet" href="<%- asset.siteNavCss %>">
+    <% if (siteNav) { %><link rel="stylesheet" href="<%- asset.siteNavCss %>"><% } %>
     <%- headFileBottomContent %>
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>

--- a/test/test_site/expected/bugs/index.html
+++ b/test/test_site/expected/bugs/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="..\markbind\css\bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="..\markbind\css\github.min.css">
     <link rel="stylesheet" href="..\markbind\css\markbind.css">
-    <link rel="stylesheet" href="..\markbind\css\site-nav.css">
+    
     
     <link rel="icon" href="/test_site/favicon.png">
 </head>

--- a/test/test_site/expected/sub_site/index.html
+++ b/test/test_site/expected/sub_site/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="..\markbind\css\bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="..\markbind\css\github.min.css">
     <link rel="stylesheet" href="..\markbind\css\markbind.css">
-    <link rel="stylesheet" href="..\markbind\css\site-nav.css">
+    
     
     <link rel="icon" href="/test_site/favicon.png">
 </head>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #391 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Footer will be responsive with respect to MarkBind's site navigation even though there is no site-navigation specified.

**What changes did you make? (Give an overview)**
- Change it such that `site-nav.css` is only included when a site-nav file is specified in `frontmatter`


**Is there anything you'd like reviewers to focus on?**
- Issue of using `<% %>` syntax causing unnecessary line breaks. 

**Testing instructions:**
- Checkout this PR and run `markbind init`
- Remove the `siteNav` line from `frontmatte` 
- Run `markbind serve` and inspect page source to see that `site-nav.css` is not there.
- Add back the `siteNav` line and repeat. The file should now be included.