### PR TITLE
Convert relative src references to absolute paths

### DIFF
--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -16,7 +16,7 @@
 <variable name="icon_info">:fas-info-circle:</variable>
 <variable name="icon_ticked">:far-check-square:</variable>
 
-<variable name="link_live_preview">[live preview]({{ baseUrl }}/userGuide/glossary.html#live-preview)</variable>
+<variable name="link_live_preview">[live preview](userGuide/glossary.html#live-preview)</variable>
 
 <variable name="tooltip_root_directory"><tooltip content="The directory that contains all the project files. It is also the directory in which the `site.json` configuration file is located.">root directory</tooltip></variable>
 

--- a/docs/common/header.md
+++ b/docs/common/header.md
@@ -1,10 +1,10 @@
-<link rel="stylesheet" href="{{baseUrl}}/css/main.css">
+<link rel="stylesheet" href="../css/main.css">
 <navbar placement="top" type="inverse">
-  <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand"><img src="{{baseUrl}}/images/logo-darkbackground.png" height="20" /></a>
-  <li><a href="{{baseUrl}}/index.html" class="nav-link">HOME</a></li>
-  <li><a href="{{baseUrl}}/userGuide/index.html" class="nav-link">DOCS</a></li>
-  <li><a href="{{baseUrl}}/showcase.html" class="nav-link">SHOWCASE</a></li>
-  <li><a href="{{baseUrl}}/about.html" class="nav-link">ABOUT</a></li>
+  <a slot="brand" href="../index.html" title="Home" class="navbar-brand"><img src="../images/logo-darkbackground.png" height="20" /></a>
+  <li><a href="../index.html" class="nav-link">HOME</a></li>
+  <li><a href="../userGuide/index.html" class="nav-link">DOCS</a></li>
+  <li><a href="../showcase.html" class="nav-link">SHOWCASE</a></li>
+  <li><a href="../about.html" class="nav-link">ABOUT</a></li>
   <li>
     <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link">
       <svg height="16px" fill="#777" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,13 @@
 Optimized for creating text-heavy websites %%e.g., eLearning websites, online instruction manuals, project documentation etc.%%.
 </span>
 
-<b-btn variant="primary" href="{{ baseUrl }}/userGuide/">Get Started</b-btn>
+<b-btn variant="primary" href="userGuide/">Get Started</b-btn>
 
 <hr>
 
 #### {{ icon_check_blue }} Simple syntax. Dynamic content.
 
-MarkBind source files can be as simple as basic Markdown, but you can also [**use a mix of several popular syntax schemes**]({{ baseUrl }}/userGuide/markBindSyntax.html) (<tooltip content="GitHub Flavored Markdown">GFMD</tooltip>, BootStrap, NunJucks, etc. as well as MarkBind's own custom syntax) to create more dynamic content that you cannot normally get from a typical markdown-to-html site generator.
+MarkBind source files can be as simple as basic Markdown, but you can also [**use a mix of several popular syntax schemes**](userGuide/markBindSyntax.html) (<tooltip content="GitHub Flavored Markdown">GFMD</tooltip>, BootStrap, NunJucks, etc. as well as MarkBind's own custom syntax) to create more dynamic content that you cannot normally get from a typical markdown-to-html site generator.
 
 Here are some simple text-formatting examples:
 
@@ -131,16 +131,16 @@ MarkBind is **highly optimized for creating text-heavy websites** %%e.g., eLearn
 Here are some examples:
 <div class="indented">
 
-<big>:fas-heart:</big> **Icons** can improve the readability of a text-heavy document. MarkBind comes with a wide selection of [icons]({{ baseUrl }}/userGuide/markBindSyntax.html#icons-fonts) and [emoji]({{ baseUrl }}/userGuide/markBindSyntax.html#emoji).<br>
-<big>:fas-search:</big> With MarkBind's [**search feature**]({{ baseUrl }}/userGuide/makingTheSiteSearchable.html), you can allow readers to search for keywords in your site.<br>
-<big>:fas-window-maximize:</big> MarkBind allows you to add [**site/page navigation menus, headers, footers**]({{ baseUrl }}/userGuide/tweakingThePageStructure.html) easily.
+<big>:fas-heart:</big> **Icons** can improve the readability of a text-heavy document. MarkBind comes with a wide selection of [icons](userGuide/markBindSyntax.html#icons-fonts) and [emoji](userGuide/markBindSyntax.html#emoji).<br>
+<big>:fas-search:</big> With MarkBind's [**search feature**](userGuide/makingTheSiteSearchable.html), you can allow readers to search for keywords in your site.<br>
+<big>:fas-window-maximize:</big> MarkBind allows you to add [**site/page navigation menus, headers, footers**](userGuide/tweakingThePageStructure.html) easily.
 </div>
 
 <hr><!-- ======================================================================================================= -->
 
 #### {{ icon_check_blue }} More control to the reader, without duplicating code.
 
-A MarkBind website can be a _buffet_ of content, as opposed to a _set menu_: a site can have optional contents that the reader can access at her discretion, and the same content can be organized in multiple ways so that the reader can choose the one that fits the need. To _cater_ (pun intended) for creating such buffet style websites, MarkBind has **[reuse mechanisms]({{ baseUrl }}/userGuide/reusingContents.html) for presenting the same content in multiple ways without duplicating the source file**.
+A MarkBind website can be a _buffet_ of content, as opposed to a _set menu_: a site can have optional contents that the reader can access at her discretion, and the same content can be organized in multiple ways so that the reader can choose the one that fits the need. To _cater_ (pun intended) for creating such buffet style websites, MarkBind has **[reuse mechanisms](userGuide/reusingContents.html) for presenting the same content in multiple ways without duplicating the source file**.
 
 For example, MarkBind has a powerful `include` mechanism that allows content fragments (i.e., a file or part of a file) to be reused at multiple places in the website. In the example below, both the modal and the expandable panel reuse the same content originating from a _single_ source file.
 
@@ -162,8 +162,8 @@ In CS, a binary tree is a tree data structure in which each node has at most two
 
 #### {{ icon_check_blue }} Easy to set up, modify, deploy, integrate.
 
-Installing MarkBind takes just one command. Creating a new MarkBind site too takes just one command. With MarkBind's _live preview_ feature, you can see how your site will look like as you modify the source file. [Deploying the site to a server]({{ baseUrl }}/userGuide/deployingTheSite.html) can be as simple as one command too.
+Installing MarkBind takes just one command. Creating a new MarkBind site too takes just one command. With MarkBind's _live preview_ feature, you can see how your site will look like as you modify the source file. [Deploying the site to a server](userGuide/deployingTheSite.html) can be as simple as one command too.
 
-As MarkBind is also optimized for project documentation, it can easily [integrate with the workflow of a software project]({{ baseUrl }}/userGuide/markBindInTheProjectWorkflow.html).
+As MarkBind is also optimized for project documentation, it can easily [integrate with the workflow of a software project](userGuide/markBindInTheProjectWorkflow.html).
 
-<b-btn variant="primary" href="{{ baseUrl }}/userGuide/">Get Started</b-btn>
+<b-btn variant="primary" href="userGuide/">Get Started</b-btn>

--- a/docs/userGuide/addingPages.md
+++ b/docs/userGuide/addingPages.md
@@ -8,7 +8,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />
@@ -28,7 +28,7 @@
 
 </div>
 
-%%You can specify which files to be omitted from the site by using the `ignore` field in the `site.config` file as explained [here]({{ baseUrl }}/userGuide/siteConfiguration.html#ignore).%%
+%%You can specify which files to be omitted from the site by using the `ignore` field in the `site.config` file as explained [here](siteConfiguration.html#ignore).%%
 
 **More importantly, `.md` and `.mbd` files can be transformed into html pages with matching names.**
 
@@ -40,7 +40,7 @@
 
 Here are the steps to add a new page to your site:
 1. Add a `.md` (or `.mbd`) file anywhere inside the root directory.
-1. Update the [`pages` attribute of the `site.json`]({{ baseUrl }}/userGuide/siteConfiguration.html#pages) to cover the new file, if necessary.
+1. Update the [`pages` attribute of the `site.json`](siteConfiguration.html#pages) to cover the new file, if necessary.
 1. Use the <trigger trigger="click" for="modal:addingPages-livePreview">live preview</trigger> to view the generated web page for the new file.
 
 <modal large title="Live Preview" id="modal:addingPages-livePreview">

--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -62,7 +62,7 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
   Deploy the site in Travis CI using the GitHub personal access token stored in `<githubTokenName>`. (default: `GITHUB_TOKEN`)<br>
   {{ icon_example }} `-t PA_TOKEN`
 
-%%{{ icon_info }} Related: [User Guide: Deploying the Website]({{ baseUrl }}/userGuide/deployingTheSite.html).%%
+%%{{ icon_info }} Related: [User Guide: Deploying the Website](deployingTheSite.html).%%
 
 <hr><!-- ========================================================================== -->
 

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -16,9 +16,9 @@
 </span>
 
 Generic steps for deploying a MarkBind site:
-1. Set the [`baseUrl` property of the `site.json` file]({{ baseUrl }}/userGuide/siteConfiguration.html#baseUrl) to match the deploy location.
-1. (Optional) Use the [`markbind serve` command]({{ baseUrl }}/userGuide/cliCommands.html#serve-command) to stage the site locally and confirm the contents are as expected.
-1. Use the [`markbind build` command]({{ baseUrl }}/userGuide/cliCommands.html#build-command) to generate the site from source files. That command puts the generated site files in a directory named `_site` (you can change the output directory using parameters supplied to the command).
+1. Set the [`baseUrl` property of the `site.json` file](siteConfiguration.html#baseUrl) to match the deploy location.
+1. (Optional) Use the [`markbind serve` command](cliCommands.html#serve-command) to stage the site locally and confirm the contents are as expected.
+1. Use the [`markbind build` command](cliCommands.html#build-command) to generate the site from source files. That command puts the generated site files in a directory named `_site` (you can change the output directory using parameters supplied to the command).
 1. Upload the site files to the Web server. The sections below explains how to automate this step for when deploying to some online platforms.
 
 ## Deploying to Github Pages
@@ -39,7 +39,7 @@ If you are deploying to the site to GitHub pages, the `baseUrl` setting in the `
 
 You can override the default deployment settings %%(e.g., repo/branch to deploy)%% in the `site.json`'s `deploy` section:
 
-<panel type="seamless" header="**User Guide: Configuring the Site → `deploy`**" popup-url="{{ baseUrl }}/userGuide/siteConfiguration.html#deploy">
+<panel type="seamless" header="**User Guide: Configuring the Site → `deploy`**" popup-url="siteConfiguration.html#deploy">
   <include src="siteConfiguration.md#site-json-deploy" />
 </panel>
 

--- a/docs/userGuide/formattingContents.md
+++ b/docs/userGuide/formattingContents.md
@@ -9,7 +9,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />

--- a/docs/userGuide/gettingStarted.md
+++ b/docs/userGuide/gettingStarted.md
@@ -85,8 +85,8 @@ To stop the web server, go to the console running the `serve` command and press 
 
 <big>**4. Next steps**</big>
 
-1. **Update the content of your site**. More info can be found in the [_User Guide: Authoring Contents_]({{ baseUrl }}/userGuide/authoringContents.html) section
-1. **Deploy your site**. More info can be found in the [_User Guide: Deploying the Site_]({{ baseUrl }}/userGuide/deployingTheSite.html) section.
+1. **Update the content of your site**. More info can be found in the [_User Guide: Authoring Contents_](authoringContents.html) section
+1. **Deploy your site**. More info can be found in the [_User Guide: Deploying the Site_](deployingTheSite.html) section.
 
 {% from "njk/common.njk" import previous_next %}
 {{ previous_next('', 'authoringContents') }}

--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -13,7 +13,7 @@
 
 {{ icon_info }} Live preview works for the following file types only: `css`, `.html`, `.md`, <tooltip content="MarkBind file">`.mbd`</tooltip>, <tooltip content="MarkBind fragment">`.mbdf`</tooltip>. Changes to `css` might may not be visible in the site until you do a manual refresh of the page.
 
-Use [the `serve` command]({{ baseUrl }}/userGuide/cliCommands.html#serve-command) to launch a live preview.
+Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.
 
 </span>
 

--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -9,7 +9,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />
@@ -18,10 +18,10 @@
 
 <span class="lead" id="overview">
 
-**MarkBind comes with with an in-built _site search_ facility**. You can add a [Search Bar]({{ baseUrl }}/userGuide/usingComponents.html#search-bar) component to your pages %%(e.g., into the top navigation bar)%% to allow readers to search your website for keywords.
+**MarkBind comes with with an in-built _site search_ facility**. You can add a [Search Bar](usingComponents.html#search-bar) component to your pages %%(e.g., into the top navigation bar)%% to allow readers to search your website for keywords.
 </span>
 
-**All headings of levels 1-3 are captured in the search index** by default. You can change this setting using the [`headingIndexLevel` property of the `site.json`]({{ baseUrl }}/userGuide/siteConfiguration.html#headingindexinglevel).
+**All headings of levels 1-3 are captured in the search index** by default. You can change this setting using the [`headingIndexLevel` property of the `site.json`](siteConfiguration.html#headingindexinglevel).
 
 <box type="info">
 

--- a/docs/userGuide/markBindInTheProjectWorkflow.md
+++ b/docs/userGuide/markBindInTheProjectWorkflow.md
@@ -20,9 +20,9 @@ While most IDEs provide previews for Markdown files, unless your MarkBind files 
 
 #### GitHub Project Workflow
 
-If you use GitHub for your project, you can [deploy your site to GitHub pages]({{ baseUrl }}/userGuide/deployingTheSite.html#deploying-to-github-pages) easily. You can even set up Travis to automatically deploy your site to GitHub pages whenever a branch in your repo is updated.
+If you use GitHub for your project, you can [deploy your site to GitHub pages](deployingTheSite.html#deploying-to-github-pages) easily. You can even set up Travis to automatically deploy your site to GitHub pages whenever a branch in your repo is updated.
 
-If you are using GitHub Pull Requests as part of your workflow, you can [set up Netlify to show a preview of the site generated from the MarkBind code in the PR]({{ baseUrl }}/userGuide/deployingTheSite.html#deploying-to-netlify).
+If you are using GitHub Pull Requests as part of your workflow, you can [set up Netlify to show a preview of the site generated from the MarkBind code in the PR](deployingTheSite.html#deploying-to-netlify).
 
 #### Using MarkBind for Project Documentation
 

--- a/docs/userGuide/markBindSyntaxOverview.md
+++ b/docs/userGuide/markBindSyntaxOverview.md
@@ -8,7 +8,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)
+[_User Guide → {{ title }}_]({{ filename }}.html)
 </span>
 
 <include src="../common/header.md" />

--- a/docs/userGuide/plugins/filterTags.mbdf
+++ b/docs/userGuide/plugins/filterTags.mbdf
@@ -72,7 +72,7 @@ Alternatively, you can specify tags to render for a page in the front matter.
 ```
 </span>
 
-Tags in `site.json` will be merged with the ones in the front matter, and are processed after front matter tags. See [Hiding Tags]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#hiding-tags) for more information.
+Tags in `site.json` will be merged with the ones in the front matter, and are processed after front matter tags. See [Hiding Tags](userGuide/tweakingThePageStructure.html#hiding-tags) for more information.
 
 #### Advanced Tagging Tips
 

--- a/docs/userGuide/reusingContents.md
+++ b/docs/userGuide/reusingContents.md
@@ -9,7 +9,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />
@@ -100,17 +100,17 @@ Optional video:
 
 #### Giving alternative contents
 
-You can use a [_Tabs_ component]({{ baseUrl }}/userGuide/usingComponents.html#tabs) to give alternative versions of content, for example, giving a code snippet in different programming languages.
+You can use a [_Tabs_ component](usingComponents.html#tabs) to give alternative versions of content, for example, giving a code snippet in different programming languages.
 
 #### Giving access to additional contents
 
 You can use following components to give readers an option to access additional content at their discretion.
-* [Tooltips]({{ baseUrl }}/userGuide/usingComponents.html#tooltip), [Popovers]({{ baseUrl }}/userGuide/usingComponents.html#popover), [Modals]({{ baseUrl }}/userGuide/usingComponents.html#modal)
-* [Expandable Panels]({{ baseUrl }}/userGuide/usingComponents.html#panel)
+* [Tooltips](usingComponents.html#tooltip), [Popovers](usingComponents.html#popover), [Modals](usingComponents.html#modal)
+* [Expandable Panels](usingComponents.html#panel)
 
 #### Organizing contents in alternative ways
 
-You can take advantage of [MarkBinds feature for content reuse]({{ baseUrl }}/userGuide/reusingContents.html), you can organize content in alternative ways to cater for different readers, without having to duplicate content. For example, you can have different pages that organizes the same information alphabetically, chronologically, by difficulty, group information by topic, etc.
+You can take advantage of [MarkBinds feature for content reuse](reusingContents.html), you can organize content in alternative ways to cater for different readers, without having to duplicate content. For example, you can have different pages that organizes the same information alphabetically, chronologically, by difficulty, group information by topic, etc.
 
 #### Optimizing the Print View
 
@@ -154,7 +154,7 @@ Then, in a page-specific CSS file,
 
 #### Creating slight variations of content
 
-Tags are a good way to create multiple variations of a page within the same source file, such as to filter content for creating multiple different versions of the same page. See [_User Guide: Tweaking the Page Structure → Tags_]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#tags) section for more information.
+Tags are a good way to create multiple variations of a page within the same source file, such as to filter content for creating multiple different versions of the same page. See [_User Guide: Tweaking the Page Structure → Tags_](tweakingThePageStructure.html#tags) section for more information.
 
 {% from "njk/common.njk" import previous_next %}
 {{ previous_next('tweakingThePageStructure', 'makingTheSiteSearchable') }}

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -85,7 +85,7 @@ Here is a typical `site.json` file:
 * **`src`**/**`glob`**: `src` can be used to specify a file e.g., `docs/index.md`.<br>
     Alternatively, `glob` can be used to define a file pattern in the [_glob syntax_](https://en.wikipedia.org/wiki/Glob_(programming)) e.g., `**/*.md`.
 * **`title`**: The page `<title>` for the generated web page. Titles specified here take priority over titles specified in the [front matter](addingPages.html#front-matter) of individual pages.
-* **`layout`**: The [layout]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
+* **`layout`**: The [layout](tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.
 * **`externalScripts`**: An array of external scripts to be referenced on the page. Scripts referenced will be run before the layout script.
 
@@ -150,7 +150,7 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 #### **`deploy`**
 
-**The settings for [auto-deployment to Github pages]({{ baseUrl }}/userGuide/deployingTheSite.html).**
+**The settings for [auto-deployment to Github pages](deployingTheSite.html).**
 
 * **`message`** [Optional. Default: `"Site Update."`]<br>
   The commit message used for the deployment commit.
@@ -174,4 +174,4 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
 
 #### **`enableSearch`**
 
-**Specifies that the website should use MarkBind's search functionality.** Default: `true`. See [User Guide: Making the Site Searchable]({{ baseUrl }}/userGuide/makingTheSiteSearchable.html) for more details.
+**Specifies that the website should use MarkBind's search functionality.** Default: `true`. See [User Guide: Making the Site Searchable](makingTheSiteSearchable.html) for more details.

--- a/docs/userGuide/syntax/links.mbdf
+++ b/docs/userGuide/syntax/links.mbdf
@@ -45,15 +45,47 @@ MarkBind home is at [here][1]
 
 <div id="intraSiteLinks">
 
-Links to files of the generated site (e.g., an HTML page or an image file) should be specified as absolute paths and should start with {{ showBaseUrlCode }} (which represents the root directory of the project).
+Links to files of the generated site (e.g., an HTML page or an image file) can be specified either as relative paths or absolute paths.
 
+Absolute paths:
 <div class="indented">
+Links should start with {{ showBaseUrlCode }} (which represents the root directory of the project). 
 
 {{ icon_example }} Here's how to specify a link to (1) a page, and (2) an image, using the {{ showBaseUrlCode }}:
 
-1. <code>Click [here]({<span></span>{ baseUrl }}/userGuide/reusingContents.html).</code>
+1. <code>Click [here]({{ showBaseUrlCode }}/userGuide/reusingContents.html).</code>
 2. `![](`{{ showBaseUrlCode }}`/images/preview.png)`
 
+</div>
+
+Relative paths:
+
+<div class="indented">
+Links to files can also be specified relative to the file that includes it.
+
+{{ icon_example }} Assuming that we have the following folder structure:
+```
+c:/course/
+  ├── textbook/
+  |      ├── subsite.md
+  |      ├── image.png
+  |      └── site.json
+  ├── index.md
+  └── site.json
+```
+
+Within `textbook/subsite.md`, we can refer to the image using:
+```html
+<img src="image.png" />
+```
+Within `index.md`, we can also display the image using
+```html
+<img src="textbook/image.png" />
+```
+or by including `subsite.md`:
+```
+<include src="textbook/subsite.md" />
+```
 </div>
 </div>
 

--- a/docs/userGuide/tweakingThePageStructure.md
+++ b/docs/userGuide/tweakingThePageStructure.md
@@ -9,7 +9,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />

--- a/docs/userGuide/usingComponents.md
+++ b/docs/userGuide/usingComponents.md
@@ -9,7 +9,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />

--- a/docs/userGuide/usingHtmlJavaScriptCss.md
+++ b/docs/userGuide/usingHtmlJavaScriptCss.md
@@ -8,7 +8,7 @@
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -453,6 +453,26 @@ specification that specifies how the product will address the requirements. </sp
               <li>Timer – Additional fixed time restriction on the player.</li>
             </ol>
             <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+          <div>
+            <p>This is a page from another Markbind site. The purpose of this page is to ensure that reuse works as expected. All the following images should display correctly.</p>
+            <p>Some variables:</p>
+            <div></div>
+            <p>IMG tags:
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+              <img src="https://dummyimage.com/600x400/000/fff"></p>
+            <p>PIC tags:
+              <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+              <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+              <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+              <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+              <pic src="https://dummyimage.com/600x400/000/fff"></pic>
+            </p>
+            <p>Anchor link:
+              <a href="https://dummyimage.com/600x400/000/fff">External Image</a></p>
+          </div>
           <h1 id="trimmed-include">Trimmed include<a class="fa fa-anchor" href="#trimmed-include"></a></h1>
           <h2 id="fragment-with-leading-spaces-and-newline"><span>Fragment with leading spaces and newline</span><a class="fa fa-anchor" href="#fragment-with-leading-spaces-and-newline"></a></h2>
           <h1 id="include-with-custom-variables">Include with custom variables<a class="fa fa-anchor" href="#include-with-custom-variables"></a></h1>
@@ -514,6 +534,7 @@ specification that specifies how the product will address the requirements. </sp
           </panel>
           <h1 id="panel-with-src-from-another-markbind-site">Panel with src from another Markbind site<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site"></a></h1>
           <panel header="## Panel with src from another Markbind site header<a class='fa fa-anchor' href='#panel-with-src-from-another-markbind-site-header'></a>" src="/test_site/sub_site/index._include_.html" expanded=""></panel>
+          <panel header="## Panel with src from another Markbind site header<a class='fa fa-anchor' href='#panel-with-src-from-another-markbind-site-header'></a>" src="/test_site/sub_site/testReuse._include_.html" expanded=""></panel>
         </div>
         <h1 id="modal-with-panel-inside">Modal with panel inside<a class="fa fa-anchor" href="#modal-with-panel-inside"></a></h1>
         <p>

--- a/test/functional/test_site/expected/sub_site/testReuse._include_.html
+++ b/test/functional/test_site/expected/sub_site/testReuse._include_.html
@@ -1,0 +1,18 @@
+<p>This is a page from another Markbind site. The purpose of this page is to ensure that reuse works as expected. All the following images should display correctly.</p>
+<p>Some variables:</p>
+<div></div>
+<p>IMG tags:
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+  <img src="https://dummyimage.com/600x400/000/fff"></p>
+<p>PIC tags:
+  <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+  <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+  <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+  <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+  <pic src="https://dummyimage.com/600x400/000/fff"></pic>
+</p>
+<p>Anchor link:
+  <a href="https://dummyimage.com/600x400/000/fff">External Image</a></p>

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -127,6 +127,7 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 # Include from another Markbind site
 <include src="sub_site/index.md" />
+<include src="sub_site/testReuse.md" />
 
 # Trimmed include
 
@@ -188,6 +189,8 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 # Panel with src from another Markbind site
 <panel header="## Panel with src from another Markbind site header" src="sub_site/index.md" expanded>
+</panel>
+<panel header="## Panel with src from another Markbind site header" src="sub_site/testReuse.md" expanded>
 </panel>
 </div>
 

--- a/test/functional/test_site/sub_site/testReuse.md
+++ b/test/functional/test_site/sub_site/testReuse.md
@@ -1,0 +1,23 @@
+This is a page from another Markbind site.
+The purpose of this page is to ensure that reuse works as expected.
+All the following images should display correctly.
+
+Some variables:
+<variable name="imgFolder">images</variable>
+
+IMG tags:
+<img src="images/I'm not allowed to use my favorite tool.png">
+<img src="{{imgFolder}}/I'm not allowed to use my favorite tool.png">
+<img src="{{baseUrl}}/{{imgFolder}}/I'm not allowed to use my favorite tool.png">
+<img src="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png">
+<img src="https://dummyimage.com/600x400/000/fff">
+
+PIC tags:
+<pic src="images/I'm not allowed to use my favorite tool.png"></pic>
+<pic src="{{imgFolder}}/I'm not allowed to use my favorite tool.png"></pic>
+<pic src="{{baseUrl}}/{{imgFolder}}/I'm not allowed to use my favorite tool.png"></pic>
+<pic src="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png"></pic>
+<pic src="https://dummyimage.com/600x400/000/fff"></pic>
+
+Anchor link:
+<a href="https://dummyimage.com/600x400/000/fff">External Image</a>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [ ] Bug fix
• [ ] New feature
• [x] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #598 
Fixes #661

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently, authors can use dynamic references in include tags.
However, if authors use dynamic resource references in src tags for pic/img etc, these references may cause broken links when re-used. This request converts all dynamic resource references to static references, so it will work consistently across all sites and sub-sites. At the same time, this request should be backward compatible, so that authors using older workarounds should expect their site to continue working.

**What changes did you make? (Give an overview)**
During the preprocess stage, in addition to preprocessing includes, also preprocess media resources (e.g. pic) to convert all dynamic references to static ones with respect to the root path (where site.json is located)
Additionally, removed unnecessary use of {{baseUrl}} from the user guide, changing all such links to static references. However, I did not touch mbdf files within `userGuide/syntax` and `userGuide/plugins`, as relative references might make it confusing to write these files in the future.

**Provide some example code that this change will affect:**
Refer to #598 
Folder structure:
```
root/
- index.md
- a/
- - img.png
- - subsite.md
```
_index.md_
```html
...
<include src="a/subsite.md" />
```
_subsite.md_
```html
...
<img src="img.png" />
```
**New syntax changes**
Authors can now also use relative src references in `img`, `pic` tags, as well as relative href attributes in `a` and `link` tags.
To use
* relative src attributes: All references without a leading '/' or {{...}} are treated as relative references.
* static src attributes: All references with a leading '/' or starts with `{{variables}}` are treated as absolute paths, and will not be modified.

**Breaking changes**
There should be no breaking changes. I tested against the old unit tests (I didn't modify anything) and code is passing. I have also added unit tests to ensure that future changes will retain this behaviour.
My PR might break existing documents if authors used incorrect URI statements like `/{{baseUrl}}/path/to/file`. Notice that this string, in the original version, essentially resolves to `//rootFolder/path/to/file` with 2 forward slashes. While previous versions might be lenient, my conversion requires stricter syntax and might result in broken links.

**Is there anything you'd like reviewers to focus on?**
Are there scenarios where this change would cause something to break? I've tested on unit tests and CS2103-website.

**Testing instructions:**
Replicate the folder structure as above. Be sure to include dynamic references to media resources. Run markbind serve, then view the generated webpage.