### PR TITLE
Add temporary styles to prevent FOUC

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -212,3 +212,7 @@ footer {
 .temp-navbar li {
     display: block;
 }
+
+.temp-dropdown {
+    display: none;
+}

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -202,3 +202,13 @@ footer {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Temporary Styles */
+
+.temp-navbar {
+    display: flex;
+}
+
+.temp-navbar li {
+    display: block;
+}

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -159,50 +159,6 @@ footer {
     border-radius: 20px;
 }
 
-/* Spinner */
-
-#loading-overlay {
-    background: white;
-    bottom: 0;
-    display: none;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 100;
-}
-
-#spinner-layout {
-    align-items: center;
-    animation: show 1s;
-    animation-fill-mode: forwards;
-    animation-timing-function: step-end;
-    display: flex;
-    height: 100%;
-    justify-content: center;
-    visibility: hidden;
-    width: 100%;
-}
-
-@keyframes show {
-    0% { visibility: hidden; }
-    100% { visibility: visible; }
-}
-
-#spinner {
-    animation: spin 1s linear infinite;
-    border: 16px solid lightgray;
-    border-radius: 50%;
-    border-top: 16px solid darkgray;
-    height: 120px;
-    width: 120px;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
 /* Temporary Styles */
 
 .temp-navbar {

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -159,7 +159,9 @@ footer {
     border-radius: 20px;
 }
 
-/* Temporary Styles */
+/* Temporary Anti-FOUC Styles */
+/* By default, some VueStrap components break the layout of the page before Vue is mounted, */
+/* so we apply temporary styles to fix the layout until Vue correctly updates the DOM. */
 
 .temp-navbar {
     display: flex;

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -48,6 +48,7 @@ function updateSearchData(vm) {
 const MarkBind = {
   executeAfterSetupScripts: jQuery.Deferred(),
 };
+
 MarkBind.afterSetup = (func) => {
   if (document.readyState !== 'loading') {
     func();
@@ -56,11 +57,16 @@ MarkBind.afterSetup = (func) => {
   }
 };
 
+function removeTemporaryStyles() {
+  jQuery('.temp-navbar').removeClass('temp-navbar');
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
   setupAnchors();
   removeLoadingOverlay();
+  removeTemporaryStyles();
   MarkBind.executeAfterSetupScripts.resolve();
 }
 

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -59,6 +59,8 @@ MarkBind.afterSetup = (func) => {
 
 function removeTemporaryStyles() {
   jQuery('.temp-navbar').removeClass('temp-navbar');
+  jQuery('.temp-dropdown').removeClass('temp-dropdown');
+  jQuery('.temp-dropdown-placeholder').remove();
 }
 
 function executeAfterMountedRoutines() {

--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -33,10 +33,6 @@ function setupAnchors() {
   });
 }
 
-function removeLoadingOverlay() {
-  jQuery('#loading-overlay').remove();
-}
-
 function updateSearchData(vm) {
   jQuery.getJSON(`${baseUrl}/siteData.json`)
     .then((siteData) => {
@@ -67,7 +63,6 @@ function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
   setupAnchors();
-  removeLoadingOverlay();
   removeTemporaryStyles();
   MarkBind.executeAfterSetupScripts.resolve();
 }

--- a/src/Page.js
+++ b/src/Page.js
@@ -49,6 +49,8 @@ const SITE_NAV_BUTTON_HTML = '<div id="site-nav-btn-wrap">\n'
   + '</div>\n'
   + '</div>';
 
+const TEMP_NAVBAR_CLASS = 'temp-navbar';
+
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
 
@@ -763,6 +765,13 @@ Page.prototype.collectHeadFiles = function (baseUrl, hostBaseUrl) {
   this.headFileBottomContent = collectedBottomContent.join('\n    ');
 };
 
+Page.prototype.insertTemporaryStyles = function (pageData) {
+  const $ = cheerio.load(pageData);
+  // inject temporary navbar styles
+  $('navbar').addClass(TEMP_NAVBAR_CLASS);
+  return $.html();
+};
+
 Page.prototype.generate = function (builtFiles) {
   this.includedFiles = {};
   this.includedFiles[this.sourcePath] = true;
@@ -784,6 +793,7 @@ Page.prototype.generate = function (builtFiles) {
       .then(result => addContentWrapper(result))
       .then(result => this.insertPageNavWrapper(result))
       .then(result => this.insertSiteNav((result)))
+      .then(result => this.insertTemporaryStyles(result))
       .then(result => this.insertFooter(result)) // Footer has to be inserted last to ensure proper formatting
       .then(result => formatFooter(result))
       .then(result => markbinder.resolveBaseUrl(result, fileConfig))

--- a/src/Page.js
+++ b/src/Page.js
@@ -50,6 +50,8 @@ const SITE_NAV_BUTTON_HTML = '<div id="site-nav-btn-wrap">\n'
   + '</div>';
 
 const TEMP_NAVBAR_CLASS = 'temp-navbar';
+const TEMP_DROPDOWN_CLASS = 'temp-dropdown';
+const TEMP_DROPDOWN_PLACEHOLDER_CLASS = 'temp-dropdown-placeholder';
 
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
@@ -769,6 +771,14 @@ Page.prototype.insertTemporaryStyles = function (pageData) {
   const $ = cheerio.load(pageData);
   // inject temporary navbar styles
   $('navbar').addClass(TEMP_NAVBAR_CLASS);
+  // inject temporary dropdown styles
+  $('dropdown').each((i, element) => {
+    const attributes = element.attribs;
+    const placeholder = `<span class=${attributes.class}>${attributes.text}</span>`;
+    $(element).before(placeholder);
+    $(element).prev().addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
+    $(element).addClass(TEMP_DROPDOWN_CLASS);
+  });
   return $.html();
 };
 

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -19,14 +19,6 @@
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>
 <body <%_ if (pageNav) { %> data-spy="scroll" data-target="#page-nav" data-offset="100" <%_ } %>>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <%- content %>
 </div>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -19,18 +19,10 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <div>
-    <navbar placement="top" type="inverse">
+    <navbar placement="top" type="inverse" class="temp-navbar">
       <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
       <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
     </navbar>

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -29,14 +29,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body data-spy="scroll" data-target="#page-nav" data-offset="100">
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <nav id="page-nav" class="navbar navbar-light bg-transparent slim-scroll">
   <a class="navbar-brand" style="white-space: inherit; color: black" href="#">Testing Page Navigation</a>
@@ -256,7 +248,7 @@
     <div id="page-nav-content-wrapper">
       <div id="content-wrapper">
         <div>
-          <navbar placement="top" type="inverse">
+          <navbar placement="top" type="inverse" class="temp-navbar">
             <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
             <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
           </navbar>

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -159,46 +159,16 @@ footer {
     border-radius: 20px;
 }
 
-/* Spinner */
+/* Temporary Styles */
 
-#loading-overlay {
-    background: white;
-    bottom: 0;
-    display: none;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 100;
-}
-
-#spinner-layout {
-    align-items: center;
-    animation: show 1s;
-    animation-fill-mode: forwards;
-    animation-timing-function: step-end;
+.temp-navbar {
     display: flex;
-    height: 100%;
-    justify-content: center;
-    visibility: hidden;
-    width: 100%;
 }
 
-@keyframes show {
-    0% { visibility: hidden; }
-    100% { visibility: visible; }
+.temp-navbar li {
+    display: block;
 }
 
-#spinner {
-    animation: spin 1s linear infinite;
-    border: 16px solid lightgray;
-    border-radius: 50%;
-    border-top: 16px solid darkgray;
-    height: 120px;
-    width: 120px;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+.temp-dropdown {
+    display: none;
 }

--- a/test/functional/test_site/expected/markbind/js/setup.js
+++ b/test/functional/test_site/expected/markbind/js/setup.js
@@ -33,10 +33,6 @@ function setupAnchors() {
   });
 }
 
-function removeLoadingOverlay() {
-  jQuery('#loading-overlay').remove();
-}
-
 function updateSearchData(vm) {
   jQuery.getJSON(`${baseUrl}/siteData.json`)
     .then((siteData) => {
@@ -48,6 +44,7 @@ function updateSearchData(vm) {
 const MarkBind = {
   executeAfterSetupScripts: jQuery.Deferred(),
 };
+
 MarkBind.afterSetup = (func) => {
   if (document.readyState !== 'loading') {
     func();
@@ -56,11 +53,17 @@ MarkBind.afterSetup = (func) => {
   }
 };
 
+function removeTemporaryStyles() {
+  jQuery('.temp-navbar').removeClass('temp-navbar');
+  jQuery('.temp-dropdown').removeClass('temp-dropdown');
+  jQuery('.temp-dropdown-placeholder').remove();
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
   setupAnchors();
-  removeLoadingOverlay();
+  removeTemporaryStyles();
   MarkBind.executeAfterSetupScripts.resolve();
 }
 

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <p>This is a page from another Markbind site.</p>

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <box id="alert-box">

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <p>A page with an empty frontmatter should still build.</p>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <p>The external script <a href="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">MathJax 2.75</a> should be included, and the following MathJax content should render:</p>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="flex-body">
   <div id="site-nav">

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="flex-body">
   <div id="site-nav">

--- a/test/functional/test_site/expected/testTags.html
+++ b/test/functional/test_site/expected/testTags.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <h1 id="front-matter-should-be-overridden-by-site-json">Front matter should be overridden by site.json<a class="fa fa-anchor" href="#front-matter-should-be-overridden-by-site-json"></a></h1>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -19,14 +19,6 @@
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
-<div id="loading-overlay">
-    <div id="spinner-layout">
-        <div id="spinner"></div>
-    </div>
-</div>
-<script type="text/javascript">
-    document.getElementById("loading-overlay").style.display = 'initial';
-</script>
 <div id="app">
     <div id="content-wrapper">
   <h1 id="some-heading">Some heading<a class="fa fa-anchor" href="#some-heading"></a></h1>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves #657.

**What is the rationale for this request?**
`navbar` component rendering only after Vue has loaded causes FOUC. To avoid the page looking broken while Vue loads, we add temporary styles.

The `dropdown` component, similarly, is always expanded until Vue is loaded. This breaks the layout of the page.

**What changes did you make? (Give an overview)**
Add temporary styles to `navbar` and `dropdown` during loading.

![tempstyles](https://user-images.githubusercontent.com/17447681/52173604-731e1200-27c2-11e9-8e5b-161143bef6bf.gif)


**Is there anything you'd like reviewers to focus on?**
- I've removed the spinner and overlay after implementing the temporary styles as they both seem to address the same issue, but the temporary styles seems to address it more simply.
- Not sure if there are any other "critical" VueStrap components that require temporary styles in order to fully consider #657 resolved.

**Testing instructions:**
Open the Netlify preview page in Chrome with network speed set to `Fast 3G` or `Slow 3G`. The page should not look broken while it loads.
Another sample (with `dropdown` component) is available at https://marvinchin.github.io/website-base-loader/