### PR TITLE
Add scrollspy only when pageNav is enabled

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -231,7 +231,7 @@ Page.prototype.prepareTemplateData = function () {
     faviconUrl: this.faviconUrl,
     headFileBottomContent: this.headFileBottomContent,
     headFileTopContent: this.headFileTopContent,
-    pageNav: this.frontMatter.pageNav,
+    pageNav: this.isPageNavigationSpecifierValid(),
     siteNav: this.frontMatter.siteNav,
     title: prefixedTitle,
   };

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -18,7 +18,7 @@
     <%- headFileBottomContent %>
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body <%_ if (pageNav) { %> data-spy="scroll" data-target="#page-nav" data-offset="100" <%_ } %>>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -18,7 +18,7 @@
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -18,7 +18,7 @@
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/testTags.html
+++ b/test/functional/test_site/expected/testTags.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -18,7 +18,7 @@
     <meta name="default-head-bottom">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
-<body data-spy="scroll" data-target="#page-nav" data-offset="100">
+<body>
 <div id="loading-overlay">
     <div id="spinner-layout">
         <div id="spinner"></div>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #619.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Previously, we added the scrollspy plugin for page navigation to all pages, regardless of whether or not page nav was enabled. This caused JS errors in the browser for pages without a valid page nav.

**What changes did you make? (Give an overview)**
I added a check to `page.ejs` to only add scrollspy when the page nav is enabled.

**Testing instructions:**
1. `markbind serve` a page that does not have a page nav specified. The page should render normally without JS errors.
2. `markbind serve` a page that has a page nav specified. The page should render normally without JS errors, and the page nav should work normally.