### PR TITLE
Improve the way site.json handles pages that match multiple glob or src entries

### DIFF
--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -98,6 +98,46 @@ Note: Page properties that are defined in `site.json` for a particular page will
 </box>
 </span>
 
+<span id="page-glob-overriding">
+<box type="warning">
+
+Note: If multiple **`src`** (pages) or **`glob`** (globs) attributes match a file, MarkBind will merge properties from all entries. If there are conflicting properties, pages are given priority over globs. If there are multiple matching glob entries, the last entry is given priority.
+
+<div class="indented">
+
+{{ icon_example }} Multiple entries matching `index.md`:
+
+```js
+{
+  "pages": [
+    {
+      "src": "index.md",
+      "title": "Hello World",
+      "searchable": "no"
+    },
+    {
+      "glob": "*.md",
+      "layout": "normal",
+      "searchable": "yes"
+    }
+  ],
+}
+```
+
+The following properties will apply to `index.md`:
+
+```js
+{
+  "src": "index.md",
+  "title": "Hello World",  // Inherited from page
+  "layout": "normal",      // Inherited from glob
+  "searchable": "no",      // Page takes priority over glob
+}
+```
+</div>
+</box>
+</span>
+
 #### **`externalScripts`**
 
 **An array of external scripts to be referenced on all pages.** To reference an external script only on specific pages, `externalScripts` should be specified in `pages` instead. Scripts referenced will be run before the layout script.

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -3,6 +3,20 @@
   "pages": [
     {
       "headings": {
+        "popover-initiated-by-trigger-honor-trigger-attribute": "popover initiated by trigger: honor trigger attribute",
+        "support-multiple-inclusions-of-a-modal": "Support multiple inclusions of a modal",
+        "remove-extra-space-in-links": "Remove extra space in links"
+      },
+      "title": "Open Bugs",
+      "src": "bugs/index.md",
+      "layout": "default",
+      "tags": [
+        "tag--shown",
+        "tag--shown-2"
+      ]
+    },
+    {
+      "headings": {
         "panel-with-heading": "Panel with heading | panel keyword",
         "panel-without-heading-with-keyword": "Panel without heading with keyword",
         "panel-with-heading-with-keyword": "Panel with heading with keyword | panel keyword",
@@ -78,6 +92,22 @@
       ]
     },
     {
+      "headings": {
+        "feature-list": "Feature list"
+      },
+      "src": "sub_site/index.md",
+      "title": "",
+      "layout": "default"
+    },
+    {
+      "headings": {
+        "some-heading": "Some heading"
+      },
+      "src": "test_md_fragment.md",
+      "title": "",
+      "layout": "default"
+    },
+    {
       "headings": {},
       "src": "testEmptyFrontmatter.md",
       "title": "Hello World",
@@ -130,36 +160,6 @@
         "tag--shown-2"
       ],
       "src": "testTags.md",
-      "layout": "default"
-    },
-    {
-      "headings": {
-        "popover-initiated-by-trigger-honor-trigger-attribute": "popover initiated by trigger: honor trigger attribute",
-        "support-multiple-inclusions-of-a-modal": "Support multiple inclusions of a modal",
-        "remove-extra-space-in-links": "Remove extra space in links"
-      },
-      "title": "Open Bugs",
-      "src": "bugs/index.md",
-      "layout": "default",
-      "tags": [
-        "tag--shown",
-        "tag--shown-2"
-      ]
-    },
-    {
-      "headings": {
-        "feature-list": "Feature list"
-      },
-      "src": "sub_site/index.md",
-      "title": "",
-      "layout": "default"
-    },
-    {
-      "headings": {
-        "some-heading": "Some heading"
-      },
-      "src": "test_md_fragment.md",
-      "title": "",
       "layout": "default"
     }
   ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Fixes #529 

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Improve the way Site handles files matched by multiple pages entries in site.json

**What changes did you make? (Give an overview)**

- Document behavior for multiple matching entries
- Enforce priority, pages over globs, otherwise later entry takes priority
- Merge properties from multiple entries instead of overwriting them
