### PR TITLE
Fix minor bug with empty plugin context

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -829,7 +829,7 @@ Page.prototype.preRender = function (content) {
   Object.entries(this.plugins).forEach(([pluginName, plugin]) => {
     if (plugin.preRender) {
       preRenderedContent
-        = plugin.preRender(preRenderedContent, this.pluginsContext[pluginName], this.frontMatter);
+        = plugin.preRender(preRenderedContent, this.pluginsContext[pluginName] || {}, this.frontMatter);
     }
   });
   return preRenderedContent;
@@ -843,7 +843,7 @@ Page.prototype.postRender = function (content) {
   Object.entries(this.plugins).forEach(([pluginName, plugin]) => {
     if (plugin.postRender) {
       postRenderedContent
-        = plugin.postRender(postRenderedContent, this.pluginsContext[pluginName], this.frontMatter);
+        = plugin.postRender(postRenderedContent, this.pluginsContext[pluginName] || {}, this.frontMatter);
     }
   });
   return postRenderedContent;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Minor bug occurs when filterTags is not given a plugin context in site.json:
```
  "plugins": [
    "filterTags"
  ],
  "pluginsContext": {
  }
```
![image](https://user-images.githubusercontent.com/19278089/53088843-e73c1200-3545-11e9-9b51-78111940989e.png)

We expect the result to equal:
```
  "plugins": [
    "filterTags"
  ],
  "pluginsContext": {
    "filterTags": {}
  }
```

**What changes did you make? (Give an overview)**

For plugins, if no plugin context is supplied, pass in an empty object instead of undefined.