### PR TITLE
Fix unexpected indentation in the first line of fenced text

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it/index.js
+++ b/src/lib/markbind/src/lib/markdown-it/index.js
@@ -12,7 +12,7 @@ const markdownIt = require('markdown-it')({
       }
     }
 
-    return '<pre class="hljs"><code>' + markdownIt.utils.escapeHtml(str) + '</code></pre>';
+    return '<pre><code class="hljs">' + markdownIt.utils.escapeHtml(str) + '</code></pre>';
   }
 });
 const slugify = require('@sindresorhus/slugify');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes #618.

**What is the rationale for this request?**

Fenced code blocks seem to have an unexpected indentation in the first line. 
As discussed in #618, this is because the `<code>` tag does not have the  `display: block` style attribute. Since the `hljs` class has this style tag by [default](https://github.com/highlightjs/highlight.js/blob/master/src/styles/default.css), this bug can be fixed by adding `class="hljs"` to the `<code>` tag.

**What changes did you make? (Give an overview)**

In `/markdown-it/index.js#15`,

`return '<pre class="hljs"><code>' + markdownIt.utils.escapeHtml(str) + '</code></pre>';` 

was changed to:

`return '<pre><code class="hljs">' + markdownIt.utils.escapeHtml(str) + '</code></pre>';`

Note that this bug only arises when no language is specified after the backticks. If a language is specified, then the current code assigns the `hljs` class to `<code>`.

**Provide some example code that this change will affect:**

The syntax for adding code blocks remains the same, only the way they are being displayed will change.

**Is there anything you'd like reviewers to focus on?**

Make sure the indentation is correct for fenced code blocks, and that inline code blocks are not being affected by this change.

**Testing instructions:**

Add a fenced code block (with no language specified) and build the website. Check that there is no unexpected indentation in the first line of the block.