### PR TITLE
Deploy user docs via Travis on release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ node_js:
   - '8'
 before_install:
   - chmod +x ./test/functional/test.sh
+deploy:
+  provider: script
+  script: cd docs && ../index.js build && ../index.js deploy --travis
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain: DevOps enhancement

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Closes #688.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Since we have implemented `markbind deploy --travis`, we can now deploy our own user documentation automatically on release with Travis.

**What changes did you make? (Give an overview)**
I added a `deploy` phase to `.travis.yml` that will build and deploy the user docs on release (a commit with a tag matching the pattern `vx.x.x`).

**Testing instructions:**
1. Pull this PR to your own fork, and test with Travis CI enabled.
	- Normal commits should test but not deploy.
	- Tagged commits matching `vx.x.x` should trigger the deploy stage. It will fail since `GITHUB_TOKEN` should not be set, but this is expected.