### PR TITLE
CLI: Add command aliases

### DIFF
--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -30,9 +30,9 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
 
 ### `build` Command
 
-**Format:**: `markbind build [<OPTIONS>] `
+**Format:** `markbind [build | b] [<OPTIONS>] `
 
-**Description**: Generates the site to the directory named `_site` in the current directory.
+**Description:** Generates the site to the directory named `_site` in the current directory.
 
 **`OPTIONS`:**
 * `<output>`<br>
@@ -46,16 +46,16 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
   {{ icon_example }} `--baseUrl staging`
 
 **{{ icon_examples }}**
-* `markbind build`
+* `markbind build` or `markbind b`
 * `markbind build ./myWebsite ./myOutDir`
 * `markbind build ./stagingDir --baseUrl staging`
 <hr><!-- ========================================================================== -->
 
 ### `deploy` Command
 
-**Format**: `markbind deploy`
+**Format:** `markbind [deploy | d]`
 
-**Description**: Deploys the site to the repo's Github pages by pushing everything in the generated site (default dir: `_site`) to the `gh-pages` branch of the current git working directory's remote repo.
+**Description:** Deploys the site to the repo's Github pages by pushing everything in the generated site (default dir: `_site`) to the `gh-pages` branch of the current git working directory's remote repo.
 
 %%{{ icon_info }} Related: [User Guide: Deploying the Website]({{ baseUrl }}/userGuide/deployingTheSite.html).%%
 
@@ -63,7 +63,7 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
 
 ### `init` Command
 
-**Format:** `markbind init [<OPTIONS>]`
+**Format:** `markbind [init | i] [<OPTIONS>]`
 
 **Description:** Initializes a directory into a MarkBind site by creating a skeleton structure for the website which includes a `index.md` and a `site.json`.
 
@@ -72,15 +72,15 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
   Root directory. Default is the current directory.<br>
   {{ icon_example }} `./myWebsite`
 
-**Examples**:
-* `markbind init` : Initializes the site in the current working directory.
+{{ icon_examples }}
+* `markbind init` or `markbind i` : Initializes the site in the current working directory.
 * `markbind init ./myWebsite` : Initializes the site in `./myWebsite` directory.
 
 <hr><!-- ========================================================================== -->
 
 ### `serve` Command
 
-**Format:** `markbind serve [<OPTIONS>]`
+**Format:** `markbind [serve | s] [<OPTIONS>]`
 
 **Description:** Does the following steps:
 1. Builds the site and puts the generated files in a directory named `_site`.
@@ -109,7 +109,7 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
    {{ icon_example }} `-s otherSite.json`
 
 {{ icon_examples }}
-* `markbind serve`
+* `markbind serve` or `markbind s`
 * `markbind serve ./myWebsite`
 * `markbind serve -p 8888 -s otherSite.json`
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ program
 
 program
   .command('init [root]')
+  .alias('i')
   .description('init a markbind website project')
   .action((root) => {
     const rootFolder = path.resolve(root || process.cwd());
@@ -52,6 +53,7 @@ program
 
 program
   .command('serve [root]')
+  .alias('s')
   .description('build then serve a website from a directory')
   .option('-f, --force-reload', 'force a full reload of all site files when a file is changed')
   .option('-n, --no-open', 'do not automatically open the site in browser')
@@ -156,6 +158,7 @@ program
 
 program
   .command('deploy')
+  .alias('d')
   .description('deploy the site to the repo\'s Github pages.')
   .action(() => {
     const rootFolder = path.resolve(process.cwd());
@@ -172,6 +175,7 @@ program
 
 program
   .command('build [root] [output]')
+  .alias('b')
   .option('--baseUrl [baseUrl]',
           'optional flag which overrides baseUrl in site.json, leave argument empty for empty baseUrl')
   .description('build a website')


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Resolves #566

**What is the rationale for this request?**

To enhance the user experience of the CLI

**What changes did you make? (Give an overview)**

- Added aliases to all the CLI command
- Updated the user guide

**Testing instructions:**

1) `markbind s` should be equivalent to `markbind serve` (and so on for the other commands)

2) `markbind --help` should automatically indicate that command aliases are available:

```
$ markbind --help

  Usage: markbind  <command>


  Options:

    -V, --version  output the version number
    -h, --help     output usage information


  Commands:

    init|i [root]                      init a markbind website project
    serve|s [options] [root]           build then serve a website from a directory
    deploy|d                           deploy the site to the repo's Github pages.
    build|b [options] [root] [output]  build a website
```