### PR TITLE
Migrate MarkBind's website to markbind.github.io

### DIFF
--- a/docs/site.json
+++ b/docs/site.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "/markbind.github.io",
+  "baseUrl": "/",
   "titlePrefix": "MarkBind",
   "pages": [
     {

--- a/docs/site.json
+++ b/docs/site.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "/",
+  "baseUrl": "",
   "titlePrefix": "MarkBind",
   "pages": [
     {

--- a/docs/site.json
+++ b/docs/site.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "/markbind",
+  "baseUrl": "/markbind.github.io",
   "titlePrefix": "MarkBind",
   "pages": [
     {
@@ -29,6 +29,7 @@
   ],
   "deploy": {
     "message": "Site Update.",
-    "repo": "https://github.com/MarkBind/markbind.git"
+    "repo": "https://github.com/MarkBind/markbind.github.io.git",
+    "branch": "master"
   }
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain:

Deploy the MarkBind website to `https://markbind.github.io/` instead of a redirect.

Fixes #626. 
Part of #662.

**What is the rationale for this request?**

Currently, `https://markbind.github.io` redirects to `https://markbind.github.io/markbind/`.
These changes will deploy the released version of the MarkBind website directly to `https://markbind.github.io`  instead.

**What changes did you make? (Give an overview)**

Changes made to `site.json`:
```
"baseUrl": "/"
```
```
  "deploy": {
    "message": "Site Update.",
    "repo": "https://github.com/MarkBind/markbind.github.io.git",
    "branch": "master"
  }
```