### PR TITLE
Fix keyword with included heading

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -202,14 +202,21 @@ Page.prototype.prepareTemplateData = function () {
  * @param element to find closest heading
  */
 function getClosestHeading($, headingsSelector, element) {
-  const prevHeadings = $(element).prevAll(headingsSelector);
-  if ($(prevHeadings).length === 0) {
-    if ($(element).parent().length === 0) {
-      return null;
+  const prevElements = $(element).prevAll();
+  for (let i = 0; i < prevElements.length; i += 1) {
+    const currentElement = $(prevElements[i]);
+    if (currentElement.is(headingsSelector)) {
+      return currentElement;
     }
-    return getClosestHeading($, headingsSelector, $(element).parent());
+    const childHeadings = currentElement.find(headingsSelector);
+    if (childHeadings.length > 0) {
+      return childHeadings.last();
+    }
   }
-  return prevHeadings.first();
+  if ($(element).parent().length === 0) {
+    return null;
+  }
+  return getClosestHeading($, headingsSelector, $(element).parent());
 }
 
 /**

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -154,6 +154,10 @@
         <div>
           <p><span class="keyword">included keyword</span></p>
         </div>
+        <div>
+          <h1 id="included-heading">Included Heading<a class="fa fa-anchor" href="#included-heading"></a></h1>
+        </div>
+        <span class="keyword">Keyword with included heading</span>
         <h1 id="heading-with-nested-keyword">Heading with nested keyword<a class="fa fa-anchor" href="#heading-with-nested-keyword"></a></h1>
         <div>
           <div>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -26,6 +26,7 @@
         "heading-with-multiple-keywords": "Heading with multiple keywords | keyword 1, keyword 2",
         "heading-with-keyword-in-panel": "Heading with keyword in panel | panel keyword",
         "heading-with-included-keyword": "Heading with included keyword | included keyword",
+        "included-heading": "Included Heading | Keyword with included heading",
         "heading-with-nested-keyword": "Heading with nested keyword | nested keyword",
         "normal-include": "Normal include",
         "establishing-requirements": "Establishing Requirements",

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -28,6 +28,9 @@ head: myCustomHead.md, myCustomHead2.md
 # Heading with included keyword
 <include src="testKeyword.md" />
 
+<include src="testKeywordHeading.md" />
+<span class="keyword">Keyword with included heading</span>
+
 # Heading with nested keyword
 <div>
   <div>

--- a/test/test_site/testKeywordHeading.md
+++ b/test/test_site/testKeywordHeading.md
@@ -1,0 +1,1 @@
+# Included Heading


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #443 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

The issue was that the included headings are wrapped in a divs:

![image](https://user-images.githubusercontent.com/19278089/46349263-24c9fc80-c684-11e8-9e8c-028d32fde177.png)

I've modified the logic so it also checks the children of previous elements for headings.

Added a test to match.
