### PR TITLE
Add inline code syntax highlighting with `code`{.lang}

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -37,6 +37,13 @@ pre > code.hljs {
     color: #555;
 }
 
+code.hljs.inline {
+    background: #f8f8f8;
+    color: #333;
+    display: initial;
+    padding: 0px;
+}
+
 .markbind-table {
     width: auto;
 }

--- a/docs/userGuide/markBindSyntax.md
+++ b/docs/userGuide/markBindSyntax.md
@@ -248,6 +248,19 @@ MarkBind adds several Markdown-like features on top of GFMD.
 - (X) Option 2 (selected)
 </div>
 
+#### Inline code / syntax highlighting
+
+<div class="indented">
+
+{{ icon_example }} You can syntax highlight inline code by using `{.language}`:
+```markdown
+Consider the Java method signature: `public static void main(String[] args)`{.java}.
+```
+{{ icon_arrow_down }}
+
+Consider the Java method signature: `public static void main(String[] args)`{.java}.
+</div>
+
 #### Media Embeds
 
 **There are easy ways to embed media content such as YouTube videos and PowerPoint slides**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5298,6 +5298,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.0.tgz",
       "integrity": "sha512-s3HuwE4KN+4N8gL8nLxMdPO+OXik7oJvqPgQoQNPhYMM4c0iI72n9XqNXG/bxQa8D+aU4Is2fcioryGRQ4QoLw=="
     },
+    "markdown-it-attrs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-2.3.2.tgz",
+      "integrity": "sha512-DyatNvpatg7w+fGkplWGeie7o/0TogBr2w0izyz9ZQfTMv5G3lbDHQFQ42aP2e5L2mJQt0IeAjWzvYaa2d9xzQ=="
+    },
     "markdown-it-emoji": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.5",
     "markdown-it": "^8.3.0",
     "markdown-it-anchor": "^5.0.0",
+    "markdown-it-attrs": "^2.3.2",
     "markdown-it-emoji": "^1.3.0",
     "markdown-it-imsize": "^2.0.1",
     "markdown-it-ins": "^2.0.0",

--- a/src/lib/markbind/package-lock.json
+++ b/src/lib/markbind/package-lock.json
@@ -2305,6 +2305,11 @@
         "string": "3.3.3"
       }
     },
+    "markdown-it-attrs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-2.3.2.tgz",
+      "integrity": "sha512-DyatNvpatg7w+fGkplWGeie7o/0TogBr2w0izyz9ZQfTMv5G3lbDHQFQ42aP2e5L2mJQt0IeAjWzvYaa2d9xzQ=="
+    },
     "markdown-it-emoji": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",

--- a/src/lib/markbind/package.json
+++ b/src/lib/markbind/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.5",
     "markdown-it": "^8.3.0",
     "markdown-it-anchor": "^4.0.0",
+    "markdown-it-attrs": "^2.3.2",
     "markdown-it-emoji": "^1.3.0",
     "markdown-it-imsize": "^2.0.1",
     "markdown-it-ins": "^2.0.0",

--- a/src/lib/markbind/src/lib/markdown-it/index.js
+++ b/src/lib/markbind/src/lib/markdown-it/index.js
@@ -24,6 +24,7 @@ markdownIt.use(require('markdown-it-mark'))
   .use(require('markdown-it-table-of-contents'))
   .use(require('markdown-it-task-lists'), {enabled: true})
   .use(require('markdown-it-linkify-images'), {imgClass: 'img-fluid'})
+  .use(require('markdown-it-attrs'))
   .use(require('./markdown-it-dimmed'))
   .use(require('./markdown-it-radio-button'))
   .use(require('./markdown-it-block-embed'));
@@ -37,6 +38,23 @@ markdownIt.renderer.rules.table_open = (tokens, idx) => {
 };
 markdownIt.renderer.rules.table_close = (tokens, idx) => {
   return '</table></div>';
+};
+
+// highlight inline code
+markdownIt.renderer.rules.code_inline = (tokens, idx, options, env, slf) => {
+  const token = tokens[idx];
+  const lang = token.attrGet('class');
+
+  if (lang && hljs.getLanguage(lang)) {
+    token.attrSet('class', `hljs inline ${lang}`);
+    return '<code' + slf.renderAttrs(token) + '>'
+      + hljs.highlight(lang, token.content, true).value
+      + '</code>';
+  } else {
+    return '<code' + slf.renderAttrs(token) + '>'
+      + markdownIt.utils.escapeHtml(token.content)
+      + '</code>';
+  }
 };
 
 // fix emoji numbers

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -37,6 +37,13 @@ pre > code.hljs {
     color: #555;
 }
 
+code.hljs.inline {
+    background: #f8f8f8;
+    color: #333;
+    display: initial;
+    padding: 0px;
+}
+
 .markbind-table {
     width: auto;
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #548.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
We currently allow code blocks to have syntax highlighting, but not inline code blocks. Allowing syntax highlighting for inline code blocks also would be useful.

**What changes did you make? (Give an overview)**
I added the `markdown-it-attrs` package to allow attributes to be attached to Markdown elements with `{}` eg. &#96;some code&#96;{.language} will be rendered as `<code class='language'>some code</code>`. I then added a custom `code_inline` renderer rule to render inline code blocks with a `language` specified with syntax highlighting. Finally, I added a `code.hljs.inline` CSS rule to match the background and text colour with that of `pre > code.hljs`.

**Provide some example code that this change will affect:**
```markdown
Code with syntax highlighting: `print('Hello ', name)`{.python} in the middle of some text.
```
Here's a preview:

![Inline code syntax highlighting](https://user-images.githubusercontent.com/1782590/50734733-8303ff80-11de-11e9-93f4-c5e41b7c7259.png)

**Testing instructions:**
1, Use the new &#96;some code&#96;{.language} syntax in a MarkBind document. It should render with syntax highlighting.
