### PR TITLE
Disable decamelize for anchor generation

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it/index.js
+++ b/src/lib/markbind/src/lib/markdown-it/index.js
@@ -20,7 +20,7 @@ const slugify = require('@sindresorhus/slugify');
 // markdown-it plugins
 markdownIt.use(require('markdown-it-mark'))
   .use(require('markdown-it-ins'))
-  .use(require('markdown-it-anchor'), {slugify: slugify})
+  .use(require('markdown-it-anchor'), {slugify: (str) => slugify(str, { decamelize: false })})
   .use(require('markdown-it-imsize'), {autofill: false})
   .use(require('markdown-it-table-of-contents'))
   .use(require('markdown-it-task-lists'), {enabled: true})


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #653.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently, anchors generated by MarkBind are "decamelized", with camelCased words being split: MarkBind becomes `mark-bind`. This breaks compatibility with GFMD.

**What changes did you make? (Give an overview)**
I modified the `slugify` option passed to `markdown-it-anchor` to always call `slugify()` with `decamelize: false`.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```markdown
# Headings with camelCase or PascalCase
```

**Testing instructions:**
1. Create a MarkBind page with headings that have camelCase or PascalCase. Their anchors should not be "decamelized": `# camelCase and PascalCase` should have an anchor of `#camelcase-and-pascalcase`.