### PR TITLE
Upgrade markdown-it-anchor to 5.0.0 and fix anchor tag scrolling

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -4,7 +4,8 @@ Vue.use(VueStrap);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
-    jQuery(window.location.hash)[0].scrollIntoView();
+    // remove leading hash to get element ID
+    document.getElementById(window.location.hash.slice(1)).scrollIntoView();
     window.scrollBy(0, -document.body.style.paddingTop.replace('px', ''));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5294,12 +5294,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-4.0.0.tgz",
-      "integrity": "sha1-6H+1VD4BllrfcVBsa/ewSRhBt+M=",
-      "requires": {
-        "string": "^3.3.3"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.0.tgz",
+      "integrity": "sha512-s3HuwE4KN+4N8gL8nLxMdPO+OXik7oJvqPgQoQNPhYMM4c0iI72n9XqNXG/bxQa8D+aU4Is2fcioryGRQ4QoLw=="
     },
     "markdown-it-emoji": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "live-server": "^1.2.0",
     "lodash": "^4.17.5",
     "markdown-it": "^8.3.0",
-    "markdown-it-anchor": "^4.0.0",
+    "markdown-it-anchor": "^5.0.0",
     "markdown-it-emoji": "^1.3.0",
     "markdown-it-imsize": "^2.0.1",
     "markdown-it-ins": "^2.0.0",

--- a/test/test_site/expected/bugs/index.html
+++ b/test/test_site/expected/bugs/index.html
@@ -27,7 +27,7 @@
     </navbar>
   </div>
   <div class="website-content">
-    <h2 id="popover-initiated-by-trigger-honor-trigger-attribute">popover initiated by trigger: honor trigger attribute<a class="fa fa-anchor" href="#popover-initiated-by-trigger-honor-trigger-attribute"></a></h2>
+    <h2 id="popover-initiated-by-trigger%3A-honor-trigger-attribute">popover initiated by trigger: honor trigger attribute<a class="fa fa-anchor" href="#popover-initiated-by-trigger%3A-honor-trigger-attribute"></a></h2>
     <p><a href="https://github.com/MarkBind/markbind/issues/49">Issue #49</a></p>
     <p>Repro:</p>
     <p>

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -156,12 +156,12 @@
           <span class="keyword">panel keyword</span></panel>
         <h1 id="expanded-panel-without-heading-with-keyword">Expanded panel without heading with keyword<a class="fa fa-anchor" href="#expanded-panel-without-heading-with-keyword"></a></h1>
         <panel header="# Panel without heading with keyword<a class='fa fa-anchor' href='#panel-without-heading-with-keyword'></a>" expanded="">
-          <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading">Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading"></a></h1>
+          <h1 id="keyword-should-be-tagged-to-this-heading%2C-not-the-panel-heading">Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading%2C-not-the-panel-heading"></a></h1>
           <p><span class="keyword">panel keyword</span></p>
         </panel>
         <h1 id="unexpanded-panel-with-heading-with-keyword">Unexpanded panel with heading with keyword<a class="fa fa-anchor" href="#unexpanded-panel-with-heading-with-keyword"></a></h1>
         <panel header="# Panel with heading with keyword<a class='fa fa-anchor' href='#panel-with-heading-with-keyword'></a>">
-          <h1 id="keyword-should-be-tagged-to-the-panel-heading-not-this-heading">Keyword should be tagged to the panel heading, not this heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-the-panel-heading-not-this-heading"></a></h1>
+          <h1 id="keyword-should-be-tagged-to-the-panel-heading%2C-not-this-heading">Keyword should be tagged to the panel heading, not this heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-the-panel-heading%2C-not-this-heading"></a></h1>
           <p><span class="keyword">panel keyword</span></p>
         </panel>
         <h1 id="heading-with-included-keyword">Heading with included keyword<a class="fa fa-anchor" href="#heading-with-included-keyword"></a></h1>
@@ -234,7 +234,7 @@ specification that specifies how the product will address the requirements. </sp
           <p>This is a HTML document</p>
           <p><span>It is <strong>possible</strong> to use Markdown in HTML</span></p>
         </div>
-        <h1 id="mbd-mbdf-include">Mbd, Mbdf include<a class="fa fa-anchor" href="#mbd-mbdf-include"></a></h1>
+        <h1 id="mbd%2C-mbdf-include">Mbd, Mbdf include<a class="fa fa-anchor" href="#mbd%2C-mbdf-include"></a></h1>
         <div>
           <p><em>MarkBind supports .mbd files.</em></p>
         </div>

--- a/test/test_site/expected/markbind/js/setup.js
+++ b/test/test_site/expected/markbind/js/setup.js
@@ -4,7 +4,8 @@ Vue.use(VueStrap);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
-    jQuery(window.location.hash)[0].scrollIntoView();
+    // remove leading hash to get element ID
+    document.getElementById(window.location.hash.slice(1)).scrollIntoView();
     window.scrollBy(0, -document.body.style.paddingTop.replace('px', ''));
   }
 }

--- a/test/test_site/expected/requirements/SpecifyingRequirements._include_.html
+++ b/test/test_site/expected/requirements/SpecifyingRequirements._include_.html
@@ -4,7 +4,7 @@
     The next phase is to convert requirements into a product specification that specifies how the product will address the requirements. </seg>
 </p>
 <p>Given next are some tools and techniques that can be used to specify requirements. Note that they can also be used for establishing requirements too.</p>
-<h2 id="textual-descriptions-unstructured-prose">Textual descriptions (unstructured prose)</h2>
+<h2 id="textual-descriptions-(unstructured-prose)">Textual descriptions (unstructured prose)</h2>
 <p>This is the most straight forward way of describing requirements. A textual description can be used to give a quick overview of the domain/system that is understandable to both the users and the development team. Textual descriptions are especially useful
   when describing the vision of a product. However, lengthy textual descriptions are hard to follow.</p>
 <h2 id="feature-list">Feature list</h2>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -14,7 +14,7 @@
         "outer-nested-panel-without-src": "Outer nested panel without src",
         "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
         "unexpanded-panel-header": "Unexpanded panel header",
-        "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading | panel keyword",
+        "keyword-should-be-tagged-to-this-heading%2C-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading | panel keyword",
         "panel-without-src-content-heading": "Panel without src content heading",
         "panel-normal-source-content-headings": "Panel normal source content headings",
         "panel-source-segment-content-headings": "Panel source segment content headings",
@@ -45,7 +45,7 @@
         "boilerplate-include": "Boilerplate include",
         "nested-include": "Nested include",
         "html-include": "HTML include",
-        "mbd-mbdf-include": "Mbd, Mbdf include",
+        "mbd%2C-mbdf-include": "Mbd, Mbdf include",
         "include-from-another-markbind-site": "Include from another Markbind site",
         "panel-without-src": "Panel without src",
         "panel-with-normal-src": "Panel with normal src",
@@ -74,7 +74,7 @@
     },
     {
       "headings": {
-        "popover-initiated-by-trigger-honor-trigger-attribute": "popover initiated by trigger: honor trigger attribute",
+        "popover-initiated-by-trigger%3A-honor-trigger-attribute": "popover initiated by trigger: honor trigger attribute",
         "support-multiple-inclusions-of-a-modal": "Support multiple inclusions of a modal",
         "remove-extra-space-in-links": "Remove extra space in links"
       },

--- a/test/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
+++ b/test/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
@@ -1,4 +1,4 @@
 <div id="segment">
   <h3 id="panel-source-segment-content-headings">Panel source segment content headings</h3>
 </div>
-<h3 id="this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data">This heading is not src of any panel, so it should not be in the search data</h3>
+<h3 id="this-heading-is-not-src-of-any-panel%2C-so-it-should-not-be-in-the-search-data">This heading is not src of any panel, so it should not be in the search data</h3>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of #413.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
`markdown-it-anchor@5.0.0` creates anchor tags with URL encoded characters when the heading contains special characters. For example, "Guideline: Avoid Unsafe Shortcuts" becomes `guideline%3A-avoid-unsafe-shortcuts`. This breaks the use of jQuery to scroll to the correct anchor as jQuery will not be able to locate elements with special characters in the `id`. This can be fixed by using `document.getElementById` to locate the element instead.

**What changes did you make? (Give an overview)**
Upgrade `markdown-it-anchor` to `^5.0.0` and use `document.getElementById` to locate the element to scroll to instead of jQuery.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```markdown
## Guideline: Avoid Unsafe Shortcuts
```
**Testing instructions:**
1. Create a markdown document with headers that have special characters eg. `:`. The anchor link should be able to scroll normally despite being generated from `markdown-it-anchor@5.0.0`.