### PR TITLE
User guide: Mention baseUrl override

### DIFF
--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -42,7 +42,7 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
 | `--baseurl <override-base-url>`	| Build site with the baseUrl overridden. |
 | `--one-page <file>` | Render and serve only a single page from your website. |
-| --no-open | Don't open browser automatically. |
+| `--no-open` | Don't open browser automatically. |
 
 Note: Live reload is only supported for the following file types:
 

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -40,9 +40,9 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
-| `--baseurl <override-base-url>`	| Build site with the baseUrl overridden. |
-| `--one-page <file>` | Render and serve only a single page from your website. |
+| `--baseurl <override-base-url>` | Build site with the baseUrl overridden. |
 | `--no-open` | Don't open browser automatically. |
+| `--one-page <file>` | Render and serve only a single page from your website. |
 
 Note: Live reload is only supported for the following file types:
 

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -40,9 +40,9 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-f`, `--force-reload` | Force a full reload of all site files when a file is changed. |
 | `-p`, `--port <port>` | The port used for serving your website. |
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
+| `--baseurl <override-base-url>`	| Build site with the baseUrl overridden. |
 | `--one-page <file>` | Render and serve only a single page from your website. |
 | --no-open | Don't open browser automatically. |
-| `--baseurl <override-base-url>`	| Build site with the baseUrl overridden. |
 
 Note: Live reload is only supported for the following file types:
 

--- a/docs/userGuide/developingASite.md
+++ b/docs/userGuide/developingASite.md
@@ -42,6 +42,7 @@ MarkBind will generate the site in a folder named `_site` in the current directo
 | `-s`, `--site-config <file>` | Specify the site config file (default: site.json) |
 | `--one-page <file>` | Render and serve only a single page from your website. |
 | --no-open | Don't open browser automatically. |
+| `--baseurl <override-base-url>`	| Build site with the baseUrl overridden. |
 
 Note: Live reload is only supported for the following file types:
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

Fixes #493.

**What is the rationale for this request?**

The capability to override baseUrl in `markbind build` (implemented in #186) is not mentioned in the user guide.

**What changes did you make? (Give an overview)**

Added a row in the table in docs/userGuide/developingASite.md that describes how to override the baseUrl in `markbind build`.

**Provide some example code that this change will affect:**

N.A.

**Is there anything you'd like reviewers to focus on?**

No.

**Testing instructions:**

Build the site and check that the table in userGuide/developingASite.html has information about the baseUrl override capability.