### PR TITLE
Fix anchors for panel headers

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -15,7 +15,7 @@ function flattenModals() {
   });
 }
 
-function setupAnchorVisibility() {
+function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6').each((index, heading) => {
     jQuery(heading).on('mouseenter', function () {
       jQuery(this).children('.fa.fa-anchor').show();
@@ -24,12 +24,17 @@ function setupAnchorVisibility() {
       jQuery(this).children('.fa.fa-anchor').hide();
     });
   });
+  jQuery('.fa-anchor').each((index, anchor) => {
+    jQuery(anchor).on('click', function () {
+      window.location.href = jQuery(this).attr('href');
+    });
+  });
 }
 
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
-  setupAnchorVisibility();
+  setupAnchors();
 }
 
 function setupSiteNav() {

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -16,13 +16,9 @@ function flattenModals() {
 }
 
 function setupAnchors() {
-  jQuery('h1, h2, h3, h4, h5, h6').each((index, heading) => {
-    jQuery(heading).on('mouseenter', function () {
-      jQuery(this).children('.fa.fa-anchor').show();
-    });
-    jQuery(heading).on('mouseleave', function () {
-      jQuery(this).children('.fa.fa-anchor').hide();
-    });
+  jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
+    jQuery(heading).on('mouseenter', () => jQuery(heading).find('.fa.fa-anchor').show());
+    jQuery(heading).on('mouseleave', () => jQuery(heading).find('.fa.fa-anchor').hide());
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -330,6 +330,14 @@ Page.prototype.addAnchors = function (content) {
     $(headingsSelector).each((i, heading) => {
       $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
     });
+    $('panel[header]').each((i, panel) => {
+      const panelHeading = cheerio.load(md.render(panel.attribs.header), { xmlMode: false });
+      if (panelHeading(headingsSelector).length >= 1) {
+        const headingId = $(panelHeading(headingsSelector)[0]).attr('id');
+        const anchorIcon = ANCHOR_HTML.replace(/"/g, "'").replace('#', `#${headingId}`);
+        $(panel).attr('header', `${$(panel).attr('header')}${anchorIcon}`);
+      }
+    });
   }
   return $.html();
 };

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -235,43 +235,43 @@ specification that specifies how the product will address the requirements. </sp
           </ol>
           <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
         <h1 id="panel-without-src">Panel without src<a class="fa fa-anchor" href="#panel-without-src"></a></h1>
-        <panel header="## Panel without src header" expanded="">
+        <panel header="## Panel without src header<a class='fa fa-anchor' href='#panel-without-src-header'></a>" expanded="">
           <div>
             <h3 id="panel-without-src-content-heading">Panel without src content heading<a class="fa fa-anchor" href="#panel-without-src-content-heading"></a></h3>
           </div>
         </panel>
         <h1 id="panel-with-normal-src">Panel with normal src<a class="fa fa-anchor" href="#panel-with-normal-src"></a></h1>
-        <panel header="## Panel with normal src header" src="/test_site\testPanels\PanelNormalSource._include_.html" expanded=""></panel>
+        <panel header="## Panel with normal src header<a class='fa fa-anchor' href='#panel-with-normal-src-header'></a>" src="/test_site\testPanels\PanelNormalSource._include_.html" expanded=""></panel>
         <h1 id="panel-with-src-from-a-page-segment">Panel with src from a page segment<a class="fa fa-anchor" href="#panel-with-src-from-a-page-segment"></a></h1>
-        <panel header="## Panel with src from a page segment header" src="/test_site\testPanels\PanelSourceContainsSegment._include_.html#segment" expanded="" fragment="segment"></panel>
+        <panel header="## Panel with src from a page segment header<a class='fa fa-anchor' href='#panel-with-src-from-a-page-segment-header'></a>" src="/test_site\testPanels\PanelSourceContainsSegment._include_.html#segment" expanded="" fragment="segment"></panel>
         <h1 id="panel-with-boilerplate">Panel with boilerplate<a class="fa fa-anchor" href="#panel-with-boilerplate"></a></h1>
-        <panel header="## Boilerplate referencing" src="/test_site\testPanels\boilerTestPanel._include_.html" expanded=""></panel>
-        <panel header="## Referencing specified path in boilerplate" src="/test_site\testPanels\notInside._include_.html" expanded=""></panel>
+        <panel header="## Boilerplate referencing<a class='fa fa-anchor' href='#boilerplate-referencing'></a>" src="/test_site\testPanels\boilerTestPanel._include_.html" expanded=""></panel>
+        <panel header="## Referencing specified path in boilerplate<a class='fa fa-anchor' href='#referencing-specified-path-in-boilerplate'></a>" src="/test_site\testPanels\notInside._include_.html" expanded=""></panel>
         <h1 id="nested-panel">Nested panel<a class="fa fa-anchor" href="#nested-panel"></a></h1>
-        <panel header="## Outer nested panel" src="/test_site\testPanels\NestedPanel._include_.html" expanded=""></panel>
+        <panel header="## Outer nested panel<a class='fa fa-anchor' href='#outer-nested-panel'></a>" src="/test_site\testPanels\NestedPanel._include_.html" expanded=""></panel>
         <h1 id="nested-panel-without-src">Nested panel without src<a class="fa fa-anchor" href="#nested-panel-without-src"></a></h1>
-        <panel header="## Outer nested panel without src" expanded="">
+        <panel header="## Outer nested panel without src<a class='fa fa-anchor' href='#outer-nested-panel-without-src'></a>" expanded="">
           <h2 id="panel-content-of-outer-nested-panel">Panel content of outer nested panel<a class="fa fa-anchor" href="#panel-content-of-outer-nested-panel"></a></h2>
-          <panel header="## Inner panel header without src" expanded="">
+          <panel header="## Inner panel header without src<a class='fa fa-anchor' href='#inner-panel-header-without-src'></a>" expanded="">
             <h2 id="panel-content-of-inner-nested-panel">Panel content of inner nested panel<a class="fa fa-anchor" href="#panel-content-of-inner-nested-panel"></a></h2>
           </panel>
         </panel>
         <h1 id="panel-with-src-from-another-markbind-site">Panel with src from another Markbind site<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site"></a></h1>
-        <panel header="## Panel with src from another Markbind site header" src="/test_site\sub_site\index._include_.html" expanded=""></panel>
+        <panel header="## Panel with src from another Markbind site header<a class='fa fa-anchor' href='#panel-with-src-from-another-markbind-site-header'></a>" src="/test_site\sub_site\index._include_.html" expanded=""></panel>
       </div>
       <h1 id="modal-with-panel-inside">Modal with panel inside<a class="fa fa-anchor" href="#modal-with-panel-inside"></a></h1>
       <p>
         <trigger for="modal-with-panel">trigger</trigger>
       </p>
       <modal title="modal title with panel inside" id="modal-with-panel">
-        <panel header="## Panel inside modal" expanded="">
+        <panel header="## Panel inside modal<a class='fa fa-anchor' href='#panel-inside-modal'></a>" expanded="">
           <h2 id="panel-content-inside-modal">Panel content inside modal<a class="fa fa-anchor" href="#panel-content-inside-modal"></a></h2>
         </panel>
       </modal>
       <h1 id="unexpanded-panel">Unexpanded panel<a class="fa fa-anchor" href="#unexpanded-panel"></a></h1>
-      <panel header="## Unexpanded panel header">
+      <panel header="## Unexpanded panel header<a class='fa fa-anchor' href='#unexpanded-panel-header'></a>">
         <h2 id="panel-content-of-unexpanded-panel-should-not-appear-in-search-data">Panel content of unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-content-of-unexpanded-panel-should-not-appear-in-search-data"></a></h2>
-        <panel header="## Panel header inside unexpanded panel should not appear in search data" expanded="">
+        <panel header="## Panel header inside unexpanded panel should not appear in search data<a class='fa fa-anchor' href='#panel-header-inside-unexpanded-panel-should-not-appear-in-search-data'></a>" expanded="">
           <h2 id="panel-content-inside-unexpanded-panel-should-not-appear-in-search-data">Panel content inside unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-content-inside-unexpanded-panel-should-not-appear-in-search-data"></a></h2>
         </panel>
       </panel>

--- a/test/test_site/expected/markbind/js/setup.js
+++ b/test/test_site/expected/markbind/js/setup.js
@@ -15,7 +15,7 @@ function flattenModals() {
   });
 }
 
-function setupAnchorVisibility() {
+function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6').each((index, heading) => {
     jQuery(heading).on('mouseenter', function () {
       jQuery(this).children('.fa.fa-anchor').show();
@@ -24,12 +24,17 @@ function setupAnchorVisibility() {
       jQuery(this).children('.fa.fa-anchor').hide();
     });
   });
+  jQuery('.fa-anchor').each((index, anchor) => {
+    jQuery(anchor).on('click', function () {
+      window.location.href = jQuery(this).attr('href');
+    });
+  });
 }
 
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
-  setupAnchorVisibility();
+  setupAnchors();
 }
 
 function setupSiteNav() {

--- a/test/test_site/expected/markbind/js/setup.js
+++ b/test/test_site/expected/markbind/js/setup.js
@@ -16,13 +16,9 @@ function flattenModals() {
 }
 
 function setupAnchors() {
-  jQuery('h1, h2, h3, h4, h5, h6').each((index, heading) => {
-    jQuery(heading).on('mouseenter', function () {
-      jQuery(this).children('.fa.fa-anchor').show();
-    });
-    jQuery(heading).on('mouseleave', function () {
-      jQuery(this).children('.fa.fa-anchor').hide();
-    });
+  jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
+    jQuery(heading).on('mouseenter', () => jQuery(heading).find('.fa.fa-anchor').show());
+    jQuery(heading).on('mouseleave', () => jQuery(heading).find('.fa.fa-anchor').hide());
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #442 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Anchors were not being generated for panel headers, and in a previous version do not redirect to the page when clicked.

**What changes did you make? (Give an overview)**

Anchors should now be generated for panel headers correctly.

The panel headers are stored in the panel's `header` attribute and rendered by vue, so headings weren't being picked up by `Page`. I worked around this by checking all panels for the `header` attribute and adding the anchor html there.

As for the links not working previously (see https://github.com/MarkBind/markbind/issues/442#issuecomment-425638038), I added some code to `setup.js` to manually redirect the page when an anchor is clicked, it seems to be working as expected now.