### PR TITLE
Remove siteNav and pageNav entries from the glossary

### DIFF
--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -29,20 +29,5 @@ Use [the `serve` command]({{ baseUrl }}/userGuide/cliCommands.html#serve-command
 MarkBind is able to take Markdown files (`.md`) and HTML files (`.html`) as source files too.
 </span>
 
-
-#### Site Navigation Menu
-
-<span id="site-navigation-menu">
-
-_Site Navigation Menu_ (_siteNav_ for short) is a fixed menu on the **left** side of your page contents, that shows a road map of the main pages of your site.
-</span>
-
-
-#### Page Navigation Menu
-
-<span id="page-navigation-menu">
-
-_Page Navigation Menu_ (_pageNav_ for short) is a fixed menu on the **right** side of your page contents, which contains the current page's headings.
-</span>
-
 </div>
+

--- a/docs/userGuide/syntax/pageNavigationMenus.mbdf
+++ b/docs/userGuide/syntax/pageNavigationMenus.mbdf
@@ -1,12 +1,8 @@
 ## Page Navigation Menus
 
-**You can add a <trigger trigger="click" for="modal:pageStructure-pageNavigationMenu">_page navigation menu_</trigger> to a page.**
+**A _Page Navigation Menu_ (==_pageNav_ for short==) is a fixed menu on the ==right edge== of your page contents**. You can use a pageNav to show a list of the current page's headings.
 
-<modal title="Page Naviation Menu" id="modal:pageStructure-pageNavigationMenu">
-  <include src="../glossary.md#page-navigation-menu" />
-</modal>
-
-Steps to add a page navigation menu ==(_pageNav_ for short)==:
+Steps to add a pageNav:
 1. Specify your pageNav within the `<frontmatter>` of a page with <tooltip content="The value `default` will use `headingIndexingLevel` within `site.json`.">`"default"`</tooltip> or a <tooltip content="HTML defines six levels of headings, numbered from <br>`1 to 6`.">`heading level`</tooltip>.
 2. (Optional) You may also specify a page navigation title within `<frontmatter>` that will be placed at the top of the page navigation menu.
 

--- a/docs/userGuide/syntax/siteNavigationMenus.mbdf
+++ b/docs/userGuide/syntax/siteNavigationMenus.mbdf
@@ -1,12 +1,8 @@
 ## Site Navigation Menus
 
-**You can add a <trigger trigger="click" for="modal:pageStructure-siteNavidationMenu">_site navigation menu_</trigger> to a page.**
+**A _Site Navigation Menu_ (==_siteNav_ for short==) is a fixed menu on the ==left edge== of a page**, that can be used to show a road map of the main pages of your site.
 
-<modal title="Site Naviation Menu" id="modal:pageStructure-siteNavidationMenu">
-  <include src="../glossary.md#site-navigation-menu" />
-</modal>
-
-Steps to add a site navigation menu ==(_siteNav_ for short)==:
+Steps to add a siteNav:
 1. Format your siteNav as an unordered Markdown list and save it inside the `_markbind/navigation` directory.
 2. Specify the file as the value of the `siteNav` attribute in the `<frontmatter>` of the page.
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

```
Remove siteNav and pageNav entries from the glossary

The Glossary page contains entries for siteNav and pageNav.

As both are explained elsewhere in detail, these two entries are
redundant.

Let's migrate the descriptions of the two entries to their
respective in-detail descriptions, and remove the two entries from
the glossary page.
```