### PR TITLE
Allow including multiple head files

### DIFF
--- a/docs/userGuide/contentAuthoring.md
+++ b/docs/userGuide/contentAuthoring.md
@@ -434,9 +434,19 @@ alert("Welcome to my website!");
 
 Style elements placed at the bottom will override existing Bootstrap and MarkBind CSS styles if there is an overlap of selectors. 
 
+Multiple head files can be included within a page by providing a comma separated list:
+
+```html
+<frontmatter>
+  head: compiledRef.md, compiledRef2.md
+</frontmatter>
+```
+
+These will be added to `<head>` in the order in which they are listed. If the markdown head files contain scripts, this may affect the order in which they are run.
+
 Note:
   - You may specify raw `.js` or `.css` files as your head file if you wish to do so.
-  - Only one head file can be specified in a page, and you **must** include its file extension.
+  - You **must** include its file extension.
 
 ### Site Navigation
 

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -425,25 +425,34 @@ Page.prototype.collectHeadFiles = function (baseUrl, hostBaseUrl) {
   if (!head) {
     return;
   }
-  const headFilePath = path.join(this.rootPath, HEAD_FOLDER_PATH, head);
-  const headFileContent = fs.readFileSync(headFilePath, 'utf8');
-  // Set head file as an includedFile
-  this.includedFiles[headFilePath] = true;
-  // Map variables
-  const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
-  const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
-  const headFileMappedData = nunjucks.renderString(headFileContent, userDefinedVariables).trim();
-  // Split top and bottom contents
-  const $ = cheerio.load(headFileMappedData, { xmlMode: false });
-  if ($('head-top').length) {
-    this.headFileTopContent = nunjucks.renderString($('head-top').html(), { baseUrl, hostBaseUrl })
+  const headFiles = head.replace(/, */g, ',').split(',');
+  const collectedTopContent = [];
+  const collectedBottomContent = [];
+  headFiles.forEach((headFile) => {
+    const headFilePath = path.join(this.rootPath, HEAD_FOLDER_PATH, headFile);
+    const headFileContent = fs.readFileSync(headFilePath, 'utf8');
+    // Set head file as an includedFile
+    this.includedFiles[headFilePath] = true;
+    // Map variables
+    const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
+    const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
+    const headFileMappedData = nunjucks.renderString(headFileContent, userDefinedVariables).trim();
+    // Split top and bottom contents
+    const $ = cheerio.load(headFileMappedData, { xmlMode: false });
+    if ($('head-top').length) {
+      collectedTopContent.push(nunjucks.renderString($('head-top').html(), { baseUrl, hostBaseUrl })
+        .trim()
+        .replace(/\n\s*\n/g, '\n')
+        .replace(/\n/g, '\n    '));
+      $('head-top').remove();
+    }
+    collectedBottomContent.push(nunjucks.renderString($.html(), { baseUrl, hostBaseUrl })
       .trim()
-      .replace(/\n\s*\n/g, '\n');
-    $('head-top').remove();
-  }
-  this.headFileBottomContent = nunjucks.renderString($.html(), { baseUrl, hostBaseUrl })
-    .trim()
-    .replace(/\n\s*\n/g, '\n');
+      .replace(/\n\s*\n/g, '\n')
+      .replace(/\n/g, '\n    '));
+  });
+  this.headFileTopContent = collectedTopContent.join('\n    ');
+  this.headFileBottomContent = collectedBottomContent.join('\n    ');
 };
 
 Page.prototype.generate = function (builtFiles) {

--- a/test/test_site/_markbind/head/myCustomHead2.md
+++ b/test/test_site/_markbind/head/myCustomHead2.md
@@ -1,0 +1,17 @@
+<!-- Start of bottom level head file content insertion -->
+ 
+<head-top>
+
+<!-- Start of top level head file content insertion -->
+
+<script src="{{baseUrl}}/headFiles/customScriptTop2.js"></script>
+
+
+<!-- End of top level head file content insertion -->
+</head-top>
+
+<script src="{{baseUrl}}/headFiles/customScriptBottom2.js"></script>
+
+
+
+<!-- End of bottom level head file content insertion

--- a/test/test_site/expected/headFiles/customScriptBottom2.js
+++ b/test/test_site/expected/headFiles/customScriptBottom2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('second custom script inserted into bottom of head successfully!');

--- a/test/test_site/expected/headFiles/customScriptTop2.js
+++ b/test/test_site/expected/headFiles/customScriptTop2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('second custom script inserted into top of head successfully!');

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -2,8 +2,11 @@
 <html>
 <head>
     <!-- Start of top level head file content insertion -->
-<script src="/test_site/headFiles/customScriptTop.js"></script>
-<!-- End of top level head file content insertion -->
+    <script src="/test_site/headFiles/customScriptTop.js"></script>
+    <!-- End of top level head file content insertion -->
+    <!-- Start of top level head file content insertion -->
+    <script src="/test_site/headFiles/customScriptTop2.js"></script>
+    <!-- End of top level head file content insertion -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -16,8 +19,11 @@
     <link rel="stylesheet" href="markbind\css\markbind.css">
     <link rel="stylesheet" href="markbind\css\site-nav.css">
     <!-- Start of bottom level head file content insertion -->
-<script src="/test_site/headFiles/customScriptBottom.js"></script>
-<!-- End of bottom level head file content insertion-->
+    <script src="/test_site/headFiles/customScriptBottom.js"></script>
+    <!-- End of bottom level head file content insertion-->
+    <!-- Start of bottom level head file content insertion -->
+    <script src="/test_site/headFiles/customScriptBottom2.js"></script>
+    <!-- End of bottom level head file content insertion-->
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -51,7 +51,7 @@
       "title": "Hello World",
       "footer": "footer.md",
       "siteNav": "site-nav.md",
-      "head": "myCustomHead.md",
+      "head": "myCustomHead.md, myCustomHead2.md",
       "src": "index.md"
     },
     {

--- a/test/test_site/headFiles/customScriptBottom2.js
+++ b/test/test_site/headFiles/customScriptBottom2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('second custom script inserted into bottom of head successfully!');

--- a/test/test_site/headFiles/customScriptTop2.js
+++ b/test/test_site/headFiles/customScriptTop2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.info('second custom script inserted into top of head successfully!');

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -2,7 +2,7 @@
 title: Hello World
 footer: footer.md
 siteNav: site-nav.md
-head: myCustomHead.md
+head: myCustomHead.md, myCustomHead2.md
 </frontmatter>
 
 <include src="components/header.md" />


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] New feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #382 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Allow users to include multiple head files for a page

**What changes did you make? (Give an overview)**

Users can provide a comma separated list of head files within the frontmatter to include multiple file contents

**Provide some example code that this change will affect:**

In `.md`:
```
<frontmatter>
head: analytics.md, styles.md, flat.md
</frontmatter>
```

These will be added to the `head` in order
```
<head>
    <analytics head top>
    <styles head top>
    <flat head top>
    ... other files ...
    <analytics head bottom>
    <styles head bottom>
    <flat head bottom>
</head>
```
