### PR TITLE
Fix anchor text wrapping bug

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -25,11 +25,12 @@ pre > code.hljs {
 
 .fa.fa-anchor {
     color: #ccc;
-    display: none;
+    display: inline;
     font-size: 14px;
     margin-left: 10px;
     padding: 3px;
     text-decoration: none;
+    visibility: hidden;
 }
 
 .fa.fa-anchor:hover {

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -18,8 +18,10 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter', () => jQuery(heading).find('.fa.fa-anchor').show());
-    jQuery(heading).on('mouseleave', () => jQuery(heading).find('.fa.fa-anchor').hide());
+    jQuery(heading).on('mouseenter',
+                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+    jQuery(heading).on('mouseleave',
+                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -25,11 +25,12 @@ pre > code.hljs {
 
 .fa.fa-anchor {
     color: #ccc;
-    display: none;
+    display: inline;
     font-size: 14px;
     margin-left: 10px;
     padding: 3px;
     text-decoration: none;
+    visibility: hidden;
 }
 
 .fa.fa-anchor:hover {

--- a/test/test_site/expected/markbind/js/setup.js
+++ b/test/test_site/expected/markbind/js/setup.js
@@ -18,8 +18,10 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter', () => jQuery(heading).find('.fa.fa-anchor').show());
-    jQuery(heading).on('mouseleave', () => jQuery(heading).find('.fa.fa-anchor').hide());
+    jQuery(heading).on('mouseenter',
+                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+    jQuery(heading).on('mouseleave',
+                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #485 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Anchors can cause text wrapping to change when made visible.

**What changes did you make? (Give an overview)**

Use `visibility` css property instead of `display`.

`visibility: hidden` hides the element, but still allocates space for it so we don't get the wrapping issue.

Before:

![out1](https://user-images.githubusercontent.com/19278089/50440336-b4ecaa80-0930-11e9-976e-e7570371b9de.gif)

After:

![out2](https://user-images.githubusercontent.com/19278089/50440338-b7e79b00-0930-11e9-93a5-4a2b2dd45f29.gif)