### PR TITLE
Add version number after logo

### DIFF
--- a/docs/userGuide/userQuickStart.md
+++ b/docs/userGuide/userQuickStart.md
@@ -38,6 +38,7 @@ to ensure `MarkBind` is successfully installed on your system. You should see:
 | |  | | | (_| | | |    |   <  | |_) | | | | | | | | (_| |
 |_|  |_|  \__,_| |_|    |_|\_\ |____/  |_| |_| |_|  \__,_|
 
+v1.12.0
 
 Usage: index  <command>
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,11 @@ process.stdout.write(
   `${String.fromCharCode(27)}]0; MarkBind${String.fromCharCode(7)}`,
 );
 
+function printHeader() {
+  logger.logo();
+  logger.log(` v${CLI_VERSION}`);
+}
+
 program
   .allowUnknownOption()
   .usage(' <command>');
@@ -59,14 +64,14 @@ program
         if (options.output) {
           const outputPath = path.resolve(process.cwd(), options.output);
           fs.outputFileSync(outputPath, result);
-          logger.logo();
+          printHeader();
           logger.info(`Result was written to ${outputPath}`);
         } else {
           logger.log(result);
         }
       })
       .catch((error) => {
-        logger.logo();
+        printHeader();
         logger.error('Error processing fragment include:');
         logger.error(error.message);
       });
@@ -95,7 +100,7 @@ program
         if (options.output) {
           const outputPath = path.resolve(process.cwd(), options.output);
           fs.outputFileSync(outputPath, formattedResult);
-          logger.logo();
+          printHeader();
           logger.info(`Result was written to ${outputPath}`);
         } else {
           logger.log(formattedResult);
@@ -112,7 +117,7 @@ program
   .description('init a markbind website project')
   .action((root) => {
     const rootFolder = path.resolve(root || process.cwd());
-    logger.logo();
+    printHeader();
     Site.initSite(rootFolder)
       .then(() => {
         logger.info('Initialization success.');
@@ -179,7 +184,7 @@ program
       mount: [],
     };
 
-    logger.logo();
+    printHeader();
 
     site
       .readSiteConfig()
@@ -230,7 +235,7 @@ program
       .catch((err) => {
         logger.error(err.message);
       });
-    logger.logo();
+    printHeader();
   });
 
 program
@@ -244,7 +249,7 @@ program
     const rootFolder = path.resolve(root || process.cwd());
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
-    logger.logo();
+    printHeader();
     new Site(rootFolder, outputFolder)
       .generate(baseUrl)
       .then(() => {
@@ -261,7 +266,7 @@ if (!program.args.length || !ACCEPTED_COMMANDS.includes(process.argv[2])) {
   if (program.args.length) {
     logger.warn(`Command '${program.args[0]}' doesn't exist, run "markbind help" to list commands.`);
   } else {
-    logger.logo();
+    printHeader();
     program.help();
   }
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Fixes #415 
<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Adding version number after logo is printed.

**What changes did you make? (Give an overview)**

Print the version number after `logger.logo();`.

**Testing instructions:**

Execute any valid command. The version number is printed after the logo.

![image](https://user-images.githubusercontent.com/19278089/44308500-b1c53900-a3e9-11e8-8f0a-cc86de385314.png)