### PR TITLE
Use light grey for siteNav text

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -31,7 +31,7 @@
 }
 
 #site-nav a:link, #site-nav a:visited, #site-nav a:hover, #site-nav a:active {
-    color: black;
+    color: #565656;
     text-decoration: none;
 }
 
@@ -70,6 +70,7 @@
 .dropdown-btn {
     background: white;
     border: none;
+    color: #565656;
     cursor: pointer;
     display: block;
     outline: none !important;
@@ -78,7 +79,7 @@
     text-decoration: none;
 }
 
-.dropdown-btn:hover, .dropdown-btn-open {
+.dropdown-btn:hover {
     color: #0076FF;
 }
 

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -31,7 +31,7 @@
 }
 
 #site-nav a:link, #site-nav a:visited, #site-nav a:hover, #site-nav a:active {
-    color: black;
+    color: #565656;
     text-decoration: none;
 }
 
@@ -70,6 +70,7 @@
 .dropdown-btn {
     background: white;
     border: none;
+    color: #565656;
     cursor: pointer;
     display: block;
     outline: none !important;
@@ -78,7 +79,7 @@
     text-decoration: none;
 }
 
-.dropdown-btn:hover, .dropdown-btn-open {
+.dropdown-btn:hover {
     color: #0076FF;
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #542.


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
We can have lighter coloured text for the site navigation sidebar to give more relative importance to the main text.

**What changes did you make? (Give an overview)**
Adjust the `color`for `siteNav` text to be `#444444`.

**Testing instructions:**
1. Observe that in MarkBind documents with a navigation sidebar, the colour of the text is `#444444`.