### PR TITLE
Configure nunjucks to use working directory

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -58,42 +58,6 @@ const TEMP_DROPDOWN_PLACEHOLDER_CLASS = 'temp-dropdown-placeholder';
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
 
-function Page(pageConfig) {
-  this.asset = pageConfig.asset;
-  this.baseUrl = pageConfig.baseUrl;
-  this.baseUrlMap = pageConfig.baseUrlMap;
-  this.content = pageConfig.content || '';
-  this.faviconUrl = pageConfig.faviconUrl;
-  this.layout = pageConfig.layout;
-  this.layoutsAssetPath = pageConfig.layoutsAssetPath;
-  this.rootPath = pageConfig.rootPath;
-  this.enableSearch = pageConfig.enableSearch;
-  this.plugins = pageConfig.plugins;
-  this.pluginsContext = pageConfig.pluginsContext;
-  this.searchable = pageConfig.searchable;
-  this.src = pageConfig.src;
-  this.template = pageConfig.pageTemplate;
-  this.title = pageConfig.title || '';
-  this.titlePrefix = pageConfig.titlePrefix;
-  this.userDefinedVariablesMap = pageConfig.userDefinedVariablesMap;
-
-  // the source file for rendering this page
-  this.sourcePath = pageConfig.sourcePath;
-  // the temp path for writing intermediate result
-  this.tempPath = pageConfig.tempPath;
-  // the output path of this page
-  this.resultPath = pageConfig.resultPath;
-
-  this.frontMatter = {};
-  this.headFileBottomContent = '';
-  this.headFileTopContent = '';
-  this.headings = {};
-  this.headingIndexingLevel = pageConfig.headingIndexingLevel;
-  this.includedFiles = {};
-  this.keywords = {};
-  this.navigableHeadings = {};
-}
-
 /**
  * Util Methods
  */
@@ -204,6 +168,46 @@ function formatSiteNav(renderedSiteNav, src) {
     }
   });
   return $.html();
+}
+
+function Page(pageConfig) {
+  this.asset = pageConfig.asset;
+  this.baseUrl = pageConfig.baseUrl;
+  this.baseUrlMap = pageConfig.baseUrlMap;
+  this.content = pageConfig.content || '';
+  this.faviconUrl = pageConfig.faviconUrl;
+  this.layout = pageConfig.layout;
+  this.layoutsAssetPath = pageConfig.layoutsAssetPath;
+  this.rootPath = pageConfig.rootPath;
+  this.enableSearch = pageConfig.enableSearch;
+  this.plugins = pageConfig.plugins;
+  this.pluginsContext = pageConfig.pluginsContext;
+  this.searchable = pageConfig.searchable;
+  this.src = pageConfig.src;
+  this.template = pageConfig.pageTemplate;
+  this.title = pageConfig.title || '';
+  this.titlePrefix = pageConfig.titlePrefix;
+  this.userDefinedVariablesMap = pageConfig.userDefinedVariablesMap;
+
+  // the source file for rendering this page
+  this.sourcePath = pageConfig.sourcePath;
+  // the temp path for writing intermediate result
+  this.tempPath = pageConfig.tempPath;
+  // the output path of this page
+  this.resultPath = pageConfig.resultPath;
+
+  this.frontMatter = {};
+  this.headFileBottomContent = '';
+  this.headFileTopContent = '';
+  this.headings = {};
+  this.headingIndexingLevel = pageConfig.headingIndexingLevel;
+  this.includedFiles = {};
+  this.keywords = {};
+  this.navigableHeadings = {};
+
+  const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap);
+  const configUrl = newBaseUrl ? path.join(this.rootPath, newBaseUrl) : this.rootPath;
+  nunjucks.configure(configUrl);
 }
 
 /**

--- a/src/Site.js
+++ b/src/Site.js
@@ -141,6 +141,8 @@ function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfig
   this.siteConfig = {};
   this.siteConfigPath = siteConfigPath;
   this.userDefinedVariablesMap = {};
+
+  nunjucks.configure(this.rootPath);
 }
 
 /**


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #678 (I think)

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

I couldn't run `markbind serve docs` to serve the docs folder as it was giving me errors:

`C:\Users\Jamos\Desktop\Markbind>markbind serve docs`

![image](https://user-images.githubusercontent.com/19278089/52531947-2acd9980-2d58-11e9-98a9-26894df17383.png)

I had to run it from inside the folder to work:

`C:\Users\Jamos\Desktop\Markbind\docs>markbind serve`

This is due to this line from #668, nunjucks tries to read the file path from the current working directory which differs based on where the command is executed:

`{% from "userGuide/fullSyntaxReference.md" import syntax_topics as topics %}`

**What changes did you make? (Give an overview)**

Configure nunjucks to use the rootpath so sites can be served outside their working directory.
