### PR TITLE
Account for closing html tags during diff

### DIFF
--- a/test/test_site/testUtil/diffHtml.js
+++ b/test/test_site/testUtil/diffHtml.js
@@ -21,16 +21,21 @@ const endsWithUnclosedPath = (fragment) => {
 /**
  * Checks if the ending portion of the fragment is inside an html tag
  * true: <tag src=".../
+ *       <panel header="<a>link</a>" src=".../
  * false: <text> src="..
  *        <div/>
+ *        <panel header="<a>link</a>"> src="...
  */
 const endsWithOpeningTag = (fragment) => {
+  let numUnmatchedClosingBracket = 0;
   for (let i = fragment.length - 1; i >= 0; i -= 1) {
-    if (fragment[i] === '<') {
-      return true;
-    }
     if (fragment[i] === '>') {
-      return false;
+      numUnmatchedClosingBracket += 1;
+    } else if (fragment[i] === '<') {
+      if (numUnmatchedClosingBracket === 0) {
+        return true;
+      }
+      numUnmatchedClosingBracket -= 1;
     }
   }
   return false;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Address the bug found in #454 where the diffing logic incorrectly identifies a diff outside a file path.


**What changes did you make? (Give an overview)**
The fragment that causes this is (note i've formatted it for readability)
```diff
<panel header="## Panel with src from another Markbind site header<a class='fa fa-anchor' href='#panel-with-src-from-another-markbind-site-header'></a>" 
src="/test_site
+/
-\
sub_site/index._include_.html" expanded=""></panel>
```
To decide if the diff `\` is found in a path, it checks if the diff
1. is within a path - checking if there is a preceding src=" (yes)
1. fragment is within a html tag
    * here i check if i find a `>` or `<` first.
        * if `<` is found, its within a html tag - diff is in path
        * **if `>` is found, assume not within html tag - diff is not in path (and this is incorrect for the case above)**

For the last case, instead of assuming not within html tag, we look to check if the `>` is "closed" by a `<`. If so, continue searching for `<`. 

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js

```

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**
For code snippet in above found above in `test/test_site/expected/index.html`, change the path separator and check that there is no diff error reported by running `npm run test`.