### PR TITLE
Rebuild files when adding and deleting them

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       Promise.resolve('').then(() => {
         if (fsUtil.isSourceFile(filePath)) {
-          return site.rebuildAffectedSourceFiles(filePath);
+          return site.rebuildSourceFiles(filePath);
         }
         return site.buildAsset(filePath);
       }).catch((err) => {
@@ -105,7 +105,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       Promise.resolve('').then(() => {
         if (fsUtil.isSourceFile(filePath)) {
-          return site.rebuildAffectedSourceFiles(filePath);
+          return site.rebuildSourceFiles(filePath);
         }
         return site.removeAsset(filePath);
       }).catch((err) => {

--- a/src/Site.js
+++ b/src/Site.js
@@ -506,7 +506,7 @@ Site.prototype.buildSourceFiles = function () {
 Site.prototype._rebuildAffectedSourceFiles = function (filePaths) {
   const filePathArray = Array.isArray(filePaths) ? filePaths : [filePaths];
   const uniquePaths = _.uniq(filePathArray);
-  logger.verbose(`Rebuild affected paths: ${uniquePaths}`);
+  logger.info('Rebuilding affected source files');
   return new Promise((resolve, reject) => {
     this.regenerateAffectedPages(uniquePaths)
       .then(() => fs.removeAsync(this.tempPath))
@@ -526,7 +526,7 @@ Site.prototype.rebuildAffectedSourceFiles
   = delay(Site.prototype._rebuildAffectedSourceFiles, 1000);
 
 Site.prototype._rebuildSourceFiles = function () {
-  logger.verbose('Rebuild all files');
+  logger.warn('Rebuilding all source files');
   return new Promise((resolve, reject) => {
     Promise.resolve('')
       .then(() => this.updateAddressablePages())


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #509 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Markbind does not generate new pages when new files are added.

**What changes did you make? (Give an overview)**

As suggested, do an automatic force-reload when a file is add/delete/rename is detected?

**Provide some example code that this change will affect:**

Can confirm the following works:
Set site.json:
```js
  "pages": [
    {
      "glob": "**/*.md"
    }
  ],
```
Run `markbind serve`
Add any `.md` file into the folder
Corresponding .html file is built in the `_site` folder (It didn't previously)
Delete the `.md` file
Corresponding .html file is removed from the `_site` folder

**Is there anything you'd like reviewers to focus on?**

There might be a way in which we only rebuild files that have been added which reduces build time. I'm not sure if it's worth the effort to implement though as there might be a lot of edge cases.