### PR TITLE
Allow custom site.json path

### DIFF
--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -42,8 +42,6 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
 | --no-open | Don't open browser automatically. |
 
-Note: The site config file must be in the root folder.
-
 Note: Live reload is only supported for the following file types:
 
 - `.html`

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -37,7 +37,9 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 
 | Options | Description |
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
+| `-s`, `--site-config <filepath>` | Specify a custom filepath for site.json. |
 | --no-open | Don't open browser automatically. |
 
 Note: Live reload is only supported for the following file types:

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -39,8 +39,10 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 |----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
-| `-s`, `--site-config <filepath>` | Specify a custom filepath for site.json. |
+| `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
 | --no-open | Don't open browser automatically. |
+
+Note: The site config file must be in the root folder.
 
 Note: Live reload is only supported for the following file types:
 

--- a/docs/userGuide/userQuickStart.md
+++ b/docs/userGuide/userQuickStart.md
@@ -104,7 +104,7 @@ Live reload is enabled to regenerate the site for changes, so you could see the 
 |---|---|
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
-| `-s`, `--site-config <filepath>` | Specify a custom filepath for site.json. |
+| `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
 | --no-open | Don't open browser automatically. |
 
 ### Build the static site

--- a/docs/userGuide/userQuickStart.md
+++ b/docs/userGuide/userQuickStart.md
@@ -104,6 +104,7 @@ Live reload is enabled to regenerate the site for changes, so you could see the 
 |---|---|
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
+| `-s`, `--site-config <filepath>` | Specify a custom filepath for site.json. |
 | --no-open | Don't open browser automatically. |
 
 ### Build the static site

--- a/index.js
+++ b/index.js
@@ -129,13 +129,14 @@ program
   .description('build then serve a website from a directory')
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
+  .option('-s, --site-config <filepath>', 'specify a custom filepath for site.json')
   .option('--no-open', 'do not automatically open the site in browser')
   .action((root, options) => {
     const rootFolder = path.resolve(root || process.cwd());
     const logsFolder = path.join(rootFolder, '_markbind/logs');
     const outputFolder = path.join(rootFolder, '_site');
 
-    const site = new Site(rootFolder, outputFolder, options.forceReload);
+    const site = new Site(rootFolder, outputFolder, options.forceReload, options.siteConfig);
 
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ program
   .description('build then serve a website from a directory')
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
-  .option('-s, --site-config <filepath>', 'specify a custom filepath for site.json')
+  .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
   .option('--no-open', 'do not automatically open the site in browser')
   .action((root, options) => {
     const rootFolder = path.resolve(root || process.cwd());

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -100,7 +100,7 @@ const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
-  const configPath = findUp.sync(SITE_CONFIG_NAME, { cwd: rootPath });
+  const configPath = findUp.sync(siteConfigPath, { cwd: rootPath });
   this.rootPath = configPath ? path.dirname(configPath) : rootPath;
   this.outputPath = outputPath;
   this.tempPath = path.join(rootPath, TEMP_FOLDER_NAME);

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -2,7 +2,6 @@
 
 const cheerio = require('cheerio');
 const ejs = require('ejs');
-const findUp = require('find-up');
 const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
@@ -99,9 +98,8 @@ const GENERATE_SITE_LOGGING_KEY = 'Generate Site';
 const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
-function Site(rootPath, outputPath, forceReload = false) {
-  const configPath = findUp.sync(SITE_CONFIG_NAME, { cwd: rootPath });
-  this.rootPath = configPath ? path.dirname(configPath) : rootPath;
+function Site(rootPath, outputPath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
+  this.rootPath = rootPath;
   this.outputPath = outputPath;
   this.tempPath = path.join(rootPath, TEMP_FOLDER_NAME);
 
@@ -119,6 +117,7 @@ function Site(rootPath, outputPath, forceReload = false) {
   this.baseUrlMap = {};
   this.forceReload = forceReload;
   this.siteConfig = {};
+  this.siteConfigPath = siteConfigPath;
   this.userDefinedVariablesMap = {};
 }
 
@@ -235,7 +234,7 @@ Site.initSite = function (rootPath) {
 
 Site.prototype.readSiteConfig = function (baseUrl) {
   return new Promise((resolve, reject) => {
-    const siteConfigPath = path.join(this.rootPath, SITE_CONFIG_NAME);
+    const siteConfigPath = path.join(this.rootPath, this.siteConfigPath);
     fs.readJsonAsync(siteConfigPath)
       .then((config) => {
         this.siteConfig = config;
@@ -243,7 +242,7 @@ Site.prototype.readSiteConfig = function (baseUrl) {
         resolve(this.siteConfig);
       })
       .catch((err) => {
-        reject(new Error('Failed to read the site config file \'site.json\' at'
+        reject(new Error(`Failed to read the site config file '${this.siteConfigPath}' at`
           + `${this.rootPath}:\n${err.message}\nPlease ensure the file exist or is valid`));
       });
   });
@@ -332,7 +331,7 @@ Site.prototype.collectAddressablePages = function () {
 Site.prototype.collectBaseUrl = function () {
   const candidates
     = walkSync(this.rootPath, { directories: false })
-      .filter(x => x.endsWith(SITE_CONFIG_NAME))
+      .filter(x => x.endsWith(this.siteConfigPath))
       .map(x => path.resolve(this.rootPath, x));
 
   this.baseUrlMap = candidates.reduce((pre, now) => {

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -2,6 +2,7 @@
 
 const cheerio = require('cheerio');
 const ejs = require('ejs');
+const findUp = require('find-up');
 const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
@@ -99,7 +100,8 @@ const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
-  this.rootPath = rootPath;
+  const configPath = findUp.sync(SITE_CONFIG_NAME, { cwd: rootPath });
+  this.rootPath = configPath ? path.dirname(configPath) : rootPath;
   this.outputPath = outputPath;
   this.tempPath = path.join(rootPath, TEMP_FOLDER_NAME);
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #434 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Users may want to specify a custom path for the site.json

**What changes did you make? (Give an overview)**

Added a `--site-config filepath` option to `markbind serve` that allows user to specify filepath.

**Is there anything you'd like reviewers to focus on?**

I changed some behavior in the Site.js constructor (line 100~) since folder paths (like `config/site.json` were failing. Would this work? Alternatively we can ban `/` in the site.json path.