### PR TITLE
Remove unecessary trim() from content wrapper logic

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -74,7 +74,7 @@ function Page(pageConfig) {
  */
 
 function addContentWrapper(pageData) {
-  const $ = cheerio.load(pageData.trim());
+  const $ = cheerio.load(pageData);
   $(`#${CONTENT_WRAPPER_ID}`).removeAttr('id');
   return `<div id="${CONTENT_WRAPPER_ID}">`
     + `${$.html()}`


### PR DESCRIPTION
Buggy behaviour was found when trimming the pageData,
making certain Markdown content not render properly.

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Caused by #394 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Found that the `.trim()` method makes Markdown content on the first line of the `index.md` file not render properly.

**What changes did you make? (Give an overview)**
- Remove `.trim()` in `addContentWrapper`

**Testing instructions:**
- Checkout PR
- run `markbind init` and `markbind serve`
- `# Hello World` is rendered properly.