### PR TITLE
Improve searchbar example description

### DIFF
--- a/docs/userGuide/components/searchbar.md
+++ b/docs/userGuide/components/searchbar.md
@@ -4,9 +4,10 @@ The searchbar allows users to search all headings within any page on the site.
 
 <box border-left-color="#00B0F0">
   <i style="font-style: normal; font-weight: bold; color: dimgray">Example</i><br>
+  Enter a search term (eg. 'search bar') to see the search result dropdown.
   <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
   <br>
-  <searchbar :data="searchData" placeholder="Search (Right-aligned)" :on-hit="searchCallback" menu-align-right></searchbar>
+  <searchbar :data="searchData" placeholder="Search (Right-aligned dropdown)" :on-hit="searchCallback" menu-align-right></searchbar>
 </box>
 
 <tip-box border-left-color="black">
@@ -14,7 +15,7 @@ The searchbar allows users to search all headings within any page on the site.
 
 ``` html
 <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
-<searchbar :data="searchData" placeholder="Search (Right-aligned)" :on-hit="searchCallback" menu-align-right></searchbar>
+<searchbar :data="searchData" placeholder="Search (Right-aligned dropdown)" :on-hit="searchCallback" menu-align-right></searchbar>
 ```
 
 To use the searchbar within a navbar, add the following markup to your file. The searchbar can be positioned using the slot attribute for the list. The following markup adds a searchbar to the right side of the navbar with appropriate styling.

--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -12,7 +12,7 @@
 
 <span class="lead" id="overview">
 
-**MarkBind comes with with an in-built _site search_ facility**. You can add a [Search Bar]({{ baseUrl }}/userGuide/usingComponents.html#searchbar) component to your pages %%(e.g., into the top navigation bar)%% to allow readers to search your website for keywords.
+**MarkBind comes with with an in-built _site search_ facility**. You can add a [Search Bar]({{ baseUrl }}/userGuide/usingComponents.html#search-bar) component to your pages %%(e.g., into the top navigation bar)%% to allow readers to search your website for keywords.
 </span>
 
 **All headings of levels 1-3 are captured in the search index** by default. You can change this setting using the [`headingIndexLevel` property of the `site.json`]({{ baseUrl }}/userGuide/siteConfiguration.html#headingindexinglevel).


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #530.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The current example searchbar in the documentation gives a "right-aligned" variant that does not specify *what* is being right aligned. The natural assumption would be that the text in the searchbar is right aligned, but it is actually the results dropdown that is right-aligned, which is not obvious until the user enters something into the searchbar.

**What changes did you make? (Give an overview)**
Make it clearer that the right alignment refers to the results dropdown, and prompt the user to enter in search terms in the searchbar so that the difference is is visible.

Also corrected a broken link to the searchbar docs in "Making the Site Searchable".