### PR TITLE
Prune reference pages from search index

### DIFF
--- a/docs/site.json
+++ b/docs/site.json
@@ -14,6 +14,18 @@
     },
     {
       "glob": "userGuide/*.md"
+    },
+    {
+      "src": "userGuide/fullSyntaxReference.md",
+      "searchable": "no"
+    },
+    {
+      "src": "userGuide/syntaxCheatSheet.md",
+      "searchable": "no"
+    },
+    {
+      "src": "userGuide/readerFacingFeatures.md",
+      "searchable": "no"
     }
   ],
   "headingIndexingLevel": 6,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

```
Prune reference pages from the search index

The following reference pages (which contain collations of
information from other pages) appear in search results.
* Reader-Facing Features
* Full Syntax Reference
* Syntax Cheat Sheet

Let's remove these pages from the search index so that the search
can send the reader to the 'original' version of the content.
```