### PR TITLE
Force cheerio to use MarkBind's htmlparser2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2443,9 +2443,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -2583,7 +2583,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -2662,14 +2662,14 @@
           "version": "2.1.15",
           "bundled": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2760,8 +2760,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -6134,8 +6134,7 @@
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "proto-list": {
       "version": "1.2.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -837,6 +837,20 @@
         "lodash.reduce": "^4.4.0",
         "lodash.reject": "^4.4.0",
         "lodash.some": "^4.4.0"
+      },
+      "dependencies": {
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "github:MarkBind/htmlparser2#815b507c5268a178fa24741d6f74fcc0bc9be4cd",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        }
       }
     },
     "chokidar": {

--- a/test/test_site/testUtil/diffHtml.js
+++ b/test/test_site/testUtil/diffHtml.js
@@ -77,6 +77,7 @@ const diffHtml = (expected, actual) => {
   let insidePath = false;
 
   const diff = jsdiff.diffChars(expected, actual);
+  console.log(diff);
   const isDiff = part => part.added || part.removed;
 
   // assumes no space between paths

--- a/test/test_site/testUtil/diffHtml.js
+++ b/test/test_site/testUtil/diffHtml.js
@@ -77,7 +77,6 @@ const diffHtml = (expected, actual) => {
   let insidePath = false;
 
   const diff = jsdiff.diffChars(expected, actual);
-  console.log(diff);
   const isDiff = part => part.added || part.removed;
 
   // assumes no space between paths
@@ -96,6 +95,7 @@ const diffHtml = (expected, actual) => {
     }
 
     if (isDiff(part) && !insidePath) {
+      console.log(part);
       throw new Error(`Diff outside path!: '${part.value}'`);
     } else if (isDiff(part) && !isPathSeparatorDiff(part.value)) {
       throw new Error(`Diff in path!: '${part.value}'`);


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [x] Other, please explain:

Use npm-shrinkwrap.json to ensure that developers and users of MarkBind will use cheerio with MarkBind's htmlparser2. npm-shrinkwrap.json is published to npm for users that install from npm.

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #582

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Fresh installs of npm before this change may install htmlparser2 v3.10.0.
This happens on Netlify too.

This is suspected to be due to one or both of these reasons:
- cheerio specifies `"htmlparser2": "^3.9.1"` and 3.10.0-markbind.1 < 3.10.0 (https://semver.org).
- MarkBind's htmlparser2 is based off 3.9.2 and 3.9.2 < 3.10.0.

However, [fb55/htmlparser2](https://github.com/fb55/htmlparser2) published v3.10.0 in October 2018 and we only encounter this now.

**What changes did you make? (Give an overview)**

```diff
    "cheerio": {
      "version": "0.22.0",
      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
      "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
      "requires": {
        ...
+     },
+     "dependencies": {
+       "htmlparser2": {
+        "version": "3.9.2",
+         "resolved": "github:MarkBind/htmlparser2#815b507c5268a178fa24741d6f74fcc0bc9be4cd",
+         "requires": {
+           "domelementtype": "^1.3.0",
+           "domhandler": "^2.3.0",
+           "domutils": "^1.5.1",
+           "entities": "^1.1.1",
+           "inherits": "^2.0.1",
+           "readable-stream": "^2.0.2"
+         }
+       }
      }
```

**Provide some example code that this change will affect:**

\-

**Is there anything you'd like reviewers to focus on?**

Is this a good way? We will need to update npm-shrinkwrap.json whenever we update htmlparser2.

**Testing instructions:**

```shell
$ rm -rf node_modules/
$ npm i
```