### PR TITLE
Add trim attribute to include

### DIFF
--- a/docs/userGuide/includingContents.md
+++ b/docs/userGuide/includingContents.md
@@ -27,6 +27,8 @@
 
     - `optional` (optional): include the document only if it exists.
 
+    - `trim` (optional): remove leading and trailing whitespace and newlines from the document before including.
+
     Examples:
     ```html
     <include src="EstablishingRequirements.md#preview" inline/>

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -154,6 +154,7 @@ Parser.prototype._preprocess = function (node, context, config) {
     const isInline = _.hasIn(element.attribs, 'inline');
     const isDynamic = _.hasIn(element.attribs, 'dynamic');
     const isOptional = _.hasIn(element.attribs, 'optional');
+    const isTrim = _.hasIn(element.attribs, 'trim');
     element.name = isInline ? 'span' : 'div';
     element.attribs[ATTRIB_INCLUDE_PATH] = filePath;
 
@@ -208,6 +209,9 @@ Parser.prototype._preprocess = function (node, context, config) {
     delete element.attribs.boilerplate;
     delete element.attribs.src;
     delete element.attribs.inline;
+    delete element.attribs.trim;
+
+    fileContent = isTrim ? fileContent.trim() : fileContent;
 
     if (includeSrc.hash) {
       // directly get segment from the src

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -254,6 +254,8 @@ specification that specifies how the product will address the requirements. </sp
             <li>Timer – Additional fixed time restriction on the player.</li>
           </ol>
           <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+        <h1 id="trimmed-include">Trimmed include<a class="fa fa-anchor" href="#trimmed-include"></a></h1>
+        <h2 id="fragment-with-leading-spaces-and-newline"><span>Fragment with leading spaces and newline</span><a class="fa fa-anchor" href="#fragment-with-leading-spaces-and-newline"></a></h2>
         <h1 id="panel-without-src">Panel without src<a class="fa fa-anchor" href="#panel-without-src"></a></h1>
         <panel header="## Panel without src header<a class='fa fa-anchor' href='#panel-without-src-header'></a>" expanded="">
           <div>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -47,6 +47,8 @@
         "html-include": "HTML include",
         "mbd%2C-mbdf-include": "Mbd, Mbdf include",
         "include-from-another-markbind-site": "Include from another Markbind site",
+        "trimmed-include": "Trimmed include",
+        "fragment-with-leading-spaces-and-newline": "Fragment with leading spaces and newline",
         "panel-without-src": "Panel without src",
         "panel-with-normal-src": "Panel with normal src",
         "panel-with-src-from-a-page-segment": "Panel with src from a page segment",

--- a/test/test_site/index.md
+++ b/test/test_site/index.md
@@ -90,6 +90,10 @@ layout: default
 # Include from another Markbind site
 <include src="sub_site/index.md" />
 
+# Trimmed include
+
+## <include src="testTrimInclude.md" trim inline />
+
 # Panel without src
 <panel header="## Panel without src header" expanded>
 <markdown>

--- a/test/test_site/testTrimInclude.md
+++ b/test/test_site/testTrimInclude.md
@@ -1,0 +1,2 @@
+   
+Fragment with leading spaces and newline


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Fixes #494 

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Leading and trailing newlines/whitespace are helpful for clarity but can sometimes cause problems when included:

index.md:
```
<frontmatter>
  title: "Hello World"
</frontmatter>

# Test

## <include src="a.md" inline/>
```

a.md:
```
   
  Heading with leading newline
```

Actual:
![image](https://user-images.githubusercontent.com/19278089/50442062-46134f80-0938-11e9-8415-355fe139a408.png)

Expected:
![image](https://user-images.githubusercontent.com/19278089/50442075-5297a800-0938-11e9-9f0e-0a8383c5b9ee.png)


**What changes did you make? (Give an overview)**

Added a `trim` attribute which can be used with include to trim text before parsing.