### PR TITLE
Support optional includes for page fragments

### DIFF
--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -128,6 +128,87 @@ test('includeFile replaces <include src="doesNotExist.md" optional> with empty <
   expect(result).toEqual(expected);
 });
 
+test('includeFile replaces <include src="include.md#exists"> with <div>', async () => {
+  const indexPath = path.resolve('index.md');
+  const includePath = path.resolve('include.md');
+
+  const index = [
+    '# Index',
+    '<include src="include.md#exists"/>',
+    '',
+  ].join('\n');
+
+  const include = [
+    '# Include',
+    '<seg id="exists">existing segment</seg>',
+  ].join('\n');
+
+  const json = {
+    'index.md': index,
+    'include.md': include,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    `<div cwf="${indexPath}" include-path="${includePath}">`,
+    '',
+    'existing segment',
+    '</div>',
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
+test('includeFile replaces <include src="include.md#doesNotExist"> with error <div>', async () => {
+  const indexPath = path.resolve('index.md');
+  const includePath = path.resolve('include.md');
+
+  const index = [
+    '# Index',
+    '<include src="include.md#doesNotExist"/>',
+    '',
+  ].join('\n');
+
+  const include = ['# Include'].join('\n');
+
+  const json = {
+    'index.md': index,
+    'include.md': include,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    `<div style="color: red">No such segment 'doesNotExist' in file: ${includePath}`,
+    `Missing reference in ${indexPath}</div>`,
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
 test('includeFile replaces <include src="include.md#exists" optional> with <div>', async () => {
   const indexPath = path.resolve('index.md');
   const includePath = path.resolve('include.md');

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -128,6 +128,89 @@ test('includeFile replaces <include src="doesNotExist.md" optional> with empty <
   expect(result).toEqual(expected);
 });
 
+test('includeFile replaces <include src="include.md#exists" optional> with <div>', async () => {
+  const indexPath = path.resolve('index.md');
+  const includePath = path.resolve('include.md');
+
+  const index = [
+    '# Index',
+    '<include src="include.md#exists" optional/>',
+    '',
+  ].join('\n');
+
+  const include = [
+    '# Include',
+    '<seg id="exists">existing segment</seg>',
+  ].join('\n');
+
+  const json = {
+    'index.md': index,
+    'include.md': include,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    `<div cwf="${indexPath}" include-path="${includePath}">`,
+    '',
+    'existing segment',
+    '</div>',
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
+test('includeFile replaces <include src="include.md#doesNotExist" optional> with empty <div>', async () => {
+  const indexPath = path.resolve('index.md');
+  const includePath = path.resolve('include.md');
+
+  const index = [
+    '# Index',
+    '<include src="include.md#doesNotExist" optional/>',
+    '',
+  ].join('\n');
+
+  const include = ['# Include'].join('\n');
+
+  const json = {
+    'index.md': index,
+    'include.md': include,
+  };
+
+  fs.vol.fromJSON(json, '');
+  const baseUrlMap = {};
+  baseUrlMap[ROOT_PATH] = true;
+
+  const markbinder = new MarkBind();
+  const result = await markbinder.includeFile(indexPath, {
+    baseUrlMap,
+    rootPath: ROOT_PATH,
+    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
+  });
+
+  const expected = [
+    '# Index',
+    `<div cwf="${indexPath}" include-path="${includePath}">`,
+    '',
+    '',
+    '</div>',
+    '',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
 test('includeFile replaces <include dynamic> with <panel>', async () => {
   const rootPath = path.resolve('');
   const indexPath = path.resolve('index.md');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #497.


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently, we allow optional inclusion of whole documents with the `optional` tag eg. 
`<include src="doc.md" optional />`. This PR extends this functionality to page fragments as well eg.
`<include src="doc.md#segment" optional />` will be included only if `#segment` exists.

**What changes did you make? (Give an overview)**
When a page fragment that is included does not exist, we check first if the `optional` tag is used. If so, we include an empty string in place, leading to an empty `<div>`. If not, an error is emitted that the page fragment included does not exist. 

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<include src="doc.md#exists" optional />
<include src="doc.md#doesNotExist" optional />
<include src="doc.md#doesNotExist" />
```

**Is there anything you'd like reviewers to focus on?**
In previous versions, inclusion of nonexistent page fragments lead to a `<div>` with the string `null` being included instead. Since this behavior is likely to be confusing with the addition of `optional`, I have chosen to change this so that an error is emitted when an included page fragment does not exist and `optional` was not used. I have also added tests to verify this new behavior alongside those that verify the behavior of `optional` with page fragments.

**Testing instructions:**
1. Include a page fragment with `optional` eg. `<include src="doc.md#exists" optional />`.  The content of the page fragment should be included.
2. Include a nonexistent page fragment with `optional` eg. 
`<include src="doc.md#doesNotExist" optional />`.  There should not be an error and the page should render as normal.
3. Include a nonexistent page fragment normally eg. `<include src="doc.md#doesNotExist" />`.  An error should be emitted.