### PR TITLE
Collect headings inside #content-wrapper only

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -197,7 +197,8 @@ Page.prototype.prepareTemplateData = function () {
  * Records headings inside rendered page into this.headings
  */
 Page.prototype.collectHeadings = function () {
-  this.collectHeadingsInContent(fs.readFileSync(this.resultPath));
+  const $ = cheerio.load(fs.readFileSync(this.resultPath));
+  this.collectHeadingsInContent($(`#${CONTENT_WRAPPER_ID}`).html());
 };
 
 /**

--- a/test/test_site/_markbind/footers/footer.md
+++ b/test/test_site/_markbind/footers/footer.md
@@ -1,4 +1,6 @@
 <footer>
+
+# Heading in footer should not be indexed
   <div class="text-center">
     This is a dynamic height footer that supports variables {{glyphicon_tags}} and markdown <md>:smile:</md>!
   </div>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -250,6 +250,7 @@ specification that specifies how the product will address the requirements. </sp
 </div>
 <div id="flex-div"></div>
 <footer>
+  <h1 id="heading-in-footer-should-not-be-indexed">Heading in footer should not be indexed</h1>
   <div class="text-center">
     This is a dynamic height footer that supports variables <span class="glyphicon glyphicon-tags" aria-hidden="true"></span> and markdown <span>😄</span>!
   </div>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -22,8 +22,6 @@
         "panel-content-of-inner-nested-panel": "Panel content of inner nested panel",
         "panel-content-of-outer-nested-panel": "Panel content of outer nested panel",
         "feature-list": "Feature list",
-        "navigation": "Navigation",
-        "testing-site-nav": "Testing Site-Nav",
         "variables-that-reference-another-variable": "Variables that reference another variable",
         "normal-include": "Normal include",
         "establishing-requirements": "Establishing Requirements",


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes #406 

**What is the rationale for this request?**
Headings in site-nav and footer should not be searchable. should collect in page content only

**What changes did you make? (Give an overview)**
Collect headings from `#content-wrapper` only

**Testing instructions:**
1. insert headings outside page-content(site-nav, footer), check  they are not searchable