### PR TITLE
Plugins: Support shorthand syntax processing

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -152,6 +152,7 @@ MarkBind has a set of default plugins that it uses to carry out some of its feat
 Default Plugin | Functionality
 --- | ---
 `anchors` | Attaches anchor links to the side of headings.
+`shorthandSyntax` | Allows for certain syntax shorthands.
 
 Although not advised, you can disable these by passing `"off": true` in the `pluginsContext`.
 

--- a/src/plugins/default/markbind-plugin-shorthandSyntax.js
+++ b/src/plugins/default/markbind-plugin-shorthandSyntax.js
@@ -1,0 +1,22 @@
+const cheerio = module.parent.require('cheerio');
+
+// Convert panel headings: <span heading>
+function convertPanelHeadings($) {
+  $('panel>span[heading]').each((i, element) => {
+    $(element).attr('slot', 'header');
+    $(element).addClass('card-title');
+    $(element).removeAttr('heading');
+  });
+}
+
+/**
+ * Converts shorthand syntax to proper Markbind syntax
+ * @param content of the page
+ */
+module.exports = {
+  postRender: (content) => {
+    const $ = cheerio.load(content, { xmlMode: false });
+    convertPanelHeadings($);
+    return $.html();
+  },
+};

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -402,6 +402,11 @@ specification that specifies how the product will address the requirements. </sp
           <div>
             <p>Should be blank:</p>
           </div>
+          <h1 id="panel-with-shorthand-heading-syntax">Panel with shorthand heading syntax<a class="fa fa-anchor" href="#panel-with-shorthand-heading-syntax"></a></h1>
+          <panel>
+            <span slot="header" class="card-title">
+        Heading
+    </span></panel>
           <h1 id="panel-without-src">Panel without src<a class="fa fa-anchor" href="#panel-without-src"></a></h1>
           <panel header="## Panel without src header<a class='fa fa-anchor' href='#panel-without-src-header'></a>" expanded="">
             <div>
@@ -533,6 +538,7 @@ specification that specifies how the product will address the requirements. </sp
             <a class="nav-link py-1" href="#test-included-variable-overridden-by-set">Test included variable overridden by set&#x200E;</a>
             <a class="nav-link py-1" href="#test-missing-variable-with-default">Test missing variable with default&#x200E;</a>
             <a class="nav-link py-1" href="#included-variables-should-not-leak-into-other-files">Included variables should not leak into other files&#x200E;</a>
+            <a class="nav-link py-1" href="#panel-with-shorthand-heading-syntax">Panel with shorthand heading syntax&#x200E;</a>
             <a class="nav-link py-1" href="#panel-without-src">Panel without src&#x200E;</a>
             <nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">
               <a class="nav-link py-1" href="#panel-without-src-header">Panel without src header&#x200E;</a>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -99,6 +99,7 @@
         "test-included-variable-overridden-by-set": "Test included variable overridden by set",
         "test-missing-variable-with-default": "Test missing variable with default",
         "included-variables-should-not-leak-into-other-files": "Included variables should not leak into other files",
+        "panel-with-shorthand-heading-syntax": "Panel with shorthand heading syntax",
         "panel-without-src": "Panel without src",
         "panel-with-normal-src": "Panel with normal src",
         "panel-with-src-from-a-page-segment": "Panel with src from a page segment",

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -157,6 +157,13 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 <include src="testIncludeVariableLeak.md" />
 
+# Panel with shorthand heading syntax
+<panel>
+    <span heading>
+        Heading
+    </span>
+</panel>
+
 # Panel without src
 <panel header="## Panel without src header" expanded>
 <markdown>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] New feature

Fixes #492 

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

We want to be able to support shorthand syntax for certain elements.

**What changes did you make? (Give an overview)**

Have a feature that transpiles shorthand syntax into proper Markbind syntax before processing.

The current implementation is just a proof of concept. Better to migrate this function to external plugin once #474  is merged.

We can generalize this plugin so other shorthands can be added easily as well. I'm thinking we can handle these all together since they are too small to warrant their own functions/plugins.

Something like this perhaps?
```
{
  'panel>span[heading]' : (ele) => // modify ... ,
}
```
