### PR TITLE
docs: Fix broken link for "reuse mechanisms"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -143,7 +143,7 @@ Here are some examples:
 
 #### {{ icon_check_blue }} More control to the reader, without duplicating code.
 
-A MarkBind website can be a _buffet_ of content, as opposed to a _set menu_: a site can have optional contents that the reader can access at her discretion, and the same content can be organized in multiple ways so that the reader can choose the one that fits the need. To _cater_ (pun intended) for creating such buffet style websites, MarkBind has **[reuse mechanisms]({{ baseUrl }}/reusingContents.html) for presenting the same content in multiple ways without duplicating the source file**.
+A MarkBind website can be a _buffet_ of content, as opposed to a _set menu_: a site can have optional contents that the reader can access at her discretion, and the same content can be organized in multiple ways so that the reader can choose the one that fits the need. To _cater_ (pun intended) for creating such buffet style websites, MarkBind has **[reuse mechanisms]({{ baseUrl }}/userGuide/reusingContents.html) for presenting the same content in multiple ways without duplicating the source file**.
 
 For example, MarkBind has a powerful `include` mechanism that allows content fragments (i.e., a file or part of a file) to be reused at multiple places in the website. In the example below, both the modal and the expandable panel reuses the same content originating from a _single_ source file.
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Dead link in document main page

**What changes did you make? (Give an overview)**

Put the correct link

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js

```

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**

Check that `reuse mechanisms` link in preview site redirects to correct page.