### PR TITLE
Fix Travis deploy repo regex to only match .git at end

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -895,7 +895,7 @@ Site.prototype.deploy = function (travisTokenVar) {
           let repoSlug = process.env.TRAVIS_REPO_SLUG;
           if (options.repo) {
             // Extract repo slug from user-specified repo URL so that we can include the access token
-            const repoSlugRegex = /github\.com[:/]([\w-]+\/[\w-]+)\.git/;
+            const repoSlugRegex = /github\.com[:/]([\w-]+\/[\w-.]+)\.git$/;
             const repoSlugMatch = repoSlugRegex.exec(options.repo);
             if (!repoSlugMatch) {
               reject(new Error('-t/--travis expects a GitHub repository.\n'

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -433,6 +433,23 @@ describe('Site deploy with Travis', () => {
       .toEqual(`https://${process.env.GITHUB_TOKEN}@github.com/USER/REPO.git`);
   });
 
+  test('Site deploy -t/--travis deploys to correct repo when .git is in repo name', async () => {
+    process.env.TRAVIS = true;
+    process.env.GITHUB_TOKEN = 'githubToken';
+    process.env.TRAVIS_REPO_SLUG = 'TRAVIS_USER/TRAVIS_REPO.github.io';
+
+    const json = {
+      'src/template/page.ejs': PAGE_EJS,
+      'site.json': SITE_JSON_DEFAULT,
+      _site: {},
+    };
+    fs.vol.fromJSON(json, '');
+    const site = new Site('./', '_site');
+    await site.deploy(true);
+    expect(ghpages.options.repo)
+      .toEqual(`https://${process.env.GITHUB_TOKEN}@github.com/TRAVIS_USER/TRAVIS_REPO.github.io.git`);
+  });
+
   test('Site deploy -t/--travis should not deploy if not in Travis', async () => {
     const json = {
       'src/template/page.ejs': PAGE_EJS,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves an issue discovered during a test of #701.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The regex we use for matching GitHub repo slugs in Travis is incorrect and may make Travis push to the wrong repository. For example, our regex would incorrectly match `https://github.com/MarkBind/markbind.github.io.git` as `MarkBind/markbind.git`:

<img alt="Incorrect Travis regex match" src="https://user-images.githubusercontent.com/1782590/53148077-80ba0100-35e4-11e9-9455-b9668235b08c.png" height=125 />

**What changes did you make? (Give an overview)**
I fixed the regex to only match `.git` at the end (`$`) and to match periods in the repository name.

**Testing instructions:**
1. Specify a `repo` in `site.json` with a `.git` in the name. It should not match the `.git` in the name, only the end.
Eg. `https://github.com/MarkBind/markbind.github.io.git` should match as `MarkBind/markbind.github.io.git`.