### PR TITLE
Add serve --one-page option to live preview a single page

### DIFF
--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -40,6 +40,7 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
+| `--one-page <file>` | Render and serve only a single page from your website. |
 | --no-open | Don't open browser automatically. |
 
 Note: Live reload is only supported for the following file types:

--- a/docs/userGuide/userQuickStart.md
+++ b/docs/userGuide/userQuickStart.md
@@ -105,6 +105,7 @@ Live reload is enabled to regenerate the site for changes, so you could see the 
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
+| `--one-page <file>` | Render and serve only a single page from your website. |
 | --no-open | Don't open browser automatically. |
 
 ### Build the static site

--- a/index.js
+++ b/index.js
@@ -130,13 +130,20 @@ program
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
   .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
+  .option('--one-page <file>', 'render and serve only a single page in the site')
   .option('--no-open', 'do not automatically open the site in browser')
   .action((root, options) => {
     const rootFolder = path.resolve(root || process.cwd());
     const logsFolder = path.join(rootFolder, '_markbind/logs');
     const outputFolder = path.join(rootFolder, '_site');
 
-    const site = new Site(rootFolder, outputFolder, options.forceReload, options.siteConfig);
+    if (options.onePage) {
+      // replace slashes for paths on Windows
+      // eslint-disable-next-line no-param-reassign
+      options.onePage = fsUtil.ensurePosix(options.onePage);
+    }
+
+    const site = new Site(rootFolder, outputFolder, options.onePage, options.forceReload, options.siteConfig);
 
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
@@ -176,7 +183,7 @@ program
 
     // server config
     const serverConfig = {
-      open: options.open,
+      open: options.open && options.onePage ? `/${options.onePage.replace(/\.(md|mbd)$/, '.html')}` : false,
       logLevel: 0,
       root: outputFolder,
       port: options.port || 8080,

--- a/src/util/fsUtil.js
+++ b/src/util/fsUtil.js
@@ -3,6 +3,14 @@ const path = require('path');
 const sourceFileExtNames = ['.html', '.md', '.mbd', '.mbdf'];
 
 module.exports = {
+  ensurePosix: (filePath) => {
+    if (path.sep !== '/') {
+      return filePath.split(path.sep).join('/');
+    }
+
+    return filePath;
+  },
+
   isSourceFile(filePath) {
     return sourceFileExtNames.includes(path.extname(filePath));
   },


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #441.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Authors may want to preview only a single page in their website, that also includes changes from other parts of the website (eg. changes from an included page). We can allow them the option of just rendering that one page itself without having to render the entire website on each change, speeding up preview times.

**What changes did you make? (Give an overview)**
I added a `--one-page <file>` option to the CLI that allows an author to specify a single page to preview. `Site()` and `Site.js#generatePages()` was then modified to only render that page when a page has been specified via `--one-page`. Finally, `live-server` was configured to open the specified page directly.

**Testing instructions:**
1. Choose a specific page in a Markbind website to serve with `--one-page` eg. `markbind serve --one-page userGuide/components.md`.
2. Note that only `_site/userGuide/components.html` and its required files are rendered.
3. Note that the browser opens to that specific page.
4. Note that changes to the site are detected and rendered, including those not in `components.md`.
