### PR TITLE
Add support for plugins to add styles and scripts

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -119,7 +119,7 @@ Plugins can implement the methods `getLinks` and `getScripts` to add additional 
   - `utils`: Object containing the following utility functions
     - `buildStylesheet(href)`: Builds a stylesheet link element with the specified `href`.
   - Should return an array of string data containing link elements to be added.
-- `getScripts(context, pluginContext, frontMatter, utils)`: Called to get script elements to be added after the body of the page.
+- `getScripts(content, pluginContext, frontMatter, utils)`: Called to get script elements to be added after the body of the page.
   - `content`: The rendered HTML.
   - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
   - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.

--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -110,15 +110,21 @@ module.exports = {
 
 #### Assets
 
-Plugins can call the methods `addLinks` and `addScripts` to add additional assets to the page. 
+Plugins can implement the methods `getLinks` and `getScripts` to add additional assets to the page. 
 
-- `addLinks(pluginContext, frontMatter)`: Called to get link elements to be added to the head of the page.
+- `getLinks(content, pluginContext, frontMatter, utils)`: Called to get link elements to be added to the head of the page.
+  - `content`: The rendered HTML.
   - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
   - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+  - `utils`: Object containing the following utility functions
+    - `buildStylesheet(href)`: Builds a stylesheet link element with the specified `href`.
   - Should return an array of string data containing link elements to be added.
-- `addScripts(pluginContext, frontMatter)`: Called to get script elements to be added after the body of the page.
+- `getScripts(context, pluginContext, frontMatter, utils)`: Called to get script elements to be added after the body of the page.
+  - `content`: The rendered HTML.
   - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
   - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+  - `utils`: Object containing the following utility functions
+    - `buildScript(src)`: Builds a script element with the specified `src`.
   - Should return an array of string data containing script elements to be added.
 
 An example of a plugin which adds links and scripts to the page:
@@ -127,8 +133,8 @@ An example of a plugin which adds links and scripts to the page:
 // myPlugin.js
 
 module.exports = {
-  addLinks: (pluginContext, frontMatter) => ['<link rel="stylesheet" href="STYLESHEET_LINK">'].
-  addScripts: (pluginContext, frontMatter) => ['<script src="SCRIPT_LINK"></script>'],
+  getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
 };
 
 ```

--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -47,6 +47,8 @@ For example:
 
 ### Writing Plugins
 
+#### Rendering
+
 ![MarkBind Rendering]({{baseUrl}}/images/rendering.png)
 
 MarkBind provides two entry points for modifying the page, pre-render and post-render. These are controlled by implementing the `preRender()` and `postRender()` functions in the plugin:
@@ -104,6 +106,31 @@ module.exports = {
 <div id="my-div">
 [Pre-render Placeholder]
 </div>
+```
+
+#### Assets
+
+Plugins can call the methods `addLinks` and `addScripts` to add additional assets to the page. 
+
+- `addLinks(pluginContext, frontMatter)`: Called to get link elements to be added to the head of the page.
+  - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
+  - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+  - Should return an array of string data containing link elements to be added.
+- `addScripts(pluginContext, frontMatter)`: Called to get script elements to be added after the body of the page.
+  - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
+  - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+  - Should return an array of string data containing script elements to be added.
+
+An example of a plugin which adds links and scripts to the page:
+
+```js
+// myPlugin.js
+
+module.exports = {
+  addLinks: (pluginContext, frontMatter) => ['<link rel="stylesheet" href="STYLESHEET_LINK">'].
+  addScripts: (pluginContext, frontMatter) => ['<script src="SCRIPT_LINK"></script>'],
+};
+
 ```
 
 ### Built-in plugins

--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -134,10 +134,16 @@ An example of a plugin which adds links and scripts to the page:
 
 module.exports = {
   getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
-  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) => 
+    [utils.buildScript('SCRIPT_LINK'), '<script>alert("hello")</script>'],
 };
 
 ```
+
+This will add the following link and script elements to the page:
+- `<link rel="stylesheet" href="STYLESHEET_LINK">`
+- `<script src="SCRIPT_LINK"></script>`
+- `<script>alert("hello")</script>`
 
 ### Built-in plugins
 

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="<%- asset.glyphicons %>" >
     <link rel="stylesheet" href="<%- asset.highlight %>">
     <link rel="stylesheet" href="<%- asset.markbind %>">
-    <% if (asset.pluginLinks) { -%>
-    <% for (const link of asset.pluginLinks) { -%>
+<% if (asset.pluginLinks) { -%>
+<% for (const link of asset.pluginLinks) { -%>
     <%- link %>
-    <% } -%>
-    <% } -%>
+<% } -%>
+<% } -%>
     <link rel="stylesheet" href="<%- asset.layoutStyle %>">
     <% if (siteNav) { %><link rel="stylesheet" href="<%- asset.siteNavCss %>"><% } %>
     <% if (pageNav) { %><link rel="stylesheet" href="<%- asset.pageNavCss %>"><% } %>

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -16,6 +16,11 @@
     <% if (siteNav) { %><link rel="stylesheet" href="<%- asset.siteNavCss %>"><% } %>
     <% if (pageNav) { %><link rel="stylesheet" href="<%- asset.pageNavCss %>"><% } %>
     <%- headFileBottomContent %>
+<% if (pluginsContent.links) { -%>
+<% for (const link of pluginsContent.links) { -%>
+    <%- link %>
+<% } -%>
+<% } -%>
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>
 <body <%_ if (pageNav) { %> data-spy="scroll" data-target="#page-nav" data-offset="100" <%_ } %>>
@@ -36,6 +41,11 @@
 <% if (asset.externalScripts) { -%>
 <% for (const script of asset.externalScripts) { -%>
 <script src="<%- script %>"></script>
+<% } -%>
+<% } -%>
+<% if (pluginsContent.scripts) { -%>
+<% for (const script of pluginsContent.scripts) { -%>
+<%- script %>
 <% } -%>
 <% } -%>
 <script src="<%- asset.layoutScript %>"></script>

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -12,15 +12,15 @@
     <link rel="stylesheet" href="<%- asset.glyphicons %>" >
     <link rel="stylesheet" href="<%- asset.highlight %>">
     <link rel="stylesheet" href="<%- asset.markbind %>">
+    <% if (asset.pluginLinks) { -%>
+    <% for (const link of asset.pluginLinks) { -%>
+    <%- link %>
+    <% } -%>
+    <% } -%>
     <link rel="stylesheet" href="<%- asset.layoutStyle %>">
     <% if (siteNav) { %><link rel="stylesheet" href="<%- asset.siteNavCss %>"><% } %>
     <% if (pageNav) { %><link rel="stylesheet" href="<%- asset.pageNavCss %>"><% } %>
     <%- headFileBottomContent %>
-<% if (pluginsContent.links) { -%>
-<% for (const link of pluginsContent.links) { -%>
-    <%- link %>
-<% } -%>
-<% } -%>
     <% if (faviconUrl) { %><link rel="icon" href="<%- faviconUrl %>"><% } %>
 </head>
 <body <%_ if (pageNav) { %> data-spy="scroll" data-target="#page-nav" data-offset="100" <%_ } %>>
@@ -43,8 +43,8 @@
 <script src="<%- script %>"></script>
 <% } -%>
 <% } -%>
-<% if (pluginsContent.scripts) { -%>
-<% for (const script of pluginsContent.scripts) { -%>
+<% if (asset.pluginScripts) { -%>
+<% for (const script of asset.pluginScripts) { -%>
 <%- script %>
 <% } -%>
 <% } -%>

--- a/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
@@ -8,6 +8,6 @@ module.exports = {
     $('#test-markbind-plugin').append(`${pluginContext.post}`);
     return $.html();
   },
-  addLinks: () => ['<link rel="stylesheet" href="STYLESHEET_LINK">'],
-  addScripts: () => ['<script src="SCRIPT_LINK"></script>'],
+  getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
 };

--- a/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
@@ -9,5 +9,6 @@ module.exports = {
     return $.html();
   },
   getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
-  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) =>
+    [utils.buildScript('SCRIPT_LINK'), '<script>alert("hello")</script>'],
 };

--- a/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/_markbind/plugins/testMarkbindPlugin.js
@@ -8,4 +8,6 @@ module.exports = {
     $('#test-markbind-plugin').append(`${pluginContext.post}`);
     return $.html();
   },
+  addLinks: () => ['<link rel="stylesheet" href="STYLESHEET_LINK">'],
+  addScripts: () => ['<script src="SCRIPT_LINK"></script>'],
 };

--- a/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
@@ -8,6 +8,6 @@ module.exports = {
     $('#test-markbind-plugin').append(`${pluginContext.post}`);
     return $.html();
   },
-  addLinks: () => ['<link rel="stylesheet" href="STYLESHEET_LINK">'],
-  addScripts: () => ['<script src="SCRIPT_LINK"></script>'],
+  getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
 };

--- a/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
@@ -9,5 +9,6 @@ module.exports = {
     return $.html();
   },
   getLinks: (content, pluginContext, frontMatter, utils) => [utils.buildStylesheet('STYLESHEET_LINK')],
-  getScripts: (content, pluginContext, frontMatter, utils) => [utils.buildScript('SCRIPT_LINK')],
+  getScripts: (content, pluginContext, frontMatter, utils) =>
+    [utils.buildScript('SCRIPT_LINK'), '<script>alert("hello")</script>'],
 };

--- a/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
+++ b/test/functional/test_site/expected/_markbind/plugins/testMarkbindPlugin.js
@@ -8,4 +8,6 @@ module.exports = {
     $('#test-markbind-plugin').append(`${pluginContext.post}`);
     return $.html();
   },
+  addLinks: () => ['<link rel="stylesheet" href="STYLESHEET_LINK">'],
+  addScripts: () => ['<script src="SCRIPT_LINK"></script>'],
 };

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -16,6 +16,7 @@
     
     
     <meta name="default-head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -92,5 +93,6 @@
     const enableSearch = true
 </script>
 <script src="../markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="../markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -94,5 +94,6 @@
 </script>
 <script src="../markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="../markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="../markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="../markbind/css/github.min.css">
     <link rel="stylesheet" href="../markbind/css/markbind.css">
-    <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="../markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="../markbind/css/github.min.css">
     <link rel="stylesheet" href="../markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -17,8 +17,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     <link rel="stylesheet" href="markbind/css/site-nav.css">
     <link rel="stylesheet" href="markbind/css/page-nav.css">
     <!-- Start of bottom level head file content insertion -->

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -26,6 +26,7 @@
     <!-- Start of bottom level head file content insertion -->
     <script src="/test_site/headFiles/customScriptBottom2.js"></script>
     <!-- End of bottom level head file content insertion-->
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body data-spy="scroll" data-target="#page-nav" data-offset="100">
@@ -556,5 +557,6 @@ specification that specifies how the product will address the requirements. </sp
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -558,5 +558,6 @@ specification that specifies how the product will address the requirements. </sp
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -17,7 +17,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     <link rel="stylesheet" href="markbind/css/site-nav.css">
     <link rel="stylesheet" href="markbind/css/page-nav.css">
     <!-- Start of bottom level head file content insertion -->
@@ -26,7 +27,6 @@
     <!-- Start of bottom level head file content insertion -->
     <script src="/test_site/headFiles/customScriptBottom2.js"></script>
     <!-- End of bottom level head file content insertion-->
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body data-spy="scroll" data-target="#page-nav" data-offset="100">

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -16,6 +16,7 @@
     
     
     <meta name="default-head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -50,5 +51,6 @@
     const enableSearch = true
 </script>
 <script src="../markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="../markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -52,5 +52,6 @@
 </script>
 <script src="../markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="../markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="../markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="../markbind/css/github.min.css">
     <link rel="stylesheet" href="../markbind/css/markbind.css">
-    <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="../markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="../markbind/css/github.min.css">
     <link rel="stylesheet" href="../markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="../markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/testAfterSetup/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/testAfterSetup/styles.css">
     
     
     <meta name="head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -16,6 +16,7 @@
     
     
     <meta name="head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -44,5 +45,6 @@
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/testAfterSetup/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -46,5 +46,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/testAfterSetup/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/testAfterSetup/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/testAfterSetup/styles.css">
     
     
     <meta name="head-bottom">

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -16,6 +16,7 @@
     
     
     <meta name="default-head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -41,5 +42,6 @@
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -43,5 +43,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -16,6 +16,7 @@
     
     
     <meta name="default-head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -45,5 +46,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -47,5 +47,6 @@
 <script src="markbind/js/setup.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -16,6 +16,7 @@
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -57,5 +58,6 @@
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -59,5 +59,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -16,6 +16,7 @@
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -57,5 +58,6 @@
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
     
     
     <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -59,5 +59,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/testLayout/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+            <link rel="stylesheet" href="STYLESHEET_LINK">
+            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">
-    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -44,5 +44,6 @@
 </script>
 <script src="markbind/js/setup.js"></script>
 <script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -12,8 +12,8 @@
     <link rel="stylesheet" href="markbind/css/bootstrap-glyphicons.min.css" >
     <link rel="stylesheet" href="markbind/css/github.min.css">
     <link rel="stylesheet" href="markbind/css/markbind.css">
-            <link rel="stylesheet" href="STYLESHEET_LINK">
-            <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
     
     
     <meta name="default-head-bottom">

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -16,6 +16,7 @@
     
     
     <meta name="default-head-bottom">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
     <link rel="icon" href="/test_site/favicon.png">
 </head>
 <body>
@@ -42,5 +43,6 @@
     const enableSearch = true
 </script>
 <script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
 <script src="markbind/layouts/default/scripts.js"></script>
 </html>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes #692.


**What is the rationale for this request?**

Plugins might need to add stylesheets and scripts for them to work.

**What changes did you make? (Give an overview)**

Provide the `addLinks` and `addScripts` methods for plugins to call.

**Provide some example code that this change will affect:**

```js
module.exports = {
  addLinks: () => ['<link rel="stylesheet" href="STYLESHEET_LINK">'],
  addScripts: () => ['<script src="SCRIPT_LINK"></script>'],
};
```

**Is there anything you'd like reviewers to focus on?**
- I currently pass `frontMatter` as an input to `addLinks` and `addScripts`, but I'm not 100% sure if there is a use case for it.
- Similarly, I'm not sure if there is any other parameters that may be useful to `addLinks` and `addScripts` that we could pass down

**Testing instructions:**
Add a plugin which uses the `addLinks` and `addScripts` methods. The links and scripts should be added to the rendered pages.