### PR TITLE
Exit MarkBind with nonzero exit code on fatal error

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ function printHeader() {
   logger.log(` v${CLI_VERSION}`);
 }
 
+function handleError(error) {
+  logger.error(error.message);
+  process.exitCode = 1;
+}
+
 program
   .allowUnknownOption()
   .usage(' <command>');
@@ -49,9 +54,7 @@ program
       .then(() => {
         logger.info('Initialization success.');
       })
-      .catch((error) => {
-        logger.error(error.message);
-      });
+      .catch(handleError);
   });
 
 program
@@ -68,7 +71,7 @@ program
     try {
       rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
     } catch (err) {
-      logger.error(err.message);
+      handleError(err);
     }
     const logsFolder = path.join(rootFolder, '_markbind/logs');
     const outputFolder = path.join(rootFolder, '_site');
@@ -159,9 +162,7 @@ program
           logger.info('Press CTRL+C to stop ...');
         });
       })
-      .catch((error) => {
-        logger.error(error.message);
-      });
+      .catch(handleError);
   });
 
 program
@@ -176,10 +177,7 @@ program
       .then(() => {
         logger.info('Deployed!');
       })
-      .catch((err) => {
-        logger.error(err.message);
-        process.exitCode = 1;
-      });
+      .catch(handleError);
     printHeader();
   });
 
@@ -196,7 +194,7 @@ program
     try {
       rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
     } catch (err) {
-      logger.error(err.message);
+      handleError(err);
     }
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
@@ -206,9 +204,7 @@ program
       .then(() => {
         logger.info('Build success!');
       })
-      .catch((error) => {
-        logger.error(error.message);
-      });
+      .catch(handleError);
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #651.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
MarkBind should exit with a nonzero return code (eg. `1`) to indicate an error condition. This is especially important for running MarkBind in an automated context where other programs or scripts are relying on the exit code of MarkBind to detect errors (eg. as part of a custom build script, or [Travis CI automation](https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build)).

**What changes did you make? (Give an overview)**
I created a common error handler `handleError` to both log an error and set `process.exitCode = 1`, ensuring that MarkBind exits with a nonzero exit code on error.

**Testing instructions:**
1. Run a MarkBind command that will exit on an error (eg. `markbind build` on a directory without a `site.json`). MarkBind should exit with a nonzero exit code.
	- In Bash: `echo $?`
    - In PowerShell: `$LASTEXITCODE`