### PR TITLE
Suppress error message for parser test

### DIFF
--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -192,7 +192,9 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
   const baseUrlMap = {};
   baseUrlMap[ROOT_PATH] = true;
 
-  const markbinder = new MarkBind();
+  const markbinder = new MarkBind({
+    errorHandler: () => {},
+  });
   const result = await markbinder.includeFile(indexPath, {
     baseUrlMap,
     rootPath: ROOT_PATH,

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -183,6 +183,9 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
 
   const include = ['# Include'].join('\n');
 
+  const expectedErrorMessage = `No such segment 'doesNotExist' in file: ${includePath}`
+    + `\nMissing reference in ${indexPath}`;
+
   const json = {
     'index.md': index,
     'include.md': include,
@@ -193,7 +196,9 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
   baseUrlMap[ROOT_PATH] = true;
 
   const markbinder = new MarkBind({
-    errorHandler: () => {},
+    errorHandler: (e) => {
+      expect(e.message).toEqual(expectedErrorMessage);
+    },
   });
   const result = await markbinder.includeFile(indexPath, {
     baseUrlMap,
@@ -203,8 +208,7 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
 
   const expected = [
     '# Index',
-    `<div style="color: red">No such segment 'doesNotExist' in file: ${includePath}`,
-    `Missing reference in ${indexPath}</div>`,
+    `<div style="color: red">${expectedErrorMessage}</div>`,
     '',
   ].join('\n');
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

This error has been showing up in the [testing console](https://travis-ci.org/MarkBind/markbind/builds/477772901?utm_source=github_status&utm_medium=notification) for a while now:

![image](https://user-images.githubusercontent.com/19278089/50978283-1024bc80-152f-11e9-9d88-7facb5bfebcb.png)

I traced it back to the `includeFile replaces <include src="include.md#exists" optional> with <div>` test which was added by #517.

**What changes did you make? (Give an overview)**

An error is expected so behavior is correct. Suppress the error message by supplying a no-op error handler.
