### PR TITLE
Add previous/next links to the user guide

### DIFF
--- a/docs/njk/common.njk
+++ b/docs/njk/common.njk
@@ -1,0 +1,11 @@
+{% macro previous_next(previous_page, next_page) %}
+<div class="clearfix">
+{% if previous_page != ''%}
+<span class="float-left"><b-btn variant="light" href="{{ baseUrl }}/userGuide/{{ previous_page }}.html"><md>:far-arrow-alt-circle-left: <include src="{{ previous_page }}.md#title" inline /></md></b-btn></span>
+{% endif %}
+{% if next_page != ''%}
+<span class="float-right"><b-btn variant="light" href="{{ baseUrl }}/userGuide/{{ next_page }}.html"><md><include src="{{ next_page }}.md#title" inline /> :far-arrow-alt-circle-right:</md></b-btn></span>
+</div>
+{% endif %}
+<br>
+{% endmacro %}

--- a/docs/userGuide/addingPages.md
+++ b/docs/userGuide/addingPages.md
@@ -1,4 +1,4 @@
-<variable name="title">Adding Pages</variable>
+<variable name="title" id="title">Adding Pages</variable>
 <variable name="filename">addingPages</variable>
 
 <frontmatter>
@@ -46,3 +46,6 @@ Here are the steps to add a new page to your site:
 <modal large title="Live Preview" id="modal:addingPages-livePreview">
 <include src="glossary.md#live-preview" inline/>
 </modal>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('authoringContents', 'markBindSyntaxOverview') }}

--- a/docs/userGuide/authoringContents.md
+++ b/docs/userGuide/authoringContents.md
@@ -1,12 +1,13 @@
+<variable name="title" id="title">Authoring Contents</variable>
 <frontmatter>
-  title: "User Guide: Authoring Contents"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
 </frontmatter>
 
 <include src="../common/header.md" />
 
-# Authoring Contents
+# {{ title }}
 
 {% set pages = [
   ['Adding Pages', 'addingPages'],
@@ -30,3 +31,6 @@
 <span class="indented">More info in: <include src="{{ page[1] }}.md#link" inline trim /></span>
 
 {% endfor %}
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('gettingStarted', 'addingPages') }}

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -1,5 +1,6 @@
+<variable name="title" id="title">Deploying the Site</variable>
 <frontmatter>
-  title: "User Guide - Deploying the Site"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
   pageNav: default
@@ -7,7 +8,7 @@
 
 <include src="../common/header.md" />
 
-# Deploying the Site
+# {{ title }}
 
 <span class="lead">
 
@@ -173,3 +174,6 @@ Here are the steps to set up Netlify to use a specific version of MarkBind.
    In step 5, ==Set the `Build Command` to `markbind build --baseUrl`==
 
 </box>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('makingTheSiteSearchable', 'markBindInTheProjectWorkflow') }}

--- a/docs/userGuide/formattingContents.md
+++ b/docs/userGuide/formattingContents.md
@@ -1,4 +1,4 @@
-<variable name="title">Formatting Contents</variable>
+<variable name="title" id="title">Formatting Contents</variable>
 <variable name="filename">formattingContents</variable>
 
 <frontmatter>
@@ -42,3 +42,6 @@
 <include src="tipsAndTricks.md#escapingCharacters" />
 
 </panel>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('markBindSyntaxOverview', 'usingComponents') }}

--- a/docs/userGuide/gettingStarted.md
+++ b/docs/userGuide/gettingStarted.md
@@ -1,12 +1,13 @@
+<variable name="title" id="title">Getting Started</variable>
 <frontmatter>
-  title: "User Guide - Quick Start"
+  title: "User Guide - {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
 </frontmatter>
 
 <include src="../common/header.md" />
 
-# Getting Started
+# {{ title }}
 
 <big>**Prerequisites**</big>
 
@@ -86,3 +87,6 @@ To stop the web server, go to the console running the `serve` command and press 
 
 1. **Update the content of your site**. More info can be found in the [_User Guide: Authoring Contents_]({{ baseUrl }}/userGuide/authoringContents.html) section
 1. **Deploy your site**. More info can be found in the [_User Guide: Deploying the Site_]({{ baseUrl }}/userGuide/deployingTheSite.html) section.
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('', 'authoringContents') }}

--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -1,4 +1,4 @@
-<variable name="title">Making the Site Searchable</variable>
+<variable name="title" id="title">Making the Site Searchable</variable>
 <variable name="filename">makingTheSiteSearchable</variable>
 
 <frontmatter>
@@ -30,3 +30,6 @@
 
 If you do not wish to use MarkBind's searchbar (e.g. you have an external service provider), it may be helpful to include the option `enableSearch: false` in your `site.json`. This stops MarkBind from indexing search headings and speeds up building.
 </box>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('reusingContents', 'deployingTheSite') }}

--- a/docs/userGuide/markBindInTheProjectWorkflow.md
+++ b/docs/userGuide/markBindInTheProjectWorkflow.md
@@ -1,12 +1,13 @@
+<variable name="title" id="title">MarkBind in the Project Workflow</variable>
 <frontmatter>
-  title: "User Guide: Using MarkBind in the Project Workflow"
+  title: "User Guide: {{ title }}"
   footer: footer.md
   siteNav: userGuideSections.md
 </frontmatter>
 
 <include src="../common/header.md" />
 
-# MarkBind in the Project Workflow
+# {{ title }}
 
 <span class="lead">
 
@@ -35,3 +36,6 @@ You can keep the user docs in a separate directory (say `user-docs`) and set up 
 
 Similarly, you can keep the dev docs in a separate directory (sey `dev-docs`) and set up Netlify to deploy the site when there is an update to the `master` branch; that way, developers can see the latest version of dev-docs via the Netlify site.
 </div>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('deployingTheSite', '') }}

--- a/docs/userGuide/markBindSyntaxOverview.md
+++ b/docs/userGuide/markBindSyntaxOverview.md
@@ -1,4 +1,4 @@
-<variable name="title">MarkBind Syntax Overview</variable>
+<variable name="title" id="title">MarkBind Syntax Overview</variable>
 <variable name="filename">markBindSyntaxOverview</variable>
 
 <frontmatter>
@@ -120,3 +120,6 @@ As MarkBind uses [VueStrap](https://bootstrap-vue.js.org/docs/components/alert/)
 </box>
 
 As MarkBind uses Nunjucks behind the scene, **MarkBind is generally compatible with Nunjucks**, which means you can use Nunjucks templating in your source files. Note that ==the code is processed for Nunjucks syntax before the rest of the MarkBind syntax are processed==.
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('addingPages', 'formattingContents') }}

--- a/docs/userGuide/reusingContents.md
+++ b/docs/userGuide/reusingContents.md
@@ -1,4 +1,4 @@
-<variable name="title">Reusing Contents</variable>
+<variable name="title" id="title">Reusing Contents</variable>
 <variable name="filename">reusingContents</variable>
 
 <frontmatter>
@@ -155,3 +155,6 @@ Then, in a page-specific CSS file,
 #### Creating slight variations of content
 
 Tags are a good way to create multiple variations of a page within the same source file, such as to filter content for creating multiple different versions of the same page. See [_User Guide: Tweaking the Page Structure → Tags_]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#tags) section for more information.
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('tweakingThePageStructure', 'makingTheSiteSearchable') }}

--- a/docs/userGuide/tweakingThePageStructure.md
+++ b/docs/userGuide/tweakingThePageStructure.md
@@ -1,4 +1,4 @@
-<variable name="title">Tweaking the Page Structure</variable>
+<variable name="title" id="title">Tweaking the Page Structure</variable>
 <variable name="filename">tweakingThePageStructure</variable>
 
 <frontmatter>
@@ -43,3 +43,6 @@
 <hr><!-- ======================================================================================================= -->
 
 <include src="plugins/filterTags.mbdf" />
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('usingPlugins', 'reusingContents') }}

--- a/docs/userGuide/usingComponents.md
+++ b/docs/userGuide/usingComponents.md
@@ -1,4 +1,4 @@
-<variable name="title">Using Components</variable>
+<variable name="title" id="title">Using Components</variable>
 <variable name="filename">usingComponents</variable>
 
 <frontmatter>
@@ -44,3 +44,6 @@ To use a component, just use the corresponding markup in your file. For example,
 
 <include src="./components/advanced.md" />
 <br>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('formattingContents', 'usingHtmlJavaScriptCss') }}

--- a/docs/userGuide/usingHtmlJavaScriptCss.md
+++ b/docs/userGuide/usingHtmlJavaScriptCss.md
@@ -1,4 +1,4 @@
-<variable name="title">Using HTML, JavaScript, CSS</variable>
+<variable name="title" id="title">Using HTML, JavaScript, CSS</variable>
 <variable name="filename">usingHtmlJavaScriptCss</variable>
 
 <frontmatter>
@@ -74,3 +74,6 @@ Outcome:<br>
 <markdown>##### Apples **Bananas** Cherries</markdown>
 </span>
 </div>
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('usingComponents', 'usingPlugins') }}

--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -1,4 +1,4 @@
-<variable name="title">Using Plugins</variable>
+<variable name="title" id="title">Using Plugins</variable>
 
 <frontmatter>
   title: "User Guide: {{ title }}"
@@ -151,3 +151,6 @@ This will add the following link and script elements to the page:
 MarkBind has a set of built-in plugins that can be used immediately without installation.
 
 <include src="plugins/filterTags.mbdf" />
+
+{% from "njk/common.njk" import previous_next %}
+{{ previous_next('usingHtmlJavaScriptCss', 'tweakingThePageStructure') }}


### PR DESCRIPTION
Proposed commit message (please use squash and merge):
```
Add previous/next links to the user guide

Let's add previous/next links to the bottom of the main pages of the
user guide so that readers can read the relevant pages in the correct
sequence if they want to.

These links are not added to reference pages as they are not meant
to be read in a linear sequence.

A nunjucks macro is used to minimize duplicating boilerplate code.
Using a boilerplate include is not feasible because the reused code
has conditional contents. For example, the 'next' link should not
appear in the last page of the sequence.

`<variable name='title' id='title'>` syntax is used to make the
title of a page accessible from other pages. The duplicate id attribute
can be removed after MarkBind has added support for accessing page
variables from outside of the page.
```

• [x] Documentation update
