### PR TITLE
Fix siteNav example in documentation

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -30,14 +30,16 @@
     -webkit-transition: 0.4s;
 }
 
-#site-nav a:active,
-#site-nav a:link,
-#site-nav a:visited {
+/*  Standard style order for links, see CSS2§5.11.3:
+    https://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes */
+.site-nav__a:link,
+.site-nav__a:visited,
+.site-nav__a:active {
     color: #565656;
     text-decoration: none;
 }
 
-#site-nav a:hover {
+.site-nav__a:hover {
     color: #0076FF;
 }
 

--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -1,6 +1,8 @@
-<span id="showBaseUrl">
+<span id="showBaseUrlCode">
 <code>{<span></span>{ baseUrl }}</code>
 </span>
+
+<span id="showBaseUrlText">{<span></span>{ baseUrl }}</span>
 
 <span id="markbind_blue">#00B0F0</span>
 

--- a/docs/userGuide/markBindSyntax.md
+++ b/docs/userGuide/markBindSyntax.md
@@ -322,14 +322,14 @@ More media blocks, embedding services and additional options can be found in [Ma
 
 <div id="intraSiteLinks">
 
-Links to files of the generated site (e.g., an HTML page or an image file) should be specified as absolute paths and should start with {{ showBaseUrl }} (which represents the root directory of the project).
+Links to files of the generated site (e.g., an HTML page or an image file) should be specified as absolute paths and should start with {{ showBaseUrlCode }} (which represents the root directory of the project).
 
 <div class="indented">
 
-{{ icon_example }} Here's how to specify a link to (1) a page, and (2) an image, using the {{ showBaseUrl }}:
+{{ icon_example }} Here's how to specify a link to (1) a page, and (2) an image, using the {{ showBaseUrlCode }}:
 
 1. <code>Click [here]({<span></span>{ baseUrl }}/userGuide/reusingContents.html).</code> {{ icon_arrow_right }} Click [here]({{ baseUrl }}/userGuide/reusingContents.html)
-2. `![](`{{ showBaseUrl }}`/images/preview.png)`
+2. `![](`{{ showBaseUrlCode }}`/images/preview.png)`
 
 </div>
 </div>

--- a/docs/userGuide/tweakingThePageStructure.md
+++ b/docs/userGuide/tweakingThePageStructure.md
@@ -57,9 +57,9 @@ Steps:
 
 <box>
 
-`<script src="`{{ showBaseUrl }}`/js/myCustomScript.js"></script>`<br>
-`<link rel="stylesheet" href="`{{ showBaseUrl }}`/css/main.css">`<br>
-`<link rel="stylesheet" href="`{{ showBaseUrl }}`/css/extra.css">`
+`<script src="`{{ showBaseUrlCode }}`/js/myCustomScript.js"></script>`<br>
+`<link rel="stylesheet" href="`{{ showBaseUrlCode }}`/css/main.css">`<br>
+`<link rel="stylesheet" href="`{{ showBaseUrlCode }}`/css/extra.css">`
 
 </box>
 
@@ -82,10 +82,10 @@ To specify that you want to insert `myCustomLinks.md` into the `<head>` of `myPa
 <box>
 
 **`<head-top>`**<br>
-&nbsp;&nbsp;`<script src="`{{ showBaseUrl }}`/js/myCustomScript.js"></script>`<br>
+&nbsp;&nbsp;`<script src="`{{ showBaseUrlCode }}`/js/myCustomScript.js"></script>`<br>
 **`</head-top>`**<br>
-`<link rel="stylesheet" href="`{{ showBaseUrl }}`/css/main.css">`<br>
-`<link rel="stylesheet" href="`{{ showBaseUrl }}`/css/extra.css">`
+`<link rel="stylesheet" href="`{{ showBaseUrlCode }}`/css/main.css">`<br>
+`<link rel="stylesheet" href="`{{ showBaseUrlCode }}`/css/extra.css">`
 
 </box>
 
@@ -167,14 +167,16 @@ Steps to add a site navigation menu ==(_siteNav_ for short)==:
 
 <box>
 
-`* [:house: Home](`{{showBaseUrl}}`/index.html)`<br>
-`* Docs`<br>
-&nbsp;&nbsp;&nbsp;`* [User Guide](`{{showBaseUrl}}`/ug.html)`<br>
-&nbsp;&nbsp;&nbsp;`* [Dev Guide](`{{showBaseUrl}}`/dg.html)`<br>
-`* [Search](`{{showBaseUrl}}`/search.html)`<br>
-&nbsp;&nbsp;&nbsp;`* [Google Search](https://www.google.com/)`<br>
-&nbsp;&nbsp;&nbsp;`* [YouTube Search](https://www.youtube.com/)`<br>
-`* [Contact](`{{showBaseUrl}}`/contact.html)`
+<code>
+* [:house: Home]({{ showBaseUrlText }}/index.html)<br>
+* Docs<br>
+&nbsp;&nbsp;* [User Guide]({{ showBaseUrlText }}/ug.html)<br>
+&nbsp;&nbsp;* [Dev Guide]({{ showBaseUrlText }}/dg.html)<br>
+* [Search]({{ showBaseUrlText }}/search.html)<br>
+&nbsp;&nbsp;* [Google Search](https://www.google.com/)<br>
+&nbsp;&nbsp;* [YouTube Search](https://www.youtube.com/)<br>
+* [Contact]({{ showBaseUrlText }}/contact.html)
+</code>
 </box>
 
 Here's how another page can make use of the above siteNav:
@@ -223,14 +225,16 @@ You may have additional HTML and Markdown content in a <tooltip content="the fil
 
 <box>
 
-`# Site Map`<br>
-**`<navigation>`**<br>
-`* [:house: Home](`{{showBaseUrl}}`/index.html)`<br>
-`* Docs`<br>
-&nbsp;&nbsp;&nbsp;`* [User Guide](`{{showBaseUrl}}`/ug.html)`<br>
-&nbsp;&nbsp;&nbsp;`* [Dev Guide](`{{showBaseUrl}}`/dg.html)`<br>
-`* [Search](`{{showBaseUrl}}`/search.html)`<br>
-**`</navigation>`**<br>
+<code>
+# Site Map<br>
+<strong><<span></span>navigation></strong><br>
+* [:house: Home]({{ showBaseUrlText }}/index.html)<br>
+* Docs<br>
+&nbsp;&nbsp;* [User Guide]({{ showBaseUrlText }}/ug.html)<br>
+&nbsp;&nbsp;* [Dev Guide]({{ showBaseUrlText }}/dg.html)<br>
+* [Search]({{ showBaseUrlText }}/search.html)<br>
+<strong><<span></span>/navigation></strong><br>
+</code>
 </box>
 </div>
 

--- a/docs/userGuide/tweakingThePageStructure.md
+++ b/docs/userGuide/tweakingThePageStructure.md
@@ -189,21 +189,21 @@ Here's how another page can make use of the above siteNav:
 Here's how the above siteNav will appear:
 
 <ul style="list-style-type: none; margin-left:-1em">
-  <li style="margin-top: 10px"><a href="/index.html">🏠 Home</a></li>
+  <li style="margin-top: 10px"><a class="site-nav__a" href="/index.html">🏠 Home</a></li>
   <li style="margin-top: 10px">
     <button class="dropdown-btn">Docs <i class="dropdown-btn-icon">
       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
     <div class="dropdown-container">
       <ul style="list-style-type: none; margin-left:-1em">
-        <li style="margin-top: 10px"><a href="">User Guide</a></li>
-        <li style="margin-top: 10px"><a href="">Dev Guide</a></li>
+        <li style="margin-top: 10px"><a class="site-nav__a" href="">User Guide</a></li>
+        <li style="margin-top: 10px"><a class="site-nav__a" href="">Dev Guide</a></li>
       </ul>
     </div>
   </li>
-  <li style="margin-top:10px"><a href="">Search</a>
+  <li style="margin-top:10px"><a class="site-nav__a" href="">Search</a>
     <ul style="list-style-type: none; margin-left:-1em">
-      <li style="margin-top: 10px"><a href="http://www.google.com">Google Search</a></li>
-      <li style="margin-top: 10px"><a href="http://www.youtube.com">YouTube Search</a></li>
+      <li style="margin-top: 10px"><a class="site-nav__a" href="http://www.google.com">Google Search</a></li>
+      <li style="margin-top: 10px"><a class="site-nav__a" href="http://www.youtube.com">YouTube Search</a></li>
     </ul>
   </li>
 </ul>

--- a/src/Page.js
+++ b/src/Page.js
@@ -141,6 +141,9 @@ function formatSiteNav(renderedSiteNav, src) {
   // Tidy up the style of the unordered list <ul>
   listItems.parent().attr('style', 'list-style-type: none; margin-left:-1em');
 
+  // Set class of <a> to ${SITE_NAV_ID}__a to style links
+  listItems.find('a[href]').addClass(`${SITE_NAV_ID}__a`);
+
   // Highlight current page
   const currentPageHtmlPath = src.replace(/\.(md|mbd)$/, '.html');
   listItems.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`).addClass('current');

--- a/test/test_site/expected/index.html
+++ b/test/test_site/expected/index.html
@@ -124,8 +124,8 @@
       <li style="margin-top: 10px">
         <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation"></a></h2>
       </li>
-      <li style="margin-top: 10px"><a href="/test_site/index.html" class="current">Home 🏠</a></li>
-      <li style="margin-top: 10px"><a href="/test_site/bugs/index.html">Open Bugs 🐛</a></li>
+      <li style="margin-top: 10px"><a href="/test_site/index.html" class="site-nav__a current">Home 🏠</a></li>
+      <li style="margin-top: 10px"><a href="/test_site/bugs/index.html" class="site-nav__a">Open Bugs 🐛</a></li>
       <li style="margin-top: 10px">
         <h3 id="testing-site-nav">Testing Site-Nav<a class="fa fa-anchor" href="#testing-site-nav"></a></h3>
       </li>
@@ -134,31 +134,31 @@
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
         <div class="dropdown-container dropdown-container-open">
           <ul style="list-style-type: none; margin-left:-1em">
-            <li style="margin-top: 10px"><a href="https://www.google.com/">Dropdown link one</a></li>
+            <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a">Dropdown link one</a></li>
             <li style="margin-top: 10px"><button class="dropdown-btn">Nested Dropdown title 📐
  <i class="dropdown-btn-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
               <div class="dropdown-container">
                 <ul style="list-style-type: none; margin-left:-1em">
-                  <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></li>
-                  <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link two</a></li>
+                  <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link one</a></li>
+                  <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link two</a></li>
                 </ul>
               </div>
             </li>
-            <li style="margin-top: 10px"><a href="https://www.google.com/">Dropdown link two</a></li>
+            <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a">Dropdown link two</a></li>
           </ul>
         </div>
       </li>
-      <li style="margin-top: 10px"><a href="https://www.google.com/"><mark>Third Link</mark> 📋</a></li>
-      <li style="margin-top:10px">Filler text <a href="https://www.youtube.com/"><span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span> Youtube 📺</a> filler text
+      <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a"><mark>Third Link</mark> 📋</a></li>
+      <li style="margin-top:10px">Filler text <a href="https://www.youtube.com/" class="site-nav__a"><span class="glyphicon glyphicon-facetime-video" aria-hidden="true"></span> Youtube 📺</a> filler text
         <ul style="list-style-type: none; margin-left:-1em">
-          <li style="margin-top: 10px"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">The answer to everything in the universe</a></li>
+          <li style="margin-top: 10px"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="site-nav__a">The answer to everything in the universe</a></li>
           <li style="margin-top: 10px"><button class="dropdown-btn dropdown-btn-open"><mark>Dropdown title</mark> <span class="glyphicon glyphicon-comment" aria-hidden="true"></span> ✏️ 
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
             <div class="dropdown-container dropdown-container-open">
               <ul style="list-style-type: none; margin-left:-1em">
-                <li style="margin-top: 10px"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></li>
+                <li style="margin-top: 10px"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link one</a></li>
               </ul>
             </div>
           </li>
@@ -179,7 +179,7 @@
               <div class="dropdown-container dropdown-container-open">
                 <ul style="list-style-type: none; margin-left:-1em">
                   <li style="margin-top: 10px">Hello Doge Hello Doge 🐶</li>
-                  <li style="margin-top: 10px"><a href="/test_site/index.html" class="current"><strong>NESTED LINK</strong> Home 🏠</a></li>
+                  <li style="margin-top: 10px"><a href="/test_site/index.html" class="site-nav__a current"><strong>NESTED LINK</strong> Home 🏠</a></li>
                   <li style="margin-top: 10px">Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from
                     height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text
                     cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit</li>
@@ -195,7 +195,7 @@
         <div class="dropdown-container dropdown-container-open">
           <ul style="list-style-type: none; margin-left:-1em">
             <li style="margin-top: 10px">Nested line break text ✂️</li>
-            <li style="margin-top:10px"><a href="/test_site/index.html" class="current">Nested line break href</a>
+            <li style="margin-top:10px"><a href="/test_site/index.html" class="site-nav__a current">Nested line break href</a>
               <ul style="list-style-type: none; margin-left:-1em">
                 <li style="margin-top: 10px">Nested Nested line break text ✂️</li>
               </ul>

--- a/test/test_site/expected/markbind/css/site-nav.css
+++ b/test/test_site/expected/markbind/css/site-nav.css
@@ -30,14 +30,16 @@
     -webkit-transition: 0.4s;
 }
 
-#site-nav a:active,
-#site-nav a:link,
-#site-nav a:visited {
+/*  Standard style order for links, see CSS2§5.11.3:
+    https://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes */
+.site-nav__a:link,
+.site-nav__a:visited,
+.site-nav__a:active {
     color: #565656;
     text-decoration: none;
 }
 
-#site-nav a:hover {
+.site-nav__a:hover {
     color: #0076FF;
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #559.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The documentation for the siteNav component and example code are styled incorrectly as they appear different from the actual siteNav. This may lead to user confusion.

**What changes did you make? (Give an overview)**
I added a `.site-nav` class that only has styles related to links and had both the example siteNav in the docs and the real siteNav use that class style, so that the styles of both will be consistent across both. I also changed the styles of the example code given so that they reflect the correct indentation to use.

**Testing instructions:**
1. Render a page with the siteNav. It should have the same styles as before.
2. Check the example siteNav render and code to ensure that they appear identical to the actual siteNav render and code.