### PR TITLE
Allow empty <frontmatter> tags

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -384,7 +384,7 @@ Page.prototype.collectIncludedFiles = function (dependencies) {
 Page.prototype.collectFrontMatter = function (includedPage) {
   const $ = cheerio.load(includedPage);
   const frontMatter = $('frontmatter');
-  if (frontMatter.length) {
+  if (frontMatter.text().trim()) {
     // Retrieves the front matter from either the first frontmatter element
     // or from a frontmatter element that includes from another file
     // The latter case will result in the data being wrapped in a div

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -66,6 +66,12 @@
       "src": "index.md"
     },
     {
+      "headings": {},
+      "src": "testEmptyFrontmatter.md",
+      "title": "Hello World",
+      "layout": "default"
+    },
+    {
       "headings": {
         "uses-a-layout": "Uses a layout"
       },

--- a/test/test_site/expected/testEmptyFrontmatter.html
+++ b/test/test_site/expected/testEmptyFrontmatter.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="default-head-top">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hello World</title>
+    <link rel="stylesheet" href="markbind\css\bootstrap.min.css">
+    <link rel="stylesheet" href="markbind\css\bootstrap-vue.min.css">
+    <link rel="stylesheet" href="markbind\css\font-awesome.min.css" >
+    <link rel="stylesheet" href="markbind\css\bootstrap-glyphicons.min.css" >
+    <link rel="stylesheet" href="markbind\css\github.min.css">
+    <link rel="stylesheet" href="markbind\css\markbind.css">
+    <link rel="stylesheet" href="markbind\layouts\default\styles.css">
+    
+    <meta name="default-head-bottom">
+    <link rel="icon" href="/test_site/favicon.png">
+</head>
+<body>
+<div id="app">
+    <div id="content-wrapper">
+  <p>A page with an empty frontmatter should still build.</p>
+</div>
+<div id="flex-div"></div>
+<footer>
+  <div class="text-center">
+    Default footer
+  </div>
+</footer>
+</div>
+</body>
+<script src="markbind\js\vue.min.js"></script>
+<script src="markbind\js\vue-strap.min.js"></script>
+<script src="markbind\js\polyfill.min.js"></script>
+<script src="markbind\js\bootstrap-vue.min.js"></script>
+<script>
+    const baseUrl = '/test_site'
+</script>
+<script src="markbind\js\setup.js"></script>
+<script src="markbind\layouts\default\scripts.js"></script>
+</html>

--- a/test/test_site/site.json
+++ b/test/test_site/site.json
@@ -9,6 +9,11 @@
       "layout": "testLayout"
     },
     {
+      "src": "testEmptyFrontmatter.md",
+      "title": "Hello World",
+      "layout": "testLayout"
+    },
+    {
       "src": "testLayouts.md",
       "title": "Hello World",
       "layout": "testLayout"

--- a/test/test_site/testEmptyFrontmatter.md
+++ b/test/test_site/testEmptyFrontmatter.md
@@ -1,0 +1,3 @@
+<frontmatter></frontmatter>
+
+A page with an empty frontmatter should still build.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #515.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently, having an empty `<frontmatter>` tag in pages causes a build error. We should just ignore empty `<frontmatter>` tags instead of failing to build the site.

**What changes did you make? (Give an overview)**
The check for `<frontmatter>` tags was changed such that only non-empty `<frontmatter>` tags are processed. Empty `<frontmatter>` tags are ignored.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<frontmatter></frontmatter>
```
**Testing instructions:**
1. Create a page with an empty `<frontmatter>` tag. The page should still be able to build.
