### PR TITLE
docs: Change markbind.github.io to markbind.org

### DIFF
--- a/docs/userGuide/syntax/images.mbdf
+++ b/docs/userGuide/syntax/images.mbdf
@@ -4,22 +4,22 @@
 <span id="code">
 
 ```markdown
-![](https://markbind.github.io/markbind/images/logo-lightbackground.png)
+![](https://markbind.org/images/logo-lightbackground.png)
 ```
 </span>
 <span id="output">
 
-![alt text here](https://markbind.github.io/markbind/images/logo-lightbackground.png "title here")
+![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
 </span>
 </include>
 
 <span id="short" class="d-none">
 ```markdown
-![alt text here](https://markbind.github.io/markbind/images/logo-lightbackground.png "title here")
+![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
 ```
 </span>
 
 <span id="examples" class="d-none">
 
-![alt text here](https://markbind.github.io/markbind/images/logo-lightbackground.png "title here")
+![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
 </span>

--- a/docs/userGuide/syntax/links.mbdf
+++ b/docs/userGuide/syntax/links.mbdf
@@ -7,12 +7,12 @@ Basic style:
 <span id="code">
 
 ```markdown
-MarkBind home is at [here](https://markbind.github.io).
+MarkBind home is at [here](https://markbind.org).
 ```
 </span>
 <span id="output">
 
-MarkBind home is at [here](https://markbind.github.io).
+MarkBind home is at [here](https://markbind.org).
 </span>
 </include>
 </span>
@@ -26,7 +26,7 @@ _Reference style_ links (i.e., specify the URL in a separate place):
 ```markdown
 MarkBind home is at [here][1].
 
-[1]: https://markbind.github.io
+[1]: https://markbind.org
 
 ```
 </span>
@@ -34,7 +34,7 @@ MarkBind home is at [here][1].
 
 MarkBind home is at [here][1]
 
-[1]: https://markbind.github.io
+[1]: https://markbind.org
 
 </span>
 </include>
@@ -60,15 +60,15 @@ Links to files of the generated site (e.g., an HTML page or an image file) shoul
 <span id="short" class="d-none">
 
 ```markdown
-MarkBind home is at [here](https://markbind.github.io).
+MarkBind home is at [here](https://markbind.org).
 
 MarkBind home is at [here][1].
 
-[1]: https://markbind.github.io
+[1]: https://markbind.org
 ```
 </span>
 
 <span id="examples" class="d-none">
 
-MarkBind home is at [here](https://markbind.github.io).
+MarkBind home is at [here](https://markbind.org).
 </span>

--- a/docs/userGuide/syntax/panels.mbdf
+++ b/docs/userGuide/syntax/panels.mbdf
@@ -161,14 +161,14 @@
 <span id="code">
 
 ```html
-<panel header="**Bold text** :rocket: ![](https://markbind.github.io/markbind/images/logo-lightbackground.png =x20)" type="seamless">
+<panel header="**Bold text** :rocket: ![](https://markbind.org/images/logo-lightbackground.png =x20)" type="seamless">
   ...
 </panel>
 ```
 </span>
 <span id="output">
 
-<panel header="**Bold text** :rocket: ![](https://markbind.github.io/markbind/images/logo-lightbackground.png =x20)" type="seamless">
+<panel header="**Bold text** :rocket: ![](https://markbind.org/images/logo-lightbackground.png =x20)" type="seamless">
   ...
   </panel>
 </span>

--- a/docs/userGuide/syntax/pictures.mbdf
+++ b/docs/userGuide/syntax/pictures.mbdf
@@ -6,14 +6,14 @@
 <span id="code">
 
 ```html
-<pic src="https://markbind.github.io/markbind/images/logo-lightbackground.png" width="300" alt="Logo">
+<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
 ```
 </span>
 <span id="output">
 
-<pic src="https://markbind.github.io/markbind/images/logo-lightbackground.png" width="300" alt="Logo">
+<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
 </span>
@@ -30,7 +30,7 @@ width | `string` | | The width of the image in pixels.<br>If both width and heig
 <span id="short" class="d-none">
 
 ```html
-<pic src="https://markbind.github.io/markbind/images/logo-lightbackground.png" width="300" alt="Logo">
+<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
 ```
@@ -38,7 +38,7 @@ width | `string` | | The width of the image in pixels.<br>If both width and heig
 
 <span id="examples" class="d-none">
 
-<pic src="https://markbind.github.io/markbind/images/logo-lightbackground.png" width="300" alt="Logo">
+<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
 </span>

--- a/src/Site.js
+++ b/src/Site.js
@@ -114,7 +114,7 @@ const USER_VARIABLES_DEFAULT = '<span id="example">\n'
   + '</span>';
 
 const GENERATE_SITE_LOGGING_KEY = 'Generate Site';
-const MARKBIND_WEBSITE_URL = 'https://markbind.github.io/markbind/';
+const MARKBIND_WEBSITE_URL = 'https://markbind.org/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #722.


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
We have changed our project website URL from `https://markbind.github.io/markbind` to `https://markbind.org`. We should change the URL linked to by the `{{ MarkBind }}` variable and our user documentation to the new URL.

**What changes did you make? (Give an overview)**
I updated the URL linked to by `{{ MarkBind }}` and our user documentation to be `https://markbind.org`.

**Provide some example code that this change will affect:**

```
{{ MarkBind }}
```

**Testing instructions:**
1. Use the `{{ MarkBind }}` variable on a MarkBind page. It should link to https://markbind.org.
2. Verify that the user documentation refers to markbind.org in place of markbind.github.io.