### PR TITLE
Restyle background color for inline code text

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -5,7 +5,14 @@ blockquote {
 }
 
 code {
+    background: #f8f8f8;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
     word-break: normal;
+}
+
+pre.hljs > code {
+    background: none;
 }
 
 pre > code.hljs {

--- a/docs/userGuide/markBindSyntax.md
+++ b/docs/userGuide/markBindSyntax.md
@@ -138,14 +138,13 @@ Go to the [MarkBind Website](https://markbind.github.io/markbind/)
 
 ##### Fenced code blocks / syntax highlighting
 
-<span>
-<code>```python</code>
-</span>
-
-<code>def say_hello(name):</code><br>
-&nbsp;&nbsp;&nbsp;&nbsp;`print('Hello', name)`<br>
-&nbsp;&nbsp;&nbsp;&nbsp;`print('How are you', name)`<br>
-<code>```</code>
+````
+```python
+def say_hello(name):
+    print('Hello', name)<br>
+    print('How are you', name)<br>
+```
+````
 
 ```python
 def say_hello(name):

--- a/test/test_site/expected/markbind/css/markbind.css
+++ b/test/test_site/expected/markbind/css/markbind.css
@@ -5,7 +5,14 @@ blockquote {
 }
 
 code {
+    background: #f8f8f8;
+    border-radius: 3px;
+    padding: 0.2em 0.4em;
     word-break: normal;
+}
+
+pre.hljs > code {
+    background: none;
 }
 
 pre > code.hljs {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Bug fix

Fixes #342 

**What is the rationale for this request?**
Background color for code text doesn't match panel heading color

**What changes did you make? (Give an overview)**
- Update the CSS for the `.code` class
- Also updated a section in the User Guide to use a proper multiline code block instead of many inline code blocks

**Testing instructions:**

See that inline code blocks now have a grey background:
<img width="377" alt="screenshot 2019-01-19 at 5 54 41 pm" src="https://user-images.githubusercontent.com/9073504/51461104-3997e080-1d98-11e9-8bdb-80276401e26a.png">

<img width="659" alt="screenshot 2019-01-19 at 5 55 22 pm" src="https://user-images.githubusercontent.com/9073504/51461105-3997e080-1d98-11e9-8316-ca2417882df3.png">

While multiline code blocks are unaffected:
<img width="393" alt="screenshot 2019-01-21 at 4 19 14 pm" src="https://user-images.githubusercontent.com/9073504/51461261-8bd90180-1d98-11e9-9f44-77c19c6b3991.png">
