### PR TITLE
 Indicate currently loaded page in siteNav

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -30,7 +30,9 @@
     -webkit-transition: 0.4s;
 }
 
-#site-nav a:link, #site-nav a:visited, #site-nav a:hover, #site-nav a:active {
+#site-nav a:active,
+#site-nav a:link,
+#site-nav a:visited {
     color: #565656;
     text-decoration: none;
 }
@@ -114,7 +116,9 @@
 
 /* Hamburger button */
 
-.menu-top-bar, .menu-middle-bar, .menu-bottom-bar {
+.menu-top-bar,
+.menu-middle-bar,
+.menu-bottom-bar {
     background-color: darkslategrey;
     height: 4px;
     margin: 5px 10%;

--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -41,6 +41,10 @@
     color: #0076FF;
 }
 
+#site-nav a.current {
+    color: #0072EC;
+}
+
 #site-nav-btn {
     background: transparent;
     cursor: pointer;

--- a/src/Page.js
+++ b/src/Page.js
@@ -129,7 +129,7 @@ function formatFooter(pageData) {
   return $.html();
 }
 
-function formatSiteNav(renderedSiteNav) {
+function formatSiteNav(renderedSiteNav, src) {
   const $ = cheerio.load(renderedSiteNav);
   const listItems = $.root().find('ul').first().children();
   if (listItems.length === 0) {
@@ -137,6 +137,10 @@ function formatSiteNav(renderedSiteNav) {
   }
   // Tidy up the style of the unordered list <ul>
   listItems.parent().attr('style', 'list-style-type: none; margin-left:-1em');
+
+  // Highlight current page
+  const currentPageHtmlPath = src.replace(/\.(md|mbd)$/, '.html');
+  listItems.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`).addClass('current');
 
   listItems.each(function () {
     // Tidy up the style of each list item
@@ -148,7 +152,7 @@ function formatSiteNav(renderedSiteNav) {
         // Double wrap to counter replaceWith removing <li>
         nestedList.parent().wrap('<li style="margin-top:10px"></li>');
         // Recursively format nested lists without dropdown wrapper
-        nestedList.parent().replaceWith(formatSiteNav(nestedList.parent().html()));
+        nestedList.parent().replaceWith(formatSiteNav(nestedList.parent().html(), src));
       }
     // Found nested list, render dropdown menu
     } else if ($(this).children('ul').length) {
@@ -156,8 +160,10 @@ function formatSiteNav(renderedSiteNav) {
       const dropdownTitle = $(this).contents().not('ul');
       // Replace the title with the dropdown wrapper
       dropdownTitle.remove();
-      // Check if dropdown is expanded by default
-      if (dropdownTitle.toString().includes(DROPDOWN_EXPAND_KEYWORD)) {
+      // Check if dropdown is expanded by default or if the current page is in a dropdown
+      const shouldExpandDropdown = dropdownTitle.toString().includes(DROPDOWN_EXPAND_KEYWORD)
+        || Boolean(nestedList.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`).text());
+      if (shouldExpandDropdown) {
         const expandKeywordRegex = new RegExp(DROPDOWN_EXPAND_KEYWORD, 'g');
         const dropdownTitleWithoutKeyword = dropdownTitle.toString().replace(expandKeywordRegex, '');
         const rotatedIcon = cheerio.load(DROPDOWN_BUTTON_ICON_HTML, { xmlMode: false })('i')
@@ -175,7 +181,7 @@ function formatSiteNav(renderedSiteNav) {
           + '</button>');
       }
       // Recursively format nested lists
-      nestedList.replaceWith(formatSiteNav(nestedList.parent().html()));
+      nestedList.replaceWith(formatSiteNav(nestedList.parent().html(), src));
     }
   });
   return $.html();
@@ -483,7 +489,7 @@ Page.prototype.insertSiteNav = function (pageData) {
     throw new Error(`More than one <navigation> tag found in ${siteNavPath}`);
   } else if (siteNavDataSelector('navigation').length === 1) {
     const siteNavHtml = md.render(siteNavDataSelector('navigation').html().trim().replace(/\n\s*\n/g, '\n'));
-    const formattedSiteNav = formatSiteNav(siteNavHtml);
+    const formattedSiteNav = formatSiteNav(siteNavHtml, this.src);
     siteNavDataSelector('navigation').replaceWith(formattedSiteNav);
   }
   // Wrap sections

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -35,7 +35,7 @@
       <li style="margin-top: 10px">
         <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation"></a></h2>
       </li>
-      <li style="margin-top: 10px"><a href="/test_site/index.html">Home 🏠</a></li>
+      <li style="margin-top: 10px"><a href="/test_site/index.html" class="current">Home 🏠</a></li>
       <li style="margin-top: 10px"><a href="/test_site/bugs/index.html">Open Bugs 🐛</a></li>
       <li style="margin-top: 10px">
         <h3 id="testing-site-nav">Testing Site-Nav<a class="fa fa-anchor" href="#testing-site-nav"></a></h3>
@@ -75,22 +75,22 @@
           </li>
         </ul>
       </li>
-      <li style="margin-top: 10px"><button class="dropdown-btn">Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
- <i class="dropdown-btn-icon">
+      <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open">Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
+ <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-        <div class="dropdown-container">
+        <div class="dropdown-container dropdown-container-open">
           <ul style="list-style-type: none; margin-left:-1em">
             <li style="margin-top: 10px">Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text
               Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text
               Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text
               Really Really Long Text</li>
-            <li style="margin-top: 10px"><button class="dropdown-btn">Nested Dropdown Title
- <i class="dropdown-btn-icon">
+            <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open">Nested Dropdown Title
+ <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-              <div class="dropdown-container">
+              <div class="dropdown-container dropdown-container-open">
                 <ul style="list-style-type: none; margin-left:-1em">
                   <li style="margin-top: 10px">Hello Doge Hello Doge 🐶</li>
-                  <li style="margin-top: 10px"><a href="/test_site/index.html"><strong>NESTED LINK</strong> Home 🏠</a></li>
+                  <li style="margin-top: 10px"><a href="/test_site/index.html" class="current"><strong>NESTED LINK</strong> Home 🏠</a></li>
                   <li style="margin-top: 10px">Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from
                     height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text
                     cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit</li>
@@ -100,13 +100,13 @@
           </ul>
         </div>
       </li>
-      <li style="margin-top: 10px"><button class="dropdown-btn">Test line break in navigation layout
- <i class="dropdown-btn-icon">
+      <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open">Test line break in navigation layout
+ <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
-        <div class="dropdown-container">
+        <div class="dropdown-container dropdown-container-open">
           <ul style="list-style-type: none; margin-left:-1em">
             <li style="margin-top: 10px">Nested line break text ✂️</li>
-            <li style="margin-top:10px"><a href="/test_site/index.html">Nested line break href</a>
+            <li style="margin-top:10px"><a href="/test_site/index.html" class="current">Nested line break href</a>
               <ul style="list-style-type: none; margin-left:-1em">
                 <li style="margin-top: 10px">Nested Nested line break text ✂️</li>
               </ul>

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -30,7 +30,9 @@
     -webkit-transition: 0.4s;
 }
 
-#site-nav a:link, #site-nav a:visited, #site-nav a:hover, #site-nav a:active {
+#site-nav a:active,
+#site-nav a:link,
+#site-nav a:visited {
     color: #565656;
     text-decoration: none;
 }
@@ -114,7 +116,9 @@
 
 /* Hamburger button */
 
-.menu-top-bar, .menu-middle-bar, .menu-bottom-bar {
+.menu-top-bar,
+.menu-middle-bar,
+.menu-bottom-bar {
     background-color: darkslategrey;
     height: 4px;
     margin: 5px 10%;

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -41,6 +41,10 @@
     color: #0076FF;
 }
 
+#site-nav a.current {
+    color: #0072EC;
+}
+
 #site-nav-btn {
     background: transparent;
     cursor: pointer;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #544.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Most site navigation menus in other websites indicate the current page the user is on. We can also indicate which page the user is on in MarkBind's siteNav to allow for easier navigation.

**What changes did you make? (Give an overview)**
I added a check to mark the link referring to the current page being processed in `formatSiteNav` as `class='current'` and also added a `#site-nav a.current` CSS rule to highlight pages marked as `current`, thus highlighting the current loaded page in the siteNav. If the current page link is in a dropdown that is collapsed by default, that dropdown will automatically be expanded.

**Is there anything you'd like reviewers to focus on?**
Note that the current colour being used to highlight the current page `#0072EC` is rather close to the colour for a dropdown `#0076FF`. This should not be a problem once #554 is merged.

**Testing instructions:**
1. Render and open a MarkBind page with a siteNav. If the page is listed in the siteNav, it should be highlighted.
2. If the page is inside a dropdown that is collapsed by default, it should be expanded automatically.