### PR TITLE
Disable no-underscore-dangle ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   "rules": {
     "array-bracket-newline": ["error", { "multiline": true }],
     "func-names": "off",
+    "no-underscore-dangle": "off",
     "function-paren-newline": "off",
     "indent": [
       "error",

--- a/src/Site.js
+++ b/src/Site.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 const cheerio = require('cheerio');
 const ejs = require('ejs');
 const fs = require('fs-extra-promise');
@@ -820,7 +818,6 @@ Site.prototype.deploy = function () {
   });
 };
 
-// eslint-disable-next-line no-underscore-dangle
 Site.prototype._setTimestampVariable = function () {
   const time = new Date().toUTCString();
   Object.keys(this.userDefinedVariablesMap).forEach((base) => {

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 const cheerio = require('cheerio');
 const fs = require('fs');
 const htmlparser = require('htmlparser2');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Code quality

**What is the rationale for this request?**
So that we can use the underscore naming convention for `_privateMethods()`

**What changes did you make? (Give an overview)**
- Disabled the eslint rule
- Removed existing rule overwrites

**Testing instructions:**
`npm run test`