### PR TITLE
Add progress bar and additional logging for building process

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ program
     const site = new Site(rootFolder, outputFolder);
 
     const addHandler = (filePath) => {
-      logger.info(`Reload for file add: ${filePath}`);
+      logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       Promise.resolve('').then(() => {
         if (fsUtil.isSourceFile(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);
@@ -147,7 +147,7 @@ program
     };
 
     const changeHandler = (filePath) => {
-      logger.info(`Reload for file change: ${filePath}`);
+      logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
         if (fsUtil.isSourceFile(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);
@@ -159,7 +159,7 @@ program
     };
 
     const removeHandler = (filePath) => {
-      logger.info(`Reload for file deletion: ${filePath}`);
+      logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       Promise.resolve('').then(() => {
         if (fsUtil.isSourceFile(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -9,6 +9,7 @@ const ignore = require('ignore');
 const nunjucks = require('nunjucks');
 const path = require('path');
 const Promise = require('bluebird');
+const ProgressBar = require('progress');
 const walkSync = require('walk-sync');
 
 const _ = {};
@@ -381,11 +382,13 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
 };
 
 Site.prototype.generate = function (baseUrl) {
+  const startTime = new Date();
   // Create the .tmp folder for storing intermediate results.
   logger.profile(GENERATE_SITE_LOGGING_KEY);
   fs.emptydirSync(this.tempPath);
   // Clean the output folder; create it if not exist.
   fs.emptydirSync(this.outputPath);
+  logger.info(`Website generation started at ${startTime.toLocaleTimeString()}`);
   return new Promise((resolve, reject) => {
     this.readSiteConfig(baseUrl)
       .then(() => this.collectAddressablePages())
@@ -395,6 +398,11 @@ Site.prototype.generate = function (baseUrl) {
       .then(() => this.buildSourceFiles())
       .then(() => this.copyMarkBindAsset())
       .then(() => this.writeSiteData())
+      .then(() => {
+        const endTime = new Date();
+        const totalBuildTime = (endTime - startTime) / 1000;
+        logger.info(`Website generation complete! Total build time: ${totalBuildTime}s`);
+      })
       .then(resolve)
       .catch((error) => {
         rejectHandler(reject, error, [this.tempPath, this.outputPath]);
@@ -408,6 +416,7 @@ Site.prototype.generate = function (baseUrl) {
  */
 Site.prototype.buildSourceFiles = function () {
   return new Promise((resolve, reject) => {
+    logger.info('Generating pages...');
     this.generatePages()
       .then(() => fs.removeAsync(this.tempPath))
       .then(() => logger.info('Pages built'))
@@ -476,6 +485,7 @@ Site.prototype.removeAsset
  = delay(Site.prototype._removeMultipleAssets, 1000);
 
 Site.prototype.buildAssets = function () {
+  logger.info('Building assets...');
   return new Promise((resolve, reject) => {
     const ignoreConfig = this.siteConfig.ignore || [];
     const outputFolder = path.relative(this.rootPath, this.outputPath);
@@ -487,6 +497,7 @@ Site.prototype.buildAssets = function () {
         assets.map(asset => fs.copyAsync(path.join(this.rootPath, asset), path.join(this.outputPath, asset))),
       )
       .then(copyAssets => Promise.all(copyAssets))
+      .then(() => logger.info('Assets built'))
       .then(resolve)
       .catch((error) => {
         rejectHandler(reject, error, []); // assets won't affect deletion
@@ -522,8 +533,12 @@ Site.prototype.generatePages = function () {
     title: page.title,
     searchable: page.searchable !== 'no',
   }));
+  const progressBar = new ProgressBar(`[:bar] :current / ${this.pages.length} pages built`,
+                                      { total: this.pages.length });
+  progressBar.render();
   this.pages.forEach((page) => {
     processingFiles.push(page.generate(builtFiles)
+      .then(() => progressBar.tick())
       .catch((err) => {
         logger.error(err);
         return Promise.reject(new Error(`Error while generating ${page.sourcePath}`));

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "markdown-it-video": "^0.4.0",
     "nunjucks": "^3.0.0",
     "path-is-inside": "^1.0.2",
+    "progress": "^2.0.0",
     "walk-sync": "^0.3.1",
     "winston": "^2.4.1",
     "winston-daily-rotate-file": "^3.0.1"


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [X] Enhancement to an existing feature
• [ ] Other, please explain:

Resolves #388 


**What is the rationale for this request?**
When doing a markbind build and markbind serve, the console does not print anything to indicate progress. User will stare at a blank screen until the website finish building.

**What changes did you make? (Give an overview)**
Logging building process and add timestamp for live reloading

**Provide some example code that this change will affect:**
NA

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**
1. test on 2103 website to see the log info