### PR TITLE
Support live preview for .mbd and .mbdf files

### DIFF
--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -40,6 +40,13 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-p`, `--port <port>` | The port used for serving your website. |
 | --no-open | Don't open browser automatically. |
 
+Note: Live reload is only supported for the following file types:
+
+- `.html`
+- `.md`
+- `.mbd` (MarkBind file)
+- `.mbdf` (MarkBind fragment)
+
 ## Build the static site
 
 ```

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -179,7 +179,7 @@ Parser.prototype._preprocess = function (node, context, config) {
       return createErrorNode(element, e);
     }
 
-    const isIncludeSrcMd = utils.getExtName(filePath) === 'md';
+    const isIncludeSrcMd = utils.isMarkdownFileExt(utils.getExt(filePath));
 
     if (isIncludeSrcMd && context.source === 'html') {
       // HTML include markdown, use special tag to indicate markdown code.
@@ -375,8 +375,8 @@ Parser.prototype.includeFile = function (file, config) {
       const { parent, relative } = calculateNewBaseUrls(file, config.rootPath, config.baseUrlMap);
       const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
       const fileContent = nunjucks.renderString(data, userDefinedVariables);
-      const fileExt = utils.getExtName(file);
-      if (fileExt === 'md') {
+      const fileExt = utils.getExt(file);
+      if (utils.isMarkdownFileExt(fileExt)) {
         context.source = 'md';
         parser.parseComplete(fileContent.toString());
       } else if (fileExt === 'html') {
@@ -430,8 +430,8 @@ Parser.prototype.renderFile = function (file, config) {
         reject(err);
         return;
       }
-      const fileExt = utils.getExtName(file);
-      if (fileExt === 'md') {
+      const fileExt = utils.getExt(file);
+      if (utils.isMarkdownFileExt(fileExt)) {
         const inputData = md.render(data.toString());
         context.source = 'md';
         parser.parseComplete(inputData);

--- a/lib/markbind/lib/utils.js
+++ b/lib/markbind/lib/utils.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const markdownFileExts = ['md', 'mbd', 'mbdf'];
+
 module.exports = {
   getCurrentDirectoryBase() {
     return path.basename(process.cwd());
@@ -22,7 +24,7 @@ module.exports = {
     }
   },
 
-  getExtName(file) {
+  getExt(file) {
     const ext = file.split('.').pop();
     if (!ext || ext === file) {
       return '';
@@ -42,6 +44,10 @@ module.exports = {
       path.dirname(filename),
       path.basename(filename, path.extname(filename)) + ext,
     );
+  },
+
+  isMarkdownFileExt(ext) {
+    return markdownFileExts.includes(ext);
   },
 
   isUrl(filePath) {

--- a/lib/util/fsUtil.js
+++ b/lib/util/fsUtil.js
@@ -1,10 +1,10 @@
 const path = require('path');
 
+const sourceFileExtNames = ['.html', '.md', '.mbd', '.mbdf'];
+
 module.exports = {
-  isHtml: filePath => path.extname(filePath) === '.html',
-  isMarkdown: filePath => path.extname(filePath) === '.md',
   isSourceFile(filePath) {
-    return this.isMarkdown(filePath) || this.isHtml(filePath);
+    return sourceFileExtNames.includes(path.extname(filePath));
   },
 
   isInRoot: (root, fileName) => {

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -191,6 +191,13 @@ specification that specifies how the product will address the requirements. </sp
           <p>This is a HTML document</p>
           <p><span>It is <strong>possible</strong> to use Markdown in HTML</span></p>
         </div>
+        <h1 id="mbd-mbdf-include">Mbd, Mbdf include</h1>
+        <div>
+          <p><em>MarkBind supports .mbd files.</em></p>
+        </div>
+        <div>
+          <p><code>MarkBind supports .mbdf files.</code></p>
+        </div>
         <h1 id="include-from-another-markbind-site">Include from another Markbind site</h1>
         <div>
           <p>This is a page from another Markbind site.</p>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -33,6 +33,7 @@
         "boilerplate-include": "Boilerplate include",
         "nested-include": "Nested include",
         "html-include": "HTML include",
+        "mbd-mbdf-include": "Mbd, Mbdf include",
         "include-from-another-markbind-site": "Include from another Markbind site",
         "panel-without-src": "Panel without src",
         "panel-with-normal-src": "Panel with normal src",

--- a/test/test_site/expected/testIncludeMbd.mbd
+++ b/test/test_site/expected/testIncludeMbd.mbd
@@ -1,0 +1,1 @@
+*MarkBind supports .mbd files.*

--- a/test/test_site/expected/testIncludeMbdf.mbdf
+++ b/test/test_site/expected/testIncludeMbdf.mbdf
@@ -1,0 +1,1 @@
+`MarkBind supports .mbdf files.`

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -36,6 +36,10 @@ head: myCustomHead.md
 # HTML include
 <include src="testInclude.html" />
 
+# Mbd, Mbdf include
+<include src="testIncludeMbd.mbd" />
+<include src="testIncludeMbdf.mbdf" />
+
 # Include from another Markbind site
 <include src="sub_site/index.md" />
 

--- a/test/test_site/testIncludeMbd.mbd
+++ b/test/test_site/testIncludeMbd.mbd
@@ -1,0 +1,1 @@
+*MarkBind supports .mbd files.*

--- a/test/test_site/testIncludeMbdf.mbdf
+++ b/test/test_site/testIncludeMbdf.mbdf
@@ -1,0 +1,1 @@
+`MarkBind supports .mbdf files.`


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #331 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Certain markbind specific file extensions should be eligible for live preview

**What changes did you make? (Give an overview)**

Recognize`mbd` and `mbdf` file extensions as source files.