### PR TITLE
Fix keyword with panel headings

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -231,7 +231,7 @@ function getClosestHeading($, headingsSelector, element) {
  */
 Page.prototype.collectHeadingsAndKeywords = function () {
   const $ = cheerio.load(fs.readFileSync(this.resultPath));
-  this.collectHeadingsAndKeywordsInContent($(`#${CONTENT_WRAPPER_ID}`).html(), null);
+  this.collectHeadingsAndKeywordsInContent($(`#${CONTENT_WRAPPER_ID}`).html(), null, false);
 };
 
 /**
@@ -250,54 +250,59 @@ function generateHeadingSelector(headingIndexingLevel) {
  * Records headings and keywords inside content into this.headings and this.keywords respectively
  * @param content that contains the headings and keywords
  */
-Page.prototype.collectHeadingsAndKeywordsInContent = function (content, lastHeading) {
+Page.prototype.collectHeadingsAndKeywordsInContent = function (content, lastHeading, excludeHeadings) {
   let $ = cheerio.load(content);
   const headingsSelector = generateHeadingSelector(this.headingIndexingLevel);
   $('modal').remove();
   $('panel').not('panel panel')
     .each((index, panel) => {
       if (panel.attribs.header) {
-        let closestHeading = getClosestHeading($, headingsSelector, panel);
-        if (!closestHeading) {
-          closestHeading = lastHeading;
-        }
-        this.collectHeadingsAndKeywordsInContent(md.render(panel.attribs.header), closestHeading);
+        this.collectHeadingsAndKeywordsInContent(md.render(panel.attribs.header),
+                                                 lastHeading, excludeHeadings);
       }
     })
-    .filter((index, panel) => panel.attribs.expanded !== undefined)
     .each((index, panel) => {
+      const shouldExcludeHeadings = excludeHeadings || (panel.attribs.expanded === undefined);
       let closestHeading = getClosestHeading($, headingsSelector, panel);
       if (!closestHeading) {
         closestHeading = lastHeading;
       }
+      if (panel.attribs.header) {
+        const panelHeader = md.render(panel.attribs.header);
+        if ($(panelHeader).is(headingsSelector)) {
+          closestHeading = $(panelHeader);
+        }
+      }
       if (panel.attribs.src) {
         const src = panel.attribs.src.split('#')[0];
         const includePath = path.resolve(this.resultPath,
-                                         path.relative(this.sourcePath,
-                                                       this.baseUrl
-                                                         ? path.relative(this.baseUrl, src)
-                                                         : src.substring(1)));
+                                         this.baseUrl
+                                           ? path.relative(this.sourcePath, path.relative(this.baseUrl, src))
+                                           : path.relative(path.dirname(this.sourcePath), src.substring(1)));
         const includeContent = fs.readFileSync(includePath);
         if (panel.attribs.fragment) {
           $ = cheerio.load(includeContent);
-          this.collectHeadingsAndKeywordsInContent($(`#${panel.attribs.fragment}`).html(), closestHeading);
+          this.collectHeadingsAndKeywordsInContent($(`#${panel.attribs.fragment}`).html(),
+                                                   closestHeading, shouldExcludeHeadings);
         } else {
-          this.collectHeadingsAndKeywordsInContent(includeContent, closestHeading);
+          this.collectHeadingsAndKeywordsInContent(includeContent, closestHeading, shouldExcludeHeadings);
         }
       } else {
-        this.collectHeadingsAndKeywordsInContent($(panel).html(), closestHeading);
+        this.collectHeadingsAndKeywordsInContent($(panel).html(), closestHeading, shouldExcludeHeadings);
       }
     });
   $ = cheerio.load(content);
   if (this.headingIndexingLevel > 0) {
     $('modal').remove();
     $('panel').remove();
-    $(headingsSelector).each((i, heading) => {
-      this.headings[$(heading).attr('id')] = $(heading).text();
-    });
+    if (!excludeHeadings) {
+      $(headingsSelector).each((i, heading) => {
+        this.headings[$(heading).attr('id')] = $(heading).text();
+      });
+    }
     $('.keyword').each((i, keyword) => {
       let closestHeading = getClosestHeading($, headingsSelector, keyword);
-      if (!closestHeading) {
+      if (excludeHeadings || !closestHeading) {
         if (!lastHeading) {
           logger.warn(`Missing heading for keyword: ${$(keyword).text()}`);
           return;

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -275,10 +275,11 @@ Page.prototype.collectHeadingsAndKeywordsInContent = function (content, lastHead
       }
       if (panel.attribs.src) {
         const src = panel.attribs.src.split('#')[0];
-        const includePath = path.resolve(this.resultPath,
-                                         this.baseUrl
-                                           ? path.relative(this.sourcePath, path.relative(this.baseUrl, src))
-                                           : path.relative(path.dirname(this.sourcePath), src.substring(1)));
+
+        const srcPath = path.relative(path.dirname(this.sourcePath),
+                                      path.relative(this.baseUrl.substring(1), src.substring(1)));
+        const includePath = path.resolve(path.dirname(this.resultPath),
+                                         this.baseUrl ? srcPath : srcPath.substring(3));
         const includeContent = fs.readFileSync(includePath);
         if (panel.attribs.fragment) {
           $ = cheerio.load(includeContent);

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -276,10 +276,15 @@ Page.prototype.collectHeadingsAndKeywordsInContent = function (content, lastHead
       if (panel.attribs.src) {
         const src = panel.attribs.src.split('#')[0];
 
-        const srcPath = path.relative(path.dirname(this.sourcePath),
-                                      path.relative(this.baseUrl.substring(1), src.substring(1)));
-        const includePath = path.resolve(path.dirname(this.resultPath),
-                                         this.baseUrl ? srcPath : srcPath.substring(3));
+        const buildInnerDir = path.dirname(this.sourcePath);
+        const resultInnerDir = path.dirname(this.resultPath);
+        const includeRelativeToBuildRootDirPath
+          = this.baseUrl ? path.relative(this.baseUrl, src) : src.substring(1);
+        const includeAbsoluteToBuildRootDirPath
+          = path.resolve(this.rootPath, includeRelativeToBuildRootDirPath);
+        const includeRelativeToInnerDirPath = path.relative(buildInnerDir, includeAbsoluteToBuildRootDirPath);
+        const includePath = path.resolve(resultInnerDir, includeRelativeToInnerDirPath);
+
         const includeContent = fs.readFileSync(includePath);
         if (panel.attribs.fragment) {
           $ = cheerio.load(includeContent);

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -151,6 +151,19 @@
         <h1 id="heading-with-keyword-in-panel">Heading with keyword in panel<a class="fa fa-anchor" href="#heading-with-keyword-in-panel"></a></h1>
         <panel header="Panel with keyword" expanded="">
           <span class="keyword">panel keyword</span></panel>
+        <h1 id="panel-with-heading-with-keyword">Panel with heading with keyword<a class="fa fa-anchor" href="#panel-with-heading-with-keyword"></a></h1>
+        <panel header="# Panel with heading<a class='fa fa-anchor' href='#panel-with-heading'></a>" expanded="">
+          <span class="keyword">panel keyword</span></panel>
+        <h1 id="expanded-panel-without-heading-with-keyword">Expanded panel without heading with keyword<a class="fa fa-anchor" href="#expanded-panel-without-heading-with-keyword"></a></h1>
+        <panel header="# Panel without heading with keyword<a class='fa fa-anchor' href='#panel-without-heading-with-keyword'></a>" expanded="">
+          <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading">Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading"></a></h1>
+          <p><span class="keyword">panel keyword</span></p>
+        </panel>
+        <h1 id="unexpanded-panel-with-heading-with-keyword">Unexpanded panel with heading with keyword<a class="fa fa-anchor" href="#unexpanded-panel-with-heading-with-keyword"></a></h1>
+        <panel header="# Panel with heading with keyword<a class='fa fa-anchor' href='#panel-with-heading-with-keyword'></a>">
+          <h1 id="keyword-should-be-tagged-to-the-panel-heading-not-this-heading">Keyword should be tagged to the panel heading, not this heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-the-panel-heading-not-this-heading"></a></h1>
+          <p><span class="keyword">panel keyword</span></p>
+        </panel>
         <h1 id="heading-with-included-keyword">Heading with included keyword<a class="fa fa-anchor" href="#heading-with-included-keyword"></a></h1>
         <div>
           <p><span class="keyword">included keyword</span></p>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -2,6 +2,9 @@
   "pages": [
     {
       "headings": {
+        "panel-with-heading": "Panel with heading | panel keyword",
+        "panel-without-heading-with-keyword": "Panel without heading with keyword",
+        "panel-with-heading-with-keyword": "Panel with heading with keyword | panel keyword",
         "panel-without-src-header": "Panel without src header",
         "panel-with-normal-src-header": "Panel with normal src header",
         "panel-with-src-from-a-page-segment-header": "Panel with src from a page segment header",
@@ -11,6 +14,7 @@
         "outer-nested-panel-without-src": "Outer nested panel without src",
         "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
         "unexpanded-panel-header": "Unexpanded panel header",
+        "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading | panel keyword",
         "panel-without-src-content-heading": "Panel without src content heading",
         "panel-normal-source-content-headings": "Panel normal source content headings",
         "panel-source-segment-content-headings": "Panel source segment content headings",
@@ -25,6 +29,8 @@
         "variables-that-reference-another-variable": "Variables that reference another variable",
         "heading-with-multiple-keywords": "Heading with multiple keywords | keyword 1, keyword 2",
         "heading-with-keyword-in-panel": "Heading with keyword in panel | panel keyword",
+        "expanded-panel-without-heading-with-keyword": "Expanded panel without heading with keyword",
+        "unexpanded-panel-with-heading-with-keyword": "Unexpanded panel with heading with keyword",
         "heading-with-included-keyword": "Heading with included keyword | included keyword",
         "included-heading": "Included Heading | Keyword with included heading",
         "heading-with-nested-keyword": "Heading with nested keyword | nested keyword",

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -26,6 +26,25 @@ layout: default
   <span class="keyword">panel keyword</span>
 </panel>
 
+# Panel with heading with keyword
+<panel header="# Panel with heading" expanded>
+  <span class="keyword">panel keyword</span>
+</panel>
+
+# Expanded panel without heading with keyword
+<panel header="# Panel without heading with keyword" expanded>
+
+  # Keyword should be tagged to this heading, not the panel heading
+  <span class="keyword">panel keyword</span>
+</panel>
+
+# Unexpanded panel with heading with keyword
+<panel header="# Panel with heading with keyword">
+
+  # Keyword should be tagged to the panel heading, not this heading
+  <span class="keyword">panel keyword</span>
+</panel>
+
 # Heading with included keyword
 <include src="testKeyword.md" />
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #444 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

The issue was that the panel was unexpanded, and those don't get indexed by search so keywords weren't indexed either.

Keywords should tag to the closest header that is indexed by the search data.

**What changes did you make? (Give an overview)**

Following behaviour applies for keywords within a panel:

If the panel is expanded:

- Keyword tags to the closest header within the panel if there is one
- Otherwise, keyword tags to the panel header if there is one (must have `#`)
- Otherwise, keyword tags to the closest header

If the panel is unexpanded:

- Keyword tags to the panel header if there is one, ignoring headers within the panel
- Otherwise, keyword tags to the closest header

Added tests for cases.
