### PR TITLE
Fix: Uncaught exceptions cause a silent exit

### DIFF
--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -276,7 +276,8 @@ Parser.prototype._preprocess = function (node, context, config) {
 
     // Render inner file content
     fileContent = nunjucks.renderString(fileContent,
-                                        { ...pageVariables, ...includeVariables, ...userDefinedVariables });
+                                        { ...pageVariables, ...includeVariables, ...userDefinedVariables },
+                                        { path: actualFilePath });
 
     // Delete variable attributes in include
     Object.keys(element.attribs).forEach((attribute) => {
@@ -504,7 +505,8 @@ Parser.prototype.includeFile = function (file, config) {
       const { parent, relative } = calculateNewBaseUrls(file, config.rootPath, config.baseUrlMap);
       const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
       const pageVariables = extractPageVariables(path.basename(file), data, userDefinedVariables, {});
-      const fileContent = nunjucks.renderString(data, { ...pageVariables, ...userDefinedVariables });
+      const fileContent = nunjucks.renderString(data, { ...pageVariables, ...userDefinedVariables },
+                                                { path: actualFilePath });
       const fileExt = utils.getExt(file);
       if (utils.isMarkdownFileExt(fileExt)) {
         context.source = 'md';
@@ -658,7 +660,7 @@ Parser.prototype._rebaseReference = function (node, foundBase) {
               // and let the hostBaseUrl value be injected later.
               hostBaseUrl: '{{hostBaseUrl}}',
               baseUrl: newBaseUrl,
-            });
+            }, { path: filePath });
             element.children = cheerio.parseHTML(rendered, true);
             cheerio.prototype.options.xmlMode = true;
           }
@@ -694,7 +696,7 @@ Parser.prototype._rebaseReferenceForStaticIncludes = function (pageData, element
 
   const newBase = fileBase.relative;
   const newBaseUrl = `{{hostBaseUrl}}/${newBase}`;
-  return nunjucks.renderString(pageData, { baseUrl: newBaseUrl });
+  return nunjucks.renderString(pageData, { baseUrl: newBaseUrl }, { path: filePath });
 };
 
 module.exports = Parser;

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -505,7 +505,8 @@ Parser.prototype.includeFile = function (file, config) {
       const { parent, relative } = calculateNewBaseUrls(file, config.rootPath, config.baseUrlMap);
       const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
       const pageVariables = extractPageVariables(path.basename(file), data, userDefinedVariables, {});
-      const fileContent = nunjucks.renderString(data, { ...pageVariables, ...userDefinedVariables },
+      const fileContent = nunjucks.renderString(data,
+                                                { ...pageVariables, ...userDefinedVariables },
                                                 { path: actualFilePath });
       const fileExt = utils.getExt(file);
       if (utils.isMarkdownFileExt(fileExt)) {

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -9,9 +9,10 @@ winston.configure({
   exitOnError: false,
   transports: [
     new (winston.transports.Console)({
-      level: 'error',
+      colorize: true,
       handleExceptions: true,
       humanReadableUnhandledException: true,
+      level: 'error',
       showLevel: true,
     }),
     new DailyRotateFile({

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -8,6 +8,12 @@ const DailyRotateFile = require('winston-daily-rotate-file');
 winston.configure({
   exitOnError: false,
   transports: [
+    new (winston.transports.Console)({
+      level: 'error',
+      handleExceptions: true,
+      humanReadableUnhandledException: true,
+      showLevel: true,
+    }),
     new DailyRotateFile({
       datePattern: 'YYYY-MM-DD',
       dirname: '_markbind/logs',

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -12,7 +12,7 @@ winston.configure({
       colorize: true,
       handleExceptions: true,
       humanReadableUnhandledException: true,
-      level: 'error',
+      level: 'info',
       showLevel: true,
     }),
     new DailyRotateFile({
@@ -30,15 +30,12 @@ winston.configure({
 
 module.exports = {
   error: (text) => {
-    console.log(chalk.red(`error: ${text}`));
     winston.error(text);
   },
   warn: (text) => {
-    console.log(chalk.yellow(`warning: ${text}`));
     winston.warn(text);
   },
   info: (text) => {
-    console.log(chalk.cyan('info: ') + text);
     winston.info(text);
   },
   verbose: (text) => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes #265, #610.

**What is the rationale for this request?**

Errors in building files with nunjucks (as well as uncaught exceptions) were causing a silent exit. This information should be shown to the user on the console. It was previously shown in the log file only. 

**What changes did you make? (Give an overview)**

Added a new [Console transport](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport) to winston for logging errors to the console.

Also passed the path parameter to `nunjucks.renderString()` as errors thrown by Nunjucks were not showing the file paths.

**Provide some example code that this change will affect:**

Add the following statement to any file: 

```
<!-- the following will cause an exception in Nunjucks -->
{% set error = " %}
```

Console output on `markbind build`:

```
error: uncaughtException: (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/docs/about.md) [Line 14, Column 19]
  expected block end in set statement date=Thu Feb 21 2019 10:22:03 GMT+0800 (Singapore Standard Time), pid=32358, uid=501, gid=20, cwd=/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/docs, execPath=/usr/local/Cellar/node/11.10.0/bin/node, version=v11.10.0, argv=[/usr/local/Cellar/node/11.10.0/bin/node, /usr/local/bin/markbind, build], rss=85471232, heapTotal=64253952, heapUsed=37254224, external=2661243, loadavg=[2.04248046875, 2.189453125, 2.33935546875], uptime=310221
Template render error: (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/docs/about.md) [Line 14, Column 19]
  expected block end in set statement
    at Object.exports.prettifyError (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/src/lib/markbind/node_modules/nunjucks/src/lib.js:34:15)
    at new_cls.render (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/src/lib/markbind/node_modules/nunjucks/src/environment.js:472:27)
    at new_cls.renderString (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/src/lib/markbind/node_modules/nunjucks/src/environment.js:328:21)
    at Object.module.exports.renderString (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/src/lib/markbind/node_modules/nunjucks/index.js:80:14)
    at fs.readFile (/Users/aadyaamaddi/Desktop/BComp/Semester 6 1819/CS3281:2/markbind/src/lib/markbind/src/parser.js:508:36)
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:54:3)
```