### PR TITLE
docs/reusingContents: fix typo in reusing-content-across-sites

### DIFF
--- a/docs/userGuide/reusingContents.md
+++ b/docs/userGuide/reusingContents.md
@@ -32,7 +32,7 @@
 
 ## Reusing Contents Across Sites
 
-**MarkBind supports reusing across sites.** It allows you include the pages you want from a _sub-site_ in another _main-site_ without having to change anything in the source files of the _sub-site_ as long as the sub-site source files are inside the directory of the _main site_.
+**MarkBind supports reusing across sites.** It allows you to include the pages you want from a _sub-site_ in another _main-site_ without having to change anything in the source files of the _sub-site_ as long as the sub-site source files are inside the directory of the _main site_.
 
 <div class="indented">
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

**What is the rationale for this request?**
This is just a small PR to fix a typo I discovered while working on reusing contents.

**What changes did you make? (Give an overview)**
Fixed typo in documentation.