### PR TITLE
docs/*: rename variable main_title, main_file, etc.

### DIFF
--- a/docs/userGuide/formattingContents.md
+++ b/docs/userGuide/formattingContents.md
@@ -1,22 +1,22 @@
-<variable name="main_title">Formatting Contents</variable>
-<variable name="main_filename">formattingContents</variable>
+<variable name="title">Formatting Contents</variable>
+<variable name="filename">formattingContents</variable>
 
 <frontmatter>
-  title: "User Guide: {{ main_title }}"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
   pageNav: 2
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ main_title }}_]({{ baseUrl }}/userGuide/{{ main_filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />
 
 <div class="website-content">
 
-# {{ main_title }}
+# {{ title }}
 
 <span class="lead" id="overview">
 

--- a/docs/userGuide/usingComponents.md
+++ b/docs/userGuide/usingComponents.md
@@ -1,15 +1,15 @@
-<variable name="main_title">Using Components</variable>
-<variable name="this_filename">usingComponents</variable>
+<variable name="title">Using Components</variable>
+<variable name="filename">usingComponents</variable>
 
 <frontmatter>
-  title: "User Guide: {{ main_title }}"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   pageNav: "default"
   siteNav: userGuideSections.md
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ main_title }}_]({{ baseUrl }}/userGuide/{{ this_filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />

--- a/docs/userGuide/usingHtmlJavaScriptCss.md
+++ b/docs/userGuide/usingHtmlJavaScriptCss.md
@@ -1,21 +1,21 @@
-<variable name="main_title">Using HTML, JavaScript, CSS</variable>
-<variable name="this_filename">usingHtmlJavaScriptCss</variable>
+<variable name="title">Using HTML, JavaScript, CSS</variable>
+<variable name="filename">usingHtmlJavaScriptCss</variable>
 
 <frontmatter>
-  title: "User Guide: {{ main_title }}"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
 </frontmatter>
 
 <span id="link" class="d-none">
-<md>[_User Guide → {{ main_title }}_]({{ baseUrl }}/userGuide/{{ this_filename }}.html)</md>
+<md>[_User Guide → {{ title }}_]({{ baseUrl }}/userGuide/{{ filename }}.html)</md>
 </span>
 
 <include src="../common/header.md" />
 
 <div class="website-content">
 
-# {{ main_title }}
+# {{ title }}
 
 <span id="overview" class="lead">
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update


```
Some files use the variable `main_title` (instead of `title`)
to avoid being overwritten by a similarly named variable in a
reuse context.

As of v1.19.0, variables are no longer cascaded into inner files
by default. Hence, there is no need for such a precaution.

Let's rename those variables back to `title`.
```