### PR TITLE
docs/siteConfiguration: fix broken link

### DIFF
--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -85,7 +85,7 @@ Here is a typical `site.json` file:
 * **`src`**/**`glob`**: `src` can be used to specify a file e.g., `docs/index.md`.<br>
     Alternatively, `glob` can be used to define a file pattern in the [_glob syntax_](https://en.wikipedia.org/wiki/Glob_(programming)) e.g., `**/*.md`.
 * **`title`**: The page `<title>` for the generated web page. Titles specified here take priority over titles specified in the [front matter](addingPages.html#front-matter) of individual pages.
-* **`layout`**: The [layout]({{ baseUrl }}/userGuide/advancedTopics.html#page-layout) to be used by the page. Default: `default`.
+* **`layout`**: The [layout]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.
 * **`externalScripts`**: An array of external scripts to be referenced on the page. Scripts referenced will be run before the layout script.
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

Fixes #741

**What is the rationale for this request?**
Broken link in user docs

**What changes did you make? (Give an overview)**
Replace the link

**Testing instructions:**
Navigate to http://localhost:8080/userGuide/siteConfiguration.html -> Under the `pages` section, click on the `layout` link. You will get navigated to the appropriate page in the user docs.