### PR TITLE
Load site data asynchronously

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -36,6 +36,15 @@ function setupAnchors() {
 function removeLoadingOverlay() {
   jQuery('#loading-overlay').remove();
 }
+
+function getSearchData(vm) {
+  jQuery.getJSON(`${baseUrl}/siteData.json`)
+    .then((siteData) => {
+      // eslint-disable-next-line no-param-reassign
+      vm.searchData = siteData.pages;
+    });
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
@@ -84,11 +93,7 @@ function setup() {
   setupPageNav();
 }
 
-function setupWithSearch(siteData) {
-  if (!siteData.enableSearch) {
-    setup();
-    return;
-  }
+function setupWithSearch() {
   const { searchbar } = VueStrap.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
@@ -98,7 +103,7 @@ function setupWithSearch(siteData) {
     },
     data() {
       return {
-        searchData: siteData.pages,
+        searchData: [],
       };
     },
     methods: {
@@ -110,12 +115,15 @@ function setupWithSearch(siteData) {
     },
     mounted() {
       executeAfterMountedRoutines();
+      getSearchData(this);
     },
   });
   setupSiteNav();
   setupPageNav();
 }
 
-jQuery.getJSON(`${baseUrl}/siteData.json`)
-  .then(siteData => setupWithSearch(siteData))
-  .catch(() => setup());
+if (enableSearch) {
+  setupWithSearch();
+} else {
+  setup();
+}

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -37,7 +37,7 @@ function removeLoadingOverlay() {
   jQuery('#loading-overlay').remove();
 }
 
-function getSearchData(vm) {
+function updateSearchData(vm) {
   jQuery.getJSON(`${baseUrl}/siteData.json`)
     .then((siteData) => {
       // eslint-disable-next-line no-param-reassign
@@ -115,7 +115,7 @@ function setupWithSearch() {
     },
     mounted() {
       executeAfterMountedRoutines();
-      getSearchData(this);
+      updateSearchData(this);
     },
   });
   setupSiteNav();

--- a/src/Page.js
+++ b/src/Page.js
@@ -60,6 +60,7 @@ function Page(pageConfig) {
   this.layout = pageConfig.layout;
   this.layoutsAssetPath = pageConfig.layoutsAssetPath;
   this.rootPath = pageConfig.rootPath;
+  this.enableSearch = pageConfig.enableSearch;
   this.searchable = pageConfig.searchable;
   this.src = pageConfig.src;
   this.tags = pageConfig.tags;
@@ -234,6 +235,7 @@ Page.prototype.prepareTemplateData = function () {
     pageNav: this.isPageNavigationSpecifierValid(),
     siteNav: this.frontMatter.siteNav,
     title: prefixedTitle,
+    enableSearch: this.enableSearch,
   };
 };
 

--- a/src/Site.js
+++ b/src/Site.js
@@ -313,6 +313,7 @@ Site.prototype.createPage = function (config) {
     tags: this.siteConfig.tags,
     pageTemplate: this.pageTemplate,
     rootPath: this.rootPath,
+    enableSearch: this.siteConfig.enableSearch,
     searchable: this.siteConfig.enableSearch && config.searchable,
     src: config.pageSrc,
     layoutsAssetPath: path.relative(path.dirname(resultPath),

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -38,6 +38,7 @@
 <script src="<%- asset.bootstrapVueJs %>"></script>
 <script>
     const baseUrl = '<%- baseUrl %>'
+    const enableSearch = <%- enableSearch %>
 </script>
 <script src="<%- asset.setup %>"></script>
 <% if (asset.externalScripts) { -%>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -97,6 +97,7 @@
 <script src="../markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="../markbind/js/setup.js"></script>
 <script src="../markbind/layouts/default/scripts.js"></script>

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -479,6 +479,7 @@ specification that specifies how the product will address the requirements. </sp
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/default/scripts.js"></script>

--- a/test/functional/test_site/expected/markbind/js/setup.js
+++ b/test/functional/test_site/expected/markbind/js/setup.js
@@ -36,6 +36,15 @@ function setupAnchors() {
 function removeLoadingOverlay() {
   jQuery('#loading-overlay').remove();
 }
+
+function updateSearchData(vm) {
+  jQuery.getJSON(`${baseUrl}/siteData.json`)
+    .then((siteData) => {
+      // eslint-disable-next-line no-param-reassign
+      vm.searchData = siteData.pages;
+    });
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
@@ -84,11 +93,7 @@ function setup() {
   setupPageNav();
 }
 
-function setupWithSearch(siteData) {
-  if (!siteData.enableSearch) {
-    setup();
-    return;
-  }
+function setupWithSearch() {
   const { searchbar } = VueStrap.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
@@ -98,7 +103,7 @@ function setupWithSearch(siteData) {
     },
     data() {
       return {
-        searchData: siteData.pages,
+        searchData: [],
       };
     },
     methods: {
@@ -110,12 +115,15 @@ function setupWithSearch(siteData) {
     },
     mounted() {
       executeAfterMountedRoutines();
+      updateSearchData(this);
     },
   });
   setupSiteNav();
   setupPageNav();
 }
 
-jQuery.getJSON(`${baseUrl}/siteData.json`)
-  .then(siteData => setupWithSearch(siteData))
-  .catch(() => setup());
+if (enableSearch) {
+  setupWithSearch();
+} else {
+  setup();
+}

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -55,6 +55,7 @@
 <script src="../markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="../markbind/js/setup.js"></script>
 <script src="../markbind/layouts/default/scripts.js"></script>

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -46,6 +46,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/default/scripts.js"></script>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -49,6 +49,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -62,6 +62,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -62,6 +62,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>

--- a/test/functional/test_site/expected/testTags.html
+++ b/test/functional/test_site/expected/testTags.html
@@ -63,6 +63,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/default/scripts.js"></script>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -47,6 +47,7 @@
 <script src="markbind/js/bootstrap-vue.min.js"></script>
 <script>
     const baseUrl = '/test_site'
+    const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="markbind/layouts/default/scripts.js"></script>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves #608.

**What is the rationale for this request?**

To avoid having render being blocked on waiting for `siteData.json` to load, we first render the page then load it asynchronously.

**What changes did you make? (Give an overview)**

- Embed the `enableSearch` variable in the HTML document
- Update `setup.js` to fetch `siteData.json` asynchronously

**Is there anything you'd like reviewers to focus on?**

I've embedded the `enableSearch` variable in the HTML document to allow us to decide whether to use `setup()` or `setupWithSearch()` without first having to load `siteData.json` to preserve the original behavior. However, I was wondering whether or not it would be possible for us to simply use `setupWithSearch()` for both cases, since sites with search disabled cannot use the `searchbar` component anyway (see #620). This would allow us to avoid having to embed `enableSearch` in the HTML document.

**Testing instructions:**
Observe the chrome network tab. `siteData.json` should be loaded after the page is rendered completely.