### PR TITLE
Allow references to external scripts

### DIFF
--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -28,11 +28,17 @@ Here is a typical `site.json` file:
       "src": "index.md",
       "title": "Hello World",
       "layout": "normal",
-      "searchable": "no"
+      "searchable": "no",
+      "externalScripts": [
+        "https://cdn.plot.ly/plotly-latest.min.js"
+      ]
     },
     {
       "glob": "**/index.md"
     }
+  ],
+  "externalScripts": [
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
   ],
   "deploy": {
     "message": "Site Update.",
@@ -82,6 +88,7 @@ Here is a typical `site.json` file:
 * **`title`**: The page `<title>` for the generated web page. Titles specified here take priority over titles specified in the [front matter](addingPages.html#front-matter) of individual pages.
 * **`layout`**: The [layout]({{ baseUrl }}/userGuide/advancedTopics.html#page-layout) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.
+* **`externalScripts`**: An array of external scripts to be referenced on the page. Scripts referenced will be run before the layout script.
 
 <span id="page-property-overriding">
 <box type="warning">
@@ -89,6 +96,10 @@ Here is a typical `site.json` file:
 Note: Page properties that are defined in `site.json` for a particular page will override those defined in the front matter of the page.
 </box>
 </span>
+
+#### **`externalScripts`**
+
+**An array of external scripts to be referenced on all pages.** To reference an external script only on specific pages, `externalScripts` should be specified in `pages` instead. Scripts referenced will be run before the layout script.
 
 #### **`ignore`**
 

--- a/src/Site.js
+++ b/src/Site.js
@@ -13,6 +13,7 @@ const ProgressBar = require('progress');
 const walkSync = require('walk-sync');
 
 const _ = {};
+_.union = require('lodash/union');
 _.unionWith = require('lodash/unionWith');
 _.uniq = require('lodash/uniq');
 
@@ -329,6 +330,7 @@ Site.prototype.createPage = function (config) {
                                path.join(this.siteAssetsDestPath, 'css', 'bootstrap.min.css')),
       bootstrapVue: path.relative(path.dirname(resultPath),
                                   path.join(this.siteAssetsDestPath, 'css', 'bootstrap-vue.min.css')),
+      externalScripts: _.union(this.siteConfig.externalScripts, config.externalScripts),
       fontAwesome: path.relative(path.dirname(resultPath),
                                  path.join(this.siteAssetsDestPath, 'css', 'font-awesome.min.css')),
       glyphicons: path.relative(path.dirname(resultPath),
@@ -604,6 +606,7 @@ Site.prototype.generatePages = function () {
       title: page.title,
       layout: page.layout || LAYOUT_DEFAULT_NAME,
       searchable: page.searchable !== 'no',
+      externalScripts: page.externalScripts,
     }));
   } else {
     this.pages = addressablePages.map(page => this.createPage({
@@ -612,6 +615,7 @@ Site.prototype.generatePages = function () {
       title: page.title,
       layout: page.layout || LAYOUT_DEFAULT_NAME,
       searchable: page.searchable !== 'no',
+      externalScripts: page.externalScripts,
     }));
   }
 

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -30,5 +30,10 @@
     const baseUrl = '<%- baseUrl %>'
 </script>
 <script src="<%- asset.setup %>"></script>
+<% if (asset.externalScripts) { -%>
+<% for (const script of asset.externalScripts) { -%>
+<script src="<%- script %>"></script>
+<% } -%>
+<% } -%>
 <script src="<%- asset.layoutScript %>"></script>
 </html>

--- a/test/test_site/expected/siteData.json
+++ b/test/test_site/expected/siteData.json
@@ -72,6 +72,12 @@
       "layout": "default"
     },
     {
+      "headings": {},
+      "src": "testExternalScripts.md",
+      "title": "Hello World",
+      "layout": "default"
+    },
+    {
       "headings": {
         "uses-a-layout": "Uses a layout"
       },

--- a/test/test_site/expected/testExternalScripts.html
+++ b/test/test_site/expected/testExternalScripts.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="default-head-top">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hello World</title>
+    <link rel="stylesheet" href="markbind\css\bootstrap.min.css">
+    <link rel="stylesheet" href="markbind\css\bootstrap-vue.min.css">
+    <link rel="stylesheet" href="markbind\css\font-awesome.min.css" >
+    <link rel="stylesheet" href="markbind\css\bootstrap-glyphicons.min.css" >
+    <link rel="stylesheet" href="markbind\css\github.min.css">
+    <link rel="stylesheet" href="markbind\css\markbind.css">
+    <link rel="stylesheet" href="markbind\layouts\default\styles.css">
+    
+    <meta name="default-head-bottom">
+    <link rel="icon" href="/test_site/favicon.png">
+</head>
+<body>
+<div id="app">
+    <div id="content-wrapper">
+  <p>The external script <a href="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">MathJax 2.75</a> should be included, and the following MathJax content should render:</p>
+  <box>
+    When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+  </box>
+</div>
+<div id="flex-div"></div>
+<footer>
+  <div class="text-center">
+    Default footer
+  </div>
+</footer>
+</div>
+</body>
+<script src="markbind\js\vue.min.js"></script>
+<script src="markbind\js\vue-strap.min.js"></script>
+<script src="markbind\js\polyfill.min.js"></script>
+<script src="markbind\js\bootstrap-vue.min.js"></script>
+<script>
+    const baseUrl = '/test_site'
+</script>
+<script src="markbind\js\setup.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<script src="markbind\layouts\default\scripts.js"></script>
+</html>

--- a/test/test_site/site.json
+++ b/test/test_site/site.json
@@ -14,6 +14,14 @@
       "layout": "testLayout"
     },
     {
+      "src": "testExternalScripts.md",
+      "title": "Hello World",
+      "layout": "testLayout",
+      "externalScripts": [
+        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+      ]
+    },
+    {
       "src": "testLayouts.md",
       "title": "Hello World",
       "layout": "testLayout"

--- a/test/test_site/testExternalScripts.md
+++ b/test/test_site/testExternalScripts.md
@@ -1,0 +1,6 @@
+The external script [MathJax 2.75](https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML) should be included, and the following MathJax content should render:
+
+<box>
+When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+</box>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #505.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Users may want to refer to external scripts hosted online to add functionality such as mathematical formatting eg. [MathJax](https://www.mathjax.org) or charts eg. [Plotly.js](https://github.com/plotly/plotly.js).

**What changes did you make? (Give an overview)**
I modified `page.ejs` to include any scripts in `assets.externalScripts` after the default MarkBind scripts, but before `_markbind\layouts\default\scripts.js` so that the user can override the behaviour of external scripts if necessary. Next, I modified `Site.js` to process `externalScripts` specified in either `pages` or in the config root, such that the user can choose to either reference external scripts only in specific pages or for the entire site.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```json
  "pages": [
    {
      "src": "index.md",
      "externalScripts": [
        "https://cdn.plot.ly/plotly-latest.min.js"
      ]
    }
  ],
  "externalScripts": [
    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
  ],
```
**Is there anything you'd like reviewers to focus on?**
I added a test page `testExternalScripts.md` for the per-page case, but have not added a corresponding test for the config root case since it will affect all pages in the test site. It would be cleaner if we do it in a separate test site after #574.

**Testing instructions:**
1. Reference some external scripts by specifying an array of external scripts as `externalScripts` at either `pages` or at the config root. 
	- If referenced at `pages`, they should only be referenced on those specific pages. 
	- If referenced at the config root, they should be referenced on all pages in the site.
2. The scripts should be referenced after the default MarkBind scripts, but before `_markbind\layouts\default\scripts.js`.