### PR TITLE
Support optional include

### DIFF
--- a/docs/userGuide/includingContents.md
+++ b/docs/userGuide/includingContents.md
@@ -25,11 +25,14 @@
 
     - `inline` (optional): make the included result an inline element. (wrapped in `<span>` tag)
 
+    - `optional` (optional): include the document only if it exists.
+
     Examples:
     ```html
     <include src="EstablishingRequirements.md#preview" inline/>
     <include src="../common/RequirementsVsSystemSpecification.md"/>
     <include src="../index.html" />
+    <include src="UserStories.md" optional/>
     ```
 
     <br/>

--- a/lib/markbind/lib/parser.js
+++ b/lib/markbind/lib/parser.js
@@ -68,6 +68,11 @@ function createErrorNode(element, error) {
   return Object.assign(element, _.pick(errorElement, ['name', 'attribs', 'children']));
 }
 
+function createEmptyNode() {
+  const emptyElement = cheerio.parseHTML('<div></div>', true)[0];
+  return emptyElement;
+}
+
 function isText(element) {
   return element.type === 'text' || element.type === 'comment';
 }
@@ -131,7 +136,11 @@ Parser.prototype._preprocess = function (node, context, config) {
       actualFilePath = calculateBoilerplateFilePath(element.attribs.boilerplate, filePath, config);
       this.boilerplateIncludeSrc.push({ from: context.cwf, to: actualFilePath });
     }
+    const isOptional = element.name === 'include' && _.hasIn(element.attribs, 'optional');
     if (!utils.fileExists(actualFilePath)) {
+      if (isOptional) {
+        return createEmptyNode();
+      }
       this.missingIncludeSrc.push({ from: context.cwf, to: actualFilePath });
       const error = new Error(
         `No such file: ${actualFilePath}\nMissing reference in ${element.attribs[ATTRIB_CWF]}`,
@@ -144,8 +153,14 @@ Parser.prototype._preprocess = function (node, context, config) {
   if (element.name === 'include') {
     const isInline = _.hasIn(element.attribs, 'inline');
     const isDynamic = _.hasIn(element.attribs, 'dynamic');
+    const isOptional = _.hasIn(element.attribs, 'optional');
     element.name = isInline ? 'span' : 'div';
     element.attribs[ATTRIB_INCLUDE_PATH] = filePath;
+
+    if (isOptional) {
+      // optional files have been handled earlier, so just delete the attribute here
+      delete element.attribs.optional;
+    }
 
     if (isDynamic) {
       element.name = 'panel';

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -55,6 +55,79 @@ test('includeFile replaces <include> with <div>', async () => {
   expect(result).toEqual(expected);
 });
 
+test('includeFile replaces <include src="exist.md" optional> with <div>', async () => {
+  const indexPath = path.resolve('index.md');
+  const existPath = path.resolve('exist.md');
+
+  const index = [
+    '# Index',
+    '<include src="exist.md" optional/>',
+    '',
+  ].join('\n');
+
+  const exist = ['# Exist'].join('\n');
+
+  const json = {
+    'index.md': index,
+    'exist.md': exist,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    `<div cwf="${indexPath}" include-path="${existPath}">`,
+    '',
+    '# Exist',
+    '</div>',
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
+test('includeFile replaces <include src="doesNotExist.md" optional> with empty <div>', async () => {
+  const indexPath = path.resolve('index.md');
+
+  const index = [
+    '# Index',
+    '<include src="doesNotExist.md" optional/>',
+    '',
+  ].join('\n');
+
+  const json = {
+    'index.md': index,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    '<div/>',
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
 test('includeFile replaces <include dynamic> with <panel>', async () => {
   const rootPath = path.resolve('');
   const indexPath = path.resolve('index.md');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Implements the `optional` attribute for `<include>` as suggested in #449 (originally suggested as `if-exists`).


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The `optional` attribute will allow authors to include documents only if they exist, simplifying the use of boilerplate that have sections not used by every document using the boilerplate.

**What changes did you make? (Give an overview)**
The `_preprocess` method in the parser was modified to only emit an error if the document does not exist and the document was included *without* the `optional` attribute. If a document included with `optional` does not exist, an empty `<div>` is emitted in its place with no errors.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<include src="exercises.md" optional/> 
```

**Testing instructions:**
1. If documents are included with the `optional` attribute, there will not be an error when the it does not exist and the page should render as normal.