### PR TITLE
Optimize site data update during live preview

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -454,7 +454,7 @@ Site.prototype.generate = function (baseUrl) {
       .then(() => this.buildSourceFiles())
       .then(() => this.copyMarkBindAsset())
       .then(() => this.copyLayouts())
-      .then(() => this.generateSiteData())
+      .then(() => this.updateSiteData())
       .then(() => {
         const endTime = new Date();
         const totalBuildTime = (endTime - startTime) / 1000;
@@ -656,7 +656,7 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
 
   return new Promise((resolve, reject) => {
     Promise.all(processingFiles)
-      .then(() => this.generateSiteData())
+      .then(() => this.updateSiteData(shouldRebuildAllPages ? undefined : filePaths))
       .then(() => logger.info('Pages rebuilt'))
       .then(resolve)
       .catch(reject);
@@ -667,11 +667,16 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
 /**
  * Uses heading data in built pages to generate heading and keyword information for siteData
  * Subsequently writes to siteData.json
+ * @param filePaths optional array of updated file paths during live preview.
+ *                  If undefined, generate site data for all pages
  */
-Site.prototype.generateSiteData = function () {
+Site.prototype.updateSiteData = function (filePaths) {
+  const generateForAllPages = filePaths === undefined;
   this.pages.forEach((page) => {
-    page.collectHeadingsAndKeywords();
-    page.concatenateHeadingsAndKeywords();
+    if (generateForAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
+      page.collectHeadingsAndKeywords();
+      page.concatenateHeadingsAndKeywords();
+    }
   });
   this.writeSiteData();
 };


### PR DESCRIPTION

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [x] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
For large sites, live reload re-collects and generate all heading data, causing long reload times for small changes.

**What changes did you make? (Give an overview)**
Only re-collect heading info for update pages. If `force-reload` flag is called, all site data is reloaded, ie a reload results in a full build.

Previously for `cs2103/website-base` live reload incurred additional 23s for reload (on my machine). Currently it has been reduced to on average 3-5s for changes. The speed depends on the number of affected files during a reload.

**Is there anything you'd like reviewers to focus on?**
Order and naming of default params created for `generateSiteData`.

**Testing instructions:**
1. Update header
1. Update front matter
1. Observe search is updated