### PR TITLE
Fix `markbind serve` not opening browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ program
 
     // server config
     const serverConfig = {
-      open: options.open && options.onePage ? `/${options.onePage.replace(/\.(md|mbd)$/, '.html')}` : false,
+      open: options.open && (options.onePage ? `/${options.onePage.replace(/\.(md|mbd)$/, '.html')}` : true),
       logLevel: 0,
       root: outputFolder,
       port: options.port || 8080,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

**What is the rationale for this request?**

`markbind serve` should always open the browser unless `no-open` is specified. Right now, it does not open when serving normally (e.g. `markbind serve docs` does _not_ open the browser, even though it should).

**What changes did you make? (Give an overview)**

Fix a programming error that originated from #475.

**Provide some example code that this change will affect:**

NIL

**Is there anything you'd like reviewers to focus on?**

NIL

**Testing instructions:**

`markbind serve docs` and `markbind serve docs --one-page userGuide/components.md` should open the browser.

`markbind serve docs --no-open` and `markbind serve docs --one-page userGuide/components.md --no-open` should not open the browser. 