### PR TITLE
Remove stray space from FA icon syntax example

### DIFF
--- a/docs/userGuide/syntax/icons.mbdf
+++ b/docs/userGuide/syntax/icons.mbdf
@@ -21,9 +21,9 @@ Please use the new :prefix-name: syntax instead.
 1. Decide which icon you want to use from the [list of available icons](https://fontawesome.com/icons?d=gallery&m=free).
 1. Construct the MarkBind name for the selected icon by adding the _type prefix_.
    Note: Font Awesome has three different styles for their icons, each with their own type prefix. Here is an example from each type:
-   * _Solid_ (prefix: `fas-`) e.g., :fas-file-code: (actual name `file-code`, MarkBind name **`fas-`**`file-code`)
-   * _Regular_ (prefix: `far-`) e.g., :fas-file-code: (actual name `file-code`, MarkBind name **`far-`**`file-code`)
-   * _Brands_ (prefix: `fab-`): e.g., :fab-github-alt: (actual name `github-alt`, MarkBind name **`fab-`**`github-alt`)
+   * _Solid_ (prefix: `fas-`) e.g., :fas-file-code: (actual name `file-code`, MarkBind name `fas-file-code`)
+   * _Regular_ (prefix: `far-`) e.g., :fas-file-code: (actual name `file-code`, MarkBind name `far-file-code`)
+   * _Brands_ (prefix: `fab-`): e.g., :fab-github-alt: (actual name `github-alt`, MarkBind name `fab-github-alt`)
 
 1. Insert MarkBind name for the icon enclosed within colons to get the icon in your page.<br>
   `Create a **branch**`<code>:<span></span>fas-code-branch: now!</code> → Create a **branch** :fas-code-branch: now!


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
As suggested by https://github.com/MarkBind/markbind/pull/680#issuecomment-464619261.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The syntax example for Font Awesome icons has a stray space due to bold formatting. This can be misleading as users may interpret it as a literal space to be included when using FA icons.

![image](https://user-images.githubusercontent.com/1673303/52934124-7d2e3c00-3390-11e9-8c37-b4865bd4d929.png)

**What changes did you make? (Give an overview)**
I removed the bold formatting in the above examples to remove the stray space.

**Testing instructions:**
1. Check the documentation for FA icon fonts. The stray space should no longer be there.