### PR TITLE
Revise logic to determine root folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const Promise = require('bluebird');
 const _ = {};
 _.isBoolean = require('lodash/isBoolean');
 
+const cliUtil = require('./src/util/cliUtil');
 const fsUtil = require('./src/util/fsUtil');
 const logger = require('./src/util/logger');
 const Site = require('./src/Site');
@@ -58,8 +59,13 @@ program
   .option('-o, --one-page <file>', 'render and serve only a single page in the site')
   .option('-p, --port <port>', 'port for server to listen on (Default is 8080)')
   .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
-  .action((root, options) => {
-    const rootFolder = path.resolve(root || process.cwd());
+  .action((userSpecifiedRoot, options) => {
+    let rootFolder;
+    try {
+      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
+    } catch (err) {
+      logger.error(err.message);
+    }
     const logsFolder = path.join(rootFolder, '_markbind/logs');
     const outputFolder = path.join(rootFolder, '_site');
 
@@ -175,10 +181,15 @@ program
   .option('--baseUrl [baseUrl]',
           'optional flag which overrides baseUrl in site.json, leave argument empty for empty baseUrl')
   .description('build a website')
-  .action((root, output, options) => {
+  .action((userSpecifiedRoot, output, options) => {
     // if --baseUrl contains no arguments (options.baseUrl === true) then set baseUrl to empty string
     const baseUrl = _.isBoolean(options.baseUrl) ? '' : options.baseUrl;
-    const rootFolder = path.resolve(root || process.cwd());
+    let rootFolder;
+    try {
+      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
+    } catch (err) {
+      logger.error(err.message);
+    }
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
     printHeader();

--- a/src/Site.js
+++ b/src/Site.js
@@ -2,7 +2,6 @@
 
 const cheerio = require('cheerio');
 const ejs = require('ejs');
-const findUp = require('find-up');
 const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
@@ -111,8 +110,7 @@ const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
-  const configPath = findUp.sync(siteConfigPath, { cwd: rootPath });
-  this.rootPath = configPath ? path.dirname(configPath) : rootPath;
+  this.rootPath = rootPath;
   this.outputPath = outputPath;
   this.tempPath = path.join(rootPath, TEMP_FOLDER_NAME);
 

--- a/src/util/cliUtil.js
+++ b/src/util/cliUtil.js
@@ -1,0 +1,27 @@
+const findUp = require('find-up');
+const fs = require('fs-extra-promise');
+const path = require('path');
+
+const SITE_CONFIG_NAME = 'site.json';
+
+module.exports = {
+  findRootFolder: (userSpecifiedRoot, siteConfigPath = SITE_CONFIG_NAME) => {
+    if (userSpecifiedRoot) {
+      const resolvedUserSpecifiedRoot = path.resolve(userSpecifiedRoot);
+      const expectedConfigPath = path.join(resolvedUserSpecifiedRoot, siteConfigPath);
+      if (!fs.existsSync(expectedConfigPath)) {
+        throw new Error(`Config file not found at user specified root ${resolvedUserSpecifiedRoot}`);
+      }
+      return resolvedUserSpecifiedRoot;
+    }
+
+    const currentWorkingDir = process.cwd();
+    // Enforces findUp uses value of process.cwd() to determine starting dir
+    // This allows us to define starting dir when testing by mocking process.cwd()
+    const foundConfigPath = findUp.sync(siteConfigPath, { cwd: currentWorkingDir });
+    if (!foundConfigPath) {
+      throw new Error(`No config file found in parent directories of ${currentWorkingDir}`);
+    }
+    return path.dirname(foundConfigPath);
+  },
+};

--- a/test/unit/cliUtil.test.js
+++ b/test/unit/cliUtil.test.js
@@ -1,0 +1,59 @@
+const cliUtil = require('../../src/util/cliUtil');
+const fs = require('fs');
+const path = require('path');
+
+const { SITE_JSON_DEFAULT } = require('./utils/data');
+
+jest.mock('fs');
+jest.mock('process');
+
+afterEach(() => {
+  fs.vol.reset();
+  jest.resetModules();
+});
+
+test('findRootFolder returns user specified root if site config is found there', () => {
+  const json = {
+    'userSpecifiedRoot/site.json': SITE_JSON_DEFAULT,
+  };
+  fs.vol.fromJSON(json, '');
+  const resolvedUserSpecificRoot = path.resolve('userSpecifiedRoot');
+  expect(cliUtil.findRootFolder('userSpecifiedRoot')).toBe(resolvedUserSpecificRoot);
+});
+
+test('findRootFolder throws error if site config is not found in user specified root', () => {
+  const resolvedUserSpecificRoot = path.resolve('userSpecifiedRoot');
+  expect(
+    () => {
+      cliUtil.findRootFolder('userSpecifiedRoot');
+    })
+    .toThrow(`Config file not found at user specified root ${resolvedUserSpecificRoot}`);
+});
+
+test('findRootFolder without user specified root returns first parent dir containing site config', () => {
+  const json = {
+    './site.json': SITE_JSON_DEFAULT,
+    './nested/': {},
+  };
+  const currentWorkingDir = process.cwd();
+  const nestedDir = path.join(currentWorkingDir, 'nested');
+  fs.vol.fromJSON(json, currentWorkingDir);
+  process.cwd = jest.fn().mockReturnValue(nestedDir);
+  expect(cliUtil.findRootFolder()).toBe(currentWorkingDir);
+});
+
+test('findRootFolder without user specified root throws error if no parent dirs contain site config', () => {
+  const json = {
+    './nested': {},
+  };
+  const currentWorkingDir = process.cwd();
+  const nestedDir = path.join(currentWorkingDir, 'nested');
+  fs.vol.fromJSON(json, currentWorkingDir);
+  process.cwd = jest.fn().mockReturnValue(nestedDir);
+  expect(
+    () => {
+      cliUtil.findRootFolder();
+    })
+    .toThrow(`No config file found in parent directories of ${nestedDir}`);
+});
+


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #583.

**What is the rationale for this request?**

When root folder is specified, it should ensure that the specified folder contains the `site.json` config file.

If no root folder is specified, we should search up our parent directories to find the folder containing the `site.json` file, and use it as the root folder.

**What changes did you make? (Give an overview)**

- Move process/fs level logic out of Site class to the CLI handlers
- Update logic to determine root folder to follow expected behaviour

**Provide some example code that this change will affect:**

See #583 

**Testing instructions:**
- `markbind serve nonexistent_folder` should throw error
- `markbind serve` should find the closest ancestor with `site.config` and serve from that folder
- `markbind serve` should throw error if no ancestor contains `site.config`