### PR TITLE
Support specifying include variables inline

### DIFF
--- a/docs/userGuide/syntax/includes.mbdf
+++ b/docs/userGuide/syntax/includes.mbdf
@@ -138,6 +138,16 @@ Author: {<span></span>{ author }}
 
 These variables work the same way as variables in `_markbind/variables.md`, except that they only apply to the included file. They allow the included file to be reused as a template, for different source files using different variable values.
 
+You can also specify include variables within the `<include>` tag itself by adding a `var-` prefix.
+
+<div class="indented">
+
+{{ icon_example }} Specifying `title` and `author` variables inline:
+```html
+<include src="article.md" var-title="My Title" var-author="John Doe" />
+```
+</div>
+
 If the same variable is defined in a chain of `<include>`s (e.g. `a.md` includes `b.md` includes `c.md`...), variables defined in the top-most `<include>` will take precedence. Global variables (`_markbind/variables.md`) will take precedence over any `<include>` variables.
 
 ### Using Boilerplate Files

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -94,6 +94,15 @@ function Parser(options) {
  */
 function extractIncludeVariables(includeElement, contextVariables) {
   const includedVariables = { ...contextVariables };
+  Object.keys(includeElement.attribs).forEach((attribute) => {
+    if (!attribute.startsWith('var-')) {
+      return;
+    }
+    const variableName = attribute.replace(/^var-/, '');
+    if (!includedVariables[variableName]) {
+      includedVariables[variableName] = includeElement.attribs[attribute];
+    }
+  });
   if (includeElement.children) {
     includeElement.children.forEach((child) => {
       if (child.name !== 'span') {
@@ -266,6 +275,13 @@ Parser.prototype._preprocess = function (node, context, config) {
 
     // Render inner file content
     fileContent = nunjucks.renderString(fileContent, { ...allVariables, ...userDefinedVariables });
+
+    // Delete variable attributes in include
+    Object.keys(element.attribs).forEach((attribute) => {
+      if (attribute.startsWith('var-')) {
+        delete element.attribs[attribute];
+      }
+    });
 
     delete element.attribs.boilerplate;
     delete element.attribs.src;

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -94,6 +94,7 @@
       <a class="nav-link py-1" href="#fragment-with-leading-spaces-and-newline">Fragment with leading spaces and newline&#x200E;</a>
     </nav>
     <a class="nav-link py-1" href="#include-with-custom-variables">Include with custom variables&#x200E;</a>
+    <a class="nav-link py-1" href="#test-included-variable-as-include-attribute">Test included variable as include attribute&#x200E;</a>
     <a class="nav-link py-1" href="#test-included-variable">Test included variable&#x200E;</a>
     <a class="nav-link py-1" href="#test-included-variable-with-markdown">Test included variable with markdown&#x200E;</a>
     <a class="nav-link py-1" href="#test-included-variable-as-attribute">Test included variable as attribute&#x200E;</a>
@@ -433,6 +434,8 @@ specification that specifies how the product will address the requirements. </sp
           <h2 id="fragment-with-leading-spaces-and-newline"><span>Fragment with leading spaces and newline</span><a class="fa fa-anchor" href="#fragment-with-leading-spaces-and-newline"></a></h2>
           <h1 id="include-with-custom-variables">Include with custom variables<a class="fa fa-anchor" href="#include-with-custom-variables"></a></h1>
           <div>
+            <h1 id="test-included-variable-as-include-attribute">Test included variable as include attribute<a class="fa fa-anchor" href="#test-included-variable-as-include-attribute"></a></h1>
+            <p>Included variable as include attribute</p>
             <h1 id="test-included-variable">Test included variable<a class="fa fa-anchor" href="#test-included-variable"></a></h1>
             <p>Included variable</p>
             <h1 id="test-included-variable-with-markdown">Test included variable with markdown<a class="fa fa-anchor" href="#test-included-variable-with-markdown"></a></h1>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -81,6 +81,7 @@
         "trimmed-include": "Trimmed include",
         "fragment-with-leading-spaces-and-newline": "Fragment with leading spaces and newline",
         "include-with-custom-variables": "Include with custom variables",
+        "test-included-variable-as-include-attribute": "Test included variable as include attribute",
         "test-included-variable": "Test included variable",
         "test-included-variable-with-markdown": "Test included variable with markdown",
         "test-included-variable-as-attribute": "Test included variable as attribute",

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -133,7 +133,7 @@ head: myCustomHead.md, myCustomHead2.md
 
 # Include with custom variables
 
-<include src="testIncludeVariables.md">
+<include src="testIncludeVariables.md" var-included_variable_as_include_attribute="Included variable as include attribute">
   <span id="included_variable">Included variable</span>
   <span id="included_variable_with_markdown">__**Included variable with markdown**__</span>
   <span id="included_variable_as_attribute">color: blue</span>

--- a/test/functional/test_site/testIncludeVariables.md
+++ b/test/functional/test_site/testIncludeVariables.md
@@ -1,3 +1,7 @@
+
+# Test included variable as include attribute
+{{ included_variable_as_include_attribute }}
+
 # Test included variable
 {{ included_variable }}
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #642 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Provide a simpler syntax for specifying include variables

**What changes did you make? (Give an overview)**

Authors can include variables inline by adding `var-...` attributes:

```
<include src="foo.md" var-x="bat" />
==
<include src="foo.md">
  <span id="x">bat</span>
</include>
```

Used `var` instead of `data` as it's more variable related
