### PR TITLE
Add missing title for Using Plugins page

### DIFF
--- a/docs/userGuide/tipsAndTricks.md
+++ b/docs/userGuide/tipsAndTricks.md
@@ -1,4 +1,5 @@
 <variable name="title">Tips & Tricks</variable>
+
 <frontmatter>
   title: "User Guide: {{ title | safe }}"
   footer: footer.md

--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -1,4 +1,7 @@
+<variable name="title">Using Plugins</variable>
+
 <frontmatter>
+  title: "User Guide: {{ title }}"
   footer: userGuideFooter.md
   siteNav: userGuideSections.md
 </frontmatter>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

**What is the rationale for this request?**
Page title is currently missing.

<img width="524" alt="screenshot 2019-02-20 at 9 39 16 pm" src="https://user-images.githubusercontent.com/17447681/53095546-152a5200-3558-11e9-8ac0-3f62a0a915fd.png">


**What changes did you make? (Give an overview)**
Add page title.
