### PR TITLE
Add documentation for badges

### DIFF
--- a/docs/userGuide/fullSyntaxReference.md
+++ b/docs/userGuide/fullSyntaxReference.md
@@ -35,6 +35,7 @@
   tags : ['Tags', ['other']],
   variables : ['Variables', ['other']],
 
+  badges : ['Badges', ['component', 'reader-facing']],
   boxes : ['Boxes', ['component', 'reader-facing']],
   dropdowns : ['Dropdowns', ['component', 'reader-facing']],
   footers : ['Footers', ['other', 'reader-facing']],

--- a/docs/userGuide/syntax/badges.mbdf
+++ b/docs/userGuide/syntax/badges.mbdf
@@ -1,0 +1,116 @@
+## Badges
+
+<include src="outputBox.md" boilerplate >
+<span id="code">
+
+```html
+Normal:
+<span class="badge badge-primary">Primary</span>
+<span class="badge badge-secondary">Secondary</span>
+<span class="badge badge-success">Success</span>
+<span class="badge badge-danger">Danger</span>
+<span class="badge badge-warning">Warning</span>
+<span class="badge badge-info">Info</span>
+<span class="badge badge-light">Light</span>
+<span class="badge badge-dark">Dark</span>
+<br>Pills:
+<span class="badge badge-pill badge-primary">Primary</span>
+<span class="badge badge-pill badge-secondary">Secondary</span>
+<span class="badge badge-pill badge-success">Success</span>
+<span class="badge badge-pill badge-danger">Danger</span>
+<span class="badge badge-pill badge-warning">Warning</span>
+<span class="badge badge-pill badge-info">Info</span>
+<span class="badge badge-pill badge-light">Light</span>
+<span class="badge badge-pill badge-dark">Dark</span>
+```
+</span>
+<span id="output">
+
+Normal:
+<span class="badge badge-primary">Primary</span>
+<span class="badge badge-secondary">Secondary</span>
+<span class="badge badge-success">Success</span>
+<span class="badge badge-danger">Danger</span>
+<span class="badge badge-warning">Warning</span>
+<span class="badge badge-info">Info</span>
+<span class="badge badge-light">Light</span>
+<span class="badge badge-dark">Dark</span>
+<br>Pills:
+<span class="badge badge-pill badge-primary">Primary</span>
+<span class="badge badge-pill badge-secondary">Secondary</span>
+<span class="badge badge-pill badge-success">Success</span>
+<span class="badge badge-pill badge-danger">Danger</span>
+<span class="badge badge-pill badge-warning">Warning</span>
+<span class="badge badge-pill badge-info">Info</span>
+<span class="badge badge-pill badge-light">Light</span>
+<span class="badge badge-pill badge-dark">Dark</span>
+
+</span>
+</include>
+
+You can use Badges in combination with headings, buttons, links, etc.
+
+<include src="outputBox.md" boilerplate >
+<span id="code">
+
+```html
+Links:
+<a href="#" class="badge badge-primary">Primary</a>
+<a href="#" class="badge badge-pill badge-warning">Warning</a>
+
+Buttons:
+<button type="button" class="btn btn-primary">
+  Difficulty Level <span class="badge badge-light">4</span>
+</button>
+
+Headings:
+
+### Feature X <span class="badge badge-danger">beta</span>
+##### Feature Y <span class="badge badge-pill badge-success">stable</span>
+```
+</span>
+<span id="output">
+
+Links:
+<a href="#" class="badge badge-primary">Primary</a>
+<a href="#" class="badge badge-pill badge-warning">Warning</a>
+
+Buttons:
+<button type="button" class="btn btn-primary">
+  Difficulty Level <span class="badge badge-light">4</span>
+</button>
+
+Headings:
+
+### Feature X <span class="badge badge-danger">beta</span>
+##### Feature Y <span class="badge badge-pill badge-success">stable</span>
+</span>
+</include>
+
+
+<div class="indented">
+
+%%{{ icon_info }} You can refer to [Bootstrap documentation](https://getbootstrap.com/docs/4.2/components/badge/) to find more information about Badges.%%
+</div>
+
+
+<span id="short" class="d-none">
+
+```markdown
+<span class="badge badge-primary">Primary</span>
+<span class="badge badge-pill badge-success">Success</span>
+<button type="button" class="btn btn-primary">
+  Difficulty Level <span class="badge badge-light">4</span>
+</button>
+```
+</span>
+
+<span id="examples" class="d-none">
+
+<span class="badge badge-primary">Primary</span>
+<span class="badge badge-pill badge-success">Success</span>
+<button type="button" class="btn btn-primary">
+  Difficulty Level <span class="badge badge-light">4</span>
+##### Feature Y <span class="badge badge-pill badge-warning">stable</span>
+</button>
+</span>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

I'm proposing to add documentation about badges as they can be useful to MarkBind's target users. As of now, we are simply channeling the component from Bootstrap. Perhaps we can introduce custom syntax in future.