### PR TITLE
Fix missing footer in Using Plugins page

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -2,7 +2,7 @@
 
 <frontmatter>
   title: "User Guide: {{ title }}"
-  footer: userGuideFooter.md
+  footer: footer.md
   siteNav: userGuideSections.md
 </frontmatter>
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes #729.

**What is the rationale for this request?**

The documentation page Using Plugins was missing the footer.

**What changes did you make? (Give an overview)**

Changed the footer name in frontmatter for usingPlugins.md from `userGuideFooter.md` to `footer.md`.

**Provide some example code that this change will affect:**

The page 'Using Plugins' now has a footer:

![screenshot_2019-02-26 markbind - user guide using plugins](https://user-images.githubusercontent.com/22164211/53356298-0f70aa00-3966-11e9-970b-dd58e3d3d88e.png)
