### PR TITLE
Fix scroll to heading if anchor is in the same page

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -61,6 +61,7 @@ function setupWithSearch(siteData) {
         const page = `${baseUrl}/${match.src.replace('.md', '.html')}`;
         const anchor = match.heading ? `#${match.heading.id}` : '';
         window.location = `${page}${anchor}`;
+        scrollToUrlAnchorHeading();
       },
     },
     mounted() {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

fIxes #402

**What is the rationale for this request?**
when jumping to the target in the same page, result covered by the navbar

**What changes did you make? (Give an overview)**
add `scrollToUrlAnchorHeading` to search callback, so that the scrolling is done every jumping


**Testing instructions:**
1. test on 2103 website 