### PR TITLE
markbind serve: give shorthand version for all flags

### DIFF
--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -102,10 +102,10 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
 * `-s <file>`, `--site-config <file>`<br>
    Specify the site config file (default: `site.json`)<br>
    {{ icon_example }} `-s otherSite.json`
-* `--one-page <file>`<br>
+* `-o <file>`, `--one-page <file>`<br>
    Render and serve only a single page from your website.<br>
   {{ icon_example }} `--one-page guide/index.md`
-* `--no-open`<br>
+* `-n`, `--no-open`<br>
    Don't open a live preview in the browser automatically.
 
 {{ icon_examples }}

--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -97,16 +97,16 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
   {{ icon_example }} `./myWebsite`
 * `-f`, `--force-reload`<br>
    Force live reload to process all files in the site, instead of just the relevant files. This option is useful when you are modifying a file that is not a file type monitored by the <trigger trigger="click" for="modal:cliCommands-livePreview">live preview</trigger> feature.
+* `-n`, `--no-open`<br>
+   Don't open a live preview in the browser automatically.
+* `-o <file>`, `--one-page <file>`<br>
+   Render and serve only a single page from your website.<br>
+  {{ icon_example }} `--one-page guide/index.md`
 * `-p <port>`, `--port <port>`<br>
     Serve the website in the specified port.
 * `-s <file>`, `--site-config <file>`<br>
    Specify the site config file (default: `site.json`)<br>
    {{ icon_example }} `-s otherSite.json`
-* `-o <file>`, `--one-page <file>`<br>
-   Render and serve only a single page from your website.<br>
-  {{ icon_example }} `--one-page guide/index.md`
-* `-n`, `--no-open`<br>
-   Don't open a live preview in the browser automatically.
 
 {{ icon_examples }}
 * `markbind serve`

--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ program
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
   .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
-  .option('--one-page <file>', 'render and serve only a single page in the site')
-  .option('--no-open', 'do not automatically open the site in browser')
+  .option('-o, --one-page <file>', 'render and serve only a single page in the site')
+  .option('-n, --no-open', 'do not automatically open the site in browser')
   .action((root, options) => {
     const rootFolder = path.resolve(root || process.cwd());
     const logsFolder = path.join(rootFolder, '_markbind/logs');

--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ program
   .command('serve [root]')
   .description('build then serve a website from a directory')
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
+  .option('-n, --no-open', 'do not automatically open the site in browser')
+  .option('-o, --one-page <file>', 'render and serve only a single page in the site')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
   .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
-  .option('-o, --one-page <file>', 'render and serve only a single page in the site')
-  .option('-n, --no-open', 'do not automatically open the site in browser')
   .action((root, options) => {
     const rootFolder = path.resolve(root || process.cwd());
     const logsFolder = path.join(rootFolder, '_markbind/logs');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Fixes #533.

**What is the rationale for this request?**

Currently, some of the `markbind serve` flags don't have shorthand versions. Shorthand versions should be added to make things consistent.

**What changes did you make? (Give an overview)**

Added the following shorthand flags:
1. `o` for `--one-page`
2. `n` for `--no-open`

**Provide some example code that this change will affect:**

N.A.

**Is there anything you'd like reviewers to focus on?**

N.A.

**Testing instructions:**

Build markbind locally and see if the `--one-page` and `--no-open` commands are working on using their shorthand versions.