### PR TITLE
Update live preview on variable file change

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -380,6 +380,20 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
   });
 };
 
+/**
+ * Collects the user defined variables map in the site/subsites
+ * if there is a change in the variables file
+ * @param filePaths array of paths corresponding to files that have changed
+ */
+Site.prototype.collectUserDefinedVariablesMapIfNeeded = function (filePaths) {
+  const variablesPath = path.resolve(this.rootPath, USER_VARIABLES_PATH);
+  if (filePaths.includes(variablesPath)) {
+    this.collectUserDefinedVariablesMap();
+    return true;
+  }
+  return false;
+};
+
 Site.prototype.generate = function (baseUrl) {
   // Create the .tmp folder for storing intermediate results.
   logger.profile(GENERATE_SITE_LOGGING_KEY);
@@ -549,9 +563,13 @@ Site.prototype.generatePages = function () {
 Site.prototype.regenerateAffectedPages = function (filePaths) {
   const builtFiles = {};
   const processingFiles = [];
+  const shouldRebuildAllPages = this.collectUserDefinedVariablesMapIfNeeded(filePaths);
+  if (shouldRebuildAllPages) {
+    logger.warn('Rebuilding all pages as variables file was changed');
+  }
   this._setTimestampVariable();
   this.pages.forEach((page) => {
-    if (filePaths.some(filePath => page.includedFiles[filePath])) {
+    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
       // eslint-disable-next-line no-param-reassign
       page.userDefinedVariablesMap = this.userDefinedVariablesMap;
       processingFiles.push(page.generate(builtFiles)


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #387 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to not reset live preview server to view changes in `variables.md` file.

**What changes did you make? (Give an overview)**
- Re-generate every single page if `variables.md` file is changed. (Brute force solution)

**Is there anything you'd like reviewers to focus on?**
- Code style

**Testing instructions:**
1. Checkout this PR
2. Download [387-test-v2.zip](https://github.com/MarkBind/markbind/files/2244430/387-test-v2.zip) and extract
3. Run `markbind serve`
4. Change `_markbind/variables.md` 
5. Both pages should be updated.
