### PR TITLE
Add check to ensure root folder when creating new Site object

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,13 @@ program
       options.onePage = fsUtil.ensurePosix(options.onePage);
     }
 
-    const site = new Site(rootFolder, outputFolder, options.onePage, options.forceReload, options.siteConfig);
+    let site;
+    try {
+      site = new Site(rootFolder, outputFolder, options.onePage, options.forceReload, options.siteConfig);
+    } catch (err) {
+      logger.error(err.message);
+      return;
+    }
 
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
@@ -160,7 +166,17 @@ program
   .action(() => {
     const rootFolder = path.resolve(process.cwd());
     const outputRoot = path.join(rootFolder, '_site');
-    new Site(rootFolder, outputRoot).deploy()
+
+    let site;
+    try {
+      site = new Site(rootFolder, outputRoot);
+    } catch (err) {
+      logger.error(err.message);
+      return;
+    }
+
+    site
+      .deploy()
       .then(() => {
         logger.info('Deployed!');
       })
@@ -182,7 +198,16 @@ program
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
     printHeader();
-    new Site(rootFolder, outputFolder)
+
+    let site;
+    try {
+      site = new Site(rootFolder, outputFolder);
+    } catch (err) {
+      logger.error(err.message);
+      return;
+    }
+
+    site
       .generate(baseUrl)
       .then(() => {
         logger.info('Build success!');

--- a/src/Site.js
+++ b/src/Site.js
@@ -111,6 +111,11 @@ const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
+  const rootPathExists = fs.existsSync(rootPath);
+  if (!rootPathExists) {
+    throw new Error(`root path ${rootPath} does not exist`);
+  }
+
   const configPath = findUp.sync(siteConfigPath, { cwd: rootPath });
   this.rootPath = configPath ? path.dirname(configPath) : rootPath;
   this.outputPath = outputPath;

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -22,6 +22,13 @@ jest.mock('../../src/util/logger');
 
 afterEach(() => fs.vol.reset());
 
+test('Site constructor throws error if root folder does not exist', () => {
+  expect(() => {
+    // eslint-disable-next-line no-unused-vars
+    const site = new Site('non_existent_root/', '_site');
+  }).toThrow();
+});
+
 test('Site Generate builds the correct amount of assets', async () => {
   const json = {
     'src/asset/font-awesome.csv': '',


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes #583 

**What is the rationale for this request?**

Constructing a new Site object with a non-existent root folder should not be valid.

**What changes did you make? (Give an overview)**

Add a check when constructing a new Site object to ensure that the provided root folder exists. If it does not exist, an error is thrown.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
// Should throw error
const site = new Site("non_existent_path", "_site");
```

**Is there anything you'd like reviewers to focus on?**

Whether the Site object constructor is the best place to perform the check, or if there is a more appropriate place to do it.

**Testing instructions:**

Executing `./index.js serve non_existent_root_folder` should print an error message and terminate early.