### PR TITLE
Allow search indexing to be disabled

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -71,6 +71,10 @@ function setup() {
 }
 
 function setupWithSearch(siteData) {
+  if (siteData.disableSearch) {
+    setup();
+    return;
+  }
   const { searchbar } = VueStrap.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -71,7 +71,7 @@ function setup() {
 }
 
 function setupWithSearch(siteData) {
-  if (siteData.disableSearch) {
+  if (!siteData.enableSearch) {
     setup();
     return;
   }

--- a/docs/userGuide/components/searchbar.md
+++ b/docs/userGuide/components/searchbar.md
@@ -40,3 +40,5 @@ placeholder | `String` | `''` | The placeholder text shown when no keywords are 
 
 
 %%{{ icon_info }} Related topic: [User Guide: Making the Site Searchable]({{ baseUrl }}/userGuide/makingTheSiteSearchable.html).%%
+
+If you do not wish to use MarkBind's searchbar, it may be helpful to include the option `disableSearch: true` in your `site.json`. This stops MarkBind from indexing search headings and speeds up building.

--- a/docs/userGuide/components/searchbar.md
+++ b/docs/userGuide/components/searchbar.md
@@ -40,5 +40,3 @@ placeholder | `String` | `''` | The placeholder text shown when no keywords are 
 
 
 %%{{ icon_info }} Related topic: [User Guide: Making the Site Searchable]({{ baseUrl }}/userGuide/makingTheSiteSearchable.html).%%
-
-If you do not wish to use MarkBind's searchbar, it may be helpful to include the option `disableSearch: true` in your `site.json`. This stops MarkBind from indexing search headings and speeds up building.

--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -55,4 +55,6 @@ This is good for catching <span class="keyword">regressions</span>.
 
 </div>
 
+If you do not wish to use MarkBind's searchbar (e.g. you have an external service provider), it may be helpful to include the option `enableSearch: false` in your `site.json`. This stops MarkBind from indexing search headings and speeds up building.
+
 </div>

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -120,6 +120,6 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 #### **`enableSearch`**
 
-**Specifies that the website should use MarkBind's search functionality.** Default: `true`. See [User Guide: Making the Site Searchable](userguide/makingthesitesearchable) for more details.
+**Specifies that the website should use MarkBind's search functionality.** Default: `true`. See [User Guide: Making the Site Searchable]({{ baseUrl }}/userGuide/makingTheSiteSearchable.html) for more details.
 
 </div>

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -118,8 +118,8 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 **The level of headings to be indexed for searching.** Default: `3` %%i.e., only headings of levels 1,2,3 will be indexed for searching%%.
 
-#### **`disableSearch`**
+#### **`enableSearch`**
 
-**If set to `true`, MarkBind will not index pages for searching.** See [Use Searchbar](usingComponents.html#search-bar) for more information.
+**Specifies that the website should use MarkBind's search functionality.** Default: `true`. See [User Guide: Making the Site Searchable](userguide/makingthesitesearchable) for more details.
 
 </div>

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -120,6 +120,6 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 #### **`disableSearch`**
 
-**If set to `true`, MarkBind will not index pages for searching.** See [Use Searchbar](usingComponents.html#use-searchbar) for more information.
+**If set to `true`, MarkBind will not index pages for searching.** See [Use Searchbar](usingComponents.html#search-bar) for more information.
 
 </div>

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -118,4 +118,8 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 **The level of headings to be indexed for searching.** Default: `3` %%i.e., only headings of levels 1,2,3 will be indexed for searching%%.
 
+#### **`disableSearch`**
+
+**If set to `true`, MarkBind will not index pages for searching.** See [Use Searchbar](usingComponents.html#use-searchbar) for more information.
+
 </div>

--- a/src/Site.js
+++ b/src/Site.js
@@ -274,9 +274,7 @@ Site.prototype.readSiteConfig = function (baseUrl) {
       .then((config) => {
         this.siteConfig = config;
         this.siteConfig.baseUrl = (baseUrl === undefined) ? this.siteConfig.baseUrl : baseUrl;
-        if (this.siteConfig.enableSearch === undefined) {
-          this.siteConfig.enableSearch = true;
-        }
+        this.siteConfig.enableSearch = (config.enableSearch === undefined) || config.enableSearch;
         resolve(this.siteConfig);
       })
       .catch((err) => {

--- a/src/Site.js
+++ b/src/Site.js
@@ -306,7 +306,7 @@ Site.prototype.createPage = function (config) {
     faviconUrl: config.faviconUrl,
     pageTemplate: this.pageTemplate,
     rootPath: this.rootPath,
-    searchable: !this.siteConfig.disableSearch && config.searchable,
+    searchable: (!('enableSearch' in this.siteConfig) || this.siteConfig.enableSearch) && config.searchable,
     src: config.pageSrc,
     layoutsAssetPath: path.relative(path.dirname(resultPath),
                                     path.join(this.siteAssetsDestPath, LAYOUT_SITE_FOLDER_NAME)),
@@ -700,7 +700,7 @@ Site.prototype.writeSiteData = function () {
   return new Promise((resolve, reject) => {
     const siteDataPath = path.join(this.outputPath, SITE_DATA_NAME);
     const siteData = {
-      disableSearch: this.siteConfig.disableSearch,
+      enableSearch: !('enableSearch' in this.siteConfig) || this.siteConfig.enableSearch,
       pages: this.pages.filter(page => page.searchable)
         .map(page => Object.assign({ headings: page.headings }, page.frontMatter)),
     };

--- a/src/Site.js
+++ b/src/Site.js
@@ -274,6 +274,9 @@ Site.prototype.readSiteConfig = function (baseUrl) {
       .then((config) => {
         this.siteConfig = config;
         this.siteConfig.baseUrl = (baseUrl === undefined) ? this.siteConfig.baseUrl : baseUrl;
+        if (this.siteConfig.enableSearch === undefined) {
+          this.siteConfig.enableSearch = true;
+        }
         resolve(this.siteConfig);
       })
       .catch((err) => {
@@ -306,7 +309,7 @@ Site.prototype.createPage = function (config) {
     faviconUrl: config.faviconUrl,
     pageTemplate: this.pageTemplate,
     rootPath: this.rootPath,
-    searchable: (!('enableSearch' in this.siteConfig) || this.siteConfig.enableSearch) && config.searchable,
+    searchable: this.siteConfig.enableSearch && config.searchable,
     src: config.pageSrc,
     layoutsAssetPath: path.relative(path.dirname(resultPath),
                                     path.join(this.siteAssetsDestPath, LAYOUT_SITE_FOLDER_NAME)),
@@ -700,7 +703,7 @@ Site.prototype.writeSiteData = function () {
   return new Promise((resolve, reject) => {
     const siteDataPath = path.join(this.outputPath, SITE_DATA_NAME);
     const siteData = {
-      enableSearch: !('enableSearch' in this.siteConfig) || this.siteConfig.enableSearch,
+      enableSearch: this.siteConfig.enableSearch,
       pages: this.pages.filter(page => page.searchable)
         .map(page => Object.assign({ headings: page.headings }, page.frontMatter)),
     };

--- a/src/Site.js
+++ b/src/Site.js
@@ -306,7 +306,7 @@ Site.prototype.createPage = function (config) {
     faviconUrl: config.faviconUrl,
     pageTemplate: this.pageTemplate,
     rootPath: this.rootPath,
-    searchable: config.searchable,
+    searchable: !this.siteConfig.disableSearch && config.searchable,
     src: config.pageSrc,
     layoutsAssetPath: path.relative(path.dirname(resultPath),
                                     path.join(this.siteAssetsDestPath, LAYOUT_SITE_FOLDER_NAME)),
@@ -700,6 +700,7 @@ Site.prototype.writeSiteData = function () {
   return new Promise((resolve, reject) => {
     const siteDataPath = path.join(this.outputPath, SITE_DATA_NAME);
     const siteData = {
+      disableSearch: this.siteConfig.disableSearch,
       pages: this.pages.filter(page => page.searchable)
         .map(page => Object.assign({ headings: page.headings }, page.frontMatter)),
     };

--- a/test/test_site/expected/markbind/js/setup.js
+++ b/test/test_site/expected/markbind/js/setup.js
@@ -71,6 +71,10 @@ function setup() {
 }
 
 function setupWithSearch(siteData) {
+  if (!siteData.enableSearch) {
+    setup();
+    return;
+  }
   const { searchbar } = VueStrap.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -1,4 +1,5 @@
 {
+  "enableSearch": true,
   "pages": [
     {
       "headings": {

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -203,11 +203,12 @@ test('Site read site config for default', async () => {
     'site.json': SITE_JSON_DEFAULT,
   };
   fs.vol.fromJSON(json, '');
-  const expectedSiteJson = { ...JSON.parse(SITE_JSON_DEFAULT), ...{ enableSearch: true } };
 
+  const siteConfigDefaults = { enableSearch: true };
+  const expectedSiteConfig = { ...JSON.parse(SITE_JSON_DEFAULT), ...siteConfigDefaults };
   const site = new Site('./', '_site');
   await site.readSiteConfig();
-  expect(site.siteConfig).toEqual(expectedSiteJson);
+  expect(site.siteConfig).toEqual(expectedSiteConfig);
 });
 
 test('Site read site config for custom site config', async () => {

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -203,10 +203,11 @@ test('Site read site config for default', async () => {
     'site.json': SITE_JSON_DEFAULT,
   };
   fs.vol.fromJSON(json, '');
+  const expectedSiteJson = Object.assign(JSON.parse(SITE_JSON_DEFAULT), { enableSearch: true });
 
   const site = new Site('./', '_site');
   await site.readSiteConfig();
-  expect(site.siteConfig).toEqual(JSON.parse(SITE_JSON_DEFAULT));
+  expect(site.siteConfig).toEqual(expectedSiteJson);
 });
 
 test('Site read site config for custom site config', async () => {
@@ -226,6 +227,7 @@ test('Site read site config for custom site config', async () => {
     deploy: {
       message: 'Site Update.',
     },
+    enableSearch: true,
   };
   const json = {
     'src/template/page.ejs': PAGE_EJS,

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -203,7 +203,7 @@ test('Site read site config for default', async () => {
     'site.json': SITE_JSON_DEFAULT,
   };
   fs.vol.fromJSON(json, '');
-  const expectedSiteJson = Object.assign(JSON.parse(SITE_JSON_DEFAULT), { enableSearch: true });
+  const expectedSiteJson = { ...JSON.parse(SITE_JSON_DEFAULT), ...{ enableSearch: true } };
 
   const site = new Site('./', '_site');
   await site.readSiteConfig();


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #514 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Allows the user to disable indexing of headings for search.

**What changes did you make? (Give an overview)**

Added a `disableSearch` option in the `site.json`

If set to `true`, all pages will be marked as unsearchable, so they won't be indexed in sitedata.

`setupWithSearch` is still called, but it does nothing.

**Testing instructions:**

Not sure how to test this...