### PR TITLE
Add diff printing for easier debugging

### DIFF
--- a/test/functional/testUtil/diffHtml.js
+++ b/test/functional/testUtil/diffHtml.js
@@ -1,105 +1,25 @@
 const jsdiff = require('diff');
-
-/**
- * Checks if fragment ends with an unclosed path
- * true: src="
- * false: src=""
- *        src="..."
- */
-const endsWithUnclosedPath = (fragment) => {
-  for (let i = fragment.length - 1; i > 4; i -= 1) {
-    if (fragment[i] === '"') {
-      if (fragment.substring(i - 4, i) === 'src=' || fragment.substring(i - 5, i) === 'href=') {
-        return true;
-      }
-      return false;
-    }
-  }
-  return false;
-};
-
-/**
- * Checks if the ending portion of the fragment is inside an html tag
- * true: <tag src=".../
- *       <panel header="<a>link</a>" src=".../
- * false: <text> src="..
- *        <div/>
- *        <panel header="<a>link</a>"> src="...
- */
-const endsWithOpeningTag = (fragment) => {
-  let numUnmatchedClosingBracket = 0;
-  for (let i = fragment.length - 1; i >= 0; i -= 1) {
-    if (fragment[i] === '>') {
-      numUnmatchedClosingBracket += 1;
-    } else if (fragment[i] === '<') {
-      if (numUnmatchedClosingBracket === 0) {
-        return true;
-      }
-      numUnmatchedClosingBracket -= 1;
-    }
-  }
-  return false;
-};
-
-/**
- * Checks if the start portion of the fragment closes a path
- * Assumes that previous fragment was the start of or was within an unclosed path
- * true: "
- *       path/to/file.jpg"
- *       file.jpg" <
- * false: < src="...
- *        > "...
- */
-const startsWithClosedPath = (fragment) => {
-  for (let i = 0; i <= fragment.length - 1; i += 1) {
-    if (fragment[i] === '<' || fragment[i] === '>') {
-      return false;
-    }
-    if (fragment[i] === '"') {
-      return true;
-    }
-  }
-  return false;
-};
-
-/**
- * Checks if diff is a path separator character
- */
-const isPathSeparatorDiff = diff => diff === '\\' || diff === '/';
+const DiffPrinter = require('./diffPrinter');
 
 /**
  * Checks for any diffs between expected.html and actual.html
  * @param {string} expected
  * @param {string} actual
- * @throws {Error} if any diffs that are not path separators are found
+ * @param {string} filePathName
+ * @returns {bool} if diff was found
  */
-const diffHtml = (expected, actual) => {
-  let insidePath = false;
-
-  const diff = jsdiff.diffChars(expected, actual);
+const diffHtml = (expected, actual, filePathName) => {
+  const diffParts = jsdiff.diffWords(expected, actual);
   const isDiff = part => part.added || part.removed;
-
-  // assumes no space between paths
-  const isClosedPath = fragment =>
-    insidePath
-    && startsWithClosedPath(fragment);
-
-  diff.forEach((part) => {
-    if (isClosedPath(part.value)) {
-      insidePath = false;
-    }
-
-    if (endsWithUnclosedPath(part.value) && endsWithOpeningTag(part.value)) {
-      // Any diffs following this fragment will be diffs within a path
-      insidePath = true;
-    }
-
-    if (isDiff(part) && !insidePath) {
-      throw new Error(`Diff outside path!: '${part.value}'`);
-    } else if (isDiff(part) && !isPathSeparatorDiff(part.value)) {
-      throw new Error(`Diff in path!: '${part.value}'`);
-    }
-  });
+  const hasDiff = diffParts.some(isDiff);
+  if (hasDiff) {
+    DiffPrinter.printLine();
+    DiffPrinter.printLine('-------------------------------------', 'grey');
+    DiffPrinter.printLine(`Diff found in ${filePathName}`, 'grey');
+    DiffPrinter.printLine();
+    DiffPrinter.printDiff(diffParts);
+  }
+  return hasDiff;
 };
 
 module.exports = diffHtml;

--- a/test/functional/testUtil/diffPrinter.js
+++ b/test/functional/testUtil/diffPrinter.js
@@ -1,11 +1,9 @@
-class DiffPrinter {
-  /* eslint-disable lodash/prefer-constant */
-  static get ANSI_RED() { return '\u001B[31m'; }
-  static get ANSI_GREEN() { return '\u001B[32m'; }
-  static get ANSI_GREY() { return '\u001B[90m'; }
-  static get ANSI_RESET() { return '\u001B[0m'; }
-  /* eslint-enable lodash/prefer-constant */
+const ANSI_RED = '\u001B[31m';
+const ANSI_GREEN = '\u001B[32m';
+const ANSI_GREY = '\u001B[90m';
+const ANSI_RESET = '\u001B[0m';
 
+class DiffPrinter {
   /**
    * Prints line of text in colour provided
    * @param {string} text text to print, default: no text
@@ -15,19 +13,19 @@ class DiffPrinter {
     let ansiEscCode = '';
     switch (colour) {
     case 'red':
-      ansiEscCode = DiffPrinter.ANSI_RED;
+      ansiEscCode = ANSI_RED;
       break;
     case 'green':
-      ansiEscCode = DiffPrinter.ANSI_GREEN;
+      ansiEscCode = ANSI_GREEN;
       break;
     case 'grey':
-      ansiEscCode = DiffPrinter.ANSI_GREY;
+      ansiEscCode = ANSI_GREY;
       break;
     default:
       ansiEscCode = '';
       break;
     }
-    process.stderr.write(`${ansiEscCode}${text}${DiffPrinter.ANSI_RESET}\n`);
+    process.stderr.write(`${ansiEscCode}${text}${ANSI_RESET}\n`);
   }
 
   /**
@@ -40,11 +38,11 @@ class DiffPrinter {
     let lineParts = [{ value: '' }];
     parts.forEach(({ value, added, removed }) => {
       let lines = value.split(/\n/);
-      let asciEscCode = DiffPrinter.ANSI_GREY;
-      if (added) asciEscCode = DiffPrinter.ANSI_GREEN;
-      else if (removed) asciEscCode = DiffPrinter.ANSI_RED;
+      let asciEscCode = ANSI_GREY;
+      if (added) asciEscCode = ANSI_GREEN;
+      else if (removed) asciEscCode = ANSI_RED;
       lines = lines.map(line => ({
-        value: asciEscCode + line + DiffPrinter.ANSI_RESET,
+        value: asciEscCode + line + ANSI_RESET,
         diff: added || removed,
       }));
 

--- a/test/functional/testUtil/diffPrinter.js
+++ b/test/functional/testUtil/diffPrinter.js
@@ -1,0 +1,111 @@
+class DiffPrinter {
+  /* eslint-disable lodash/prefer-constant */
+  static get ANSI_RED() { return '\u001B[31m'; }
+  static get ANSI_GREEN() { return '\u001B[32m'; }
+  static get ANSI_GREY() { return '\u001B[90m'; }
+  static get ANSI_RESET() { return '\u001B[0m'; }
+  /* eslint-enable lodash/prefer-constant */
+
+  /**
+   * Prints line of text in colour provided
+   * @param {string} text text to print, default: no text
+   * @param {string} colour colour of text, default: no colour
+   */
+  static printLine(text = '', colour = 'none') {
+    let ansiEscCode = '';
+    switch (colour) {
+    case 'red':
+      ansiEscCode = DiffPrinter.ANSI_RED;
+      break;
+    case 'green':
+      ansiEscCode = DiffPrinter.ANSI_GREEN;
+      break;
+    case 'grey':
+      ansiEscCode = DiffPrinter.ANSI_GREY;
+      break;
+    default:
+      ansiEscCode = '';
+      break;
+    }
+    process.stderr.write(`${ansiEscCode}${text}${DiffPrinter.ANSI_RESET}\n`);
+  }
+
+  /**
+   * Splits and combines change objects such that their value contains a single line
+   * Also adds ANSI Escape Codes for diffs and unchanged lines
+   * @param {Array} parts array of change objects returned by jsdiff#diffWords
+   * @returns {Array} change objects where their value contains a single line
+   */
+  static generateLineParts(parts) {
+    let lineParts = [{ value: '' }];
+    parts.forEach(({ value, added, removed }) => {
+      let lines = value.split(/\n/);
+      let asciEscCode = DiffPrinter.ANSI_GREY;
+      if (added) asciEscCode = DiffPrinter.ANSI_GREEN;
+      else if (removed) asciEscCode = DiffPrinter.ANSI_RED;
+      lines = lines.map(line => ({
+        value: asciEscCode + line + DiffPrinter.ANSI_RESET,
+        diff: added || removed,
+      }));
+
+      if (lines.length) {
+        const prevPart = lineParts.pop();
+        lines[0] = {
+          value: prevPart.value + lines[0].value,
+          diff: lines[0].diff || prevPart.diff,
+        };
+      }
+      lineParts = lineParts.concat(lines);
+    });
+    return lineParts;
+  }
+
+  /**
+   * Set line objects which contain diffs for printing
+   * Also sets top and bottom 3 lines for printing
+   * @param {Array} lineParts array of line objects after being split
+   *                          into lines by DiffPrinter#generateLineParts
+   */
+  static setPartsToPrint(lineParts) {
+    lineParts.forEach((linePart, i) => {
+      if (linePart.diff) {
+        for (let j = -3; j <= 3; j += 1) {
+          const partsToPrint = lineParts[i + j];
+          if (partsToPrint) partsToPrint.toPrint = true;
+        }
+      }
+    });
+  }
+
+  /**
+   * Prints value in line objects that are set for printing
+   * If there is a gap between lines, print ellipsis
+   * @param {Array} lineParts array of line objects after being set for printing
+   *                          in DiffPrinter#setPartsToPrint
+   */
+  static printLineParts(lineParts) {
+    lineParts.forEach((linePart, i) => {
+      const prevPart = lineParts[i - 1];
+      if (linePart.toPrint) {
+        if (prevPart && !prevPart.toPrint) {
+          this.printLine();
+          this.printLine('...', 'grey');
+          this.printLine();
+        }
+        this.printLine(linePart.value, 'none'); // already has ANSI Escape Code
+      }
+    });
+  }
+
+  /**
+   * Prints diff with ANSI Escape Codes for colour
+   * @param {Array} parts array of change of objects as returned by jsdiff#diffWords
+   */
+  static printDiff(parts) {
+    const lineParts = this.generateLineParts(parts);
+    this.setPartsToPrint(lineParts);
+    this.printLineParts(lineParts);
+  }
+}
+
+module.exports = DiffPrinter;

--- a/test/functional/testUtil/test.js
+++ b/test/functional/testUtil/test.js
@@ -17,6 +17,7 @@ const actualDirectory = path.join(sitePath, '_site');
 const expectedPaths = walkSync(expectedDirectory, { directories: false });
 const actualPaths = walkSync(actualDirectory, { directories: false });
 
+let error = false;
 if (expectedPaths.length !== actualPaths.length) {
   throw new Error('Unequal number of files');
 }
@@ -34,11 +35,8 @@ for (let i = 0; i < expectedPaths.length; i += 1) {
     // compare html files
     const expected = readFileSync(expectedDirectory, expectedFilePath);
     const actual = readFileSync(actualDirectory, actualFilePath);
-    try {
-      diffHtml(expected, actual);
-    } catch (err) {
-      throw new Error(`${err.message} in ${expectedFilePath}`);
-    }
+    const hasDiff = diffHtml(expected, actual, expectedFilePath);
+    error = error || hasDiff;
   } else if (parsed.base === 'siteData.json') {
     // compare site data
     const expected = readFileSync(expectedDirectory, expectedFilePath);
@@ -48,3 +46,5 @@ for (let i = 0; i < expectedPaths.length; i += 1) {
     }
   }
 }
+
+if (error) throw new Error('Diffs found in .html files');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [x] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
When html file compare fails on travis, there was no useful infomation. Also the diff does not finish for all files if there is a diff in one file.



**What changes did you make? (Give an overview)**
Print diffs to console. Red = removed from expected, green = added by new MarkBind, grey = common
Log can be viewed here:
https://travis-ci.org/nicholaschuayunzhi/markbind/builds/484199960?utm_source=github_status&utm_medium=notification

**Is there anything you'd like reviewers to focus on?**
If code and log is understandable. I use [jsdiff](https://github.com/kpdecker/jsdiff#examples) but i do not use the `colors` library.

Consideration: we may move to jest snapshot testing in near future?

**Testing instructions:**
Add some diffs to html file and run test.