### PR TITLE
docs: add missing searchbar closing tag in Algolia plugin example

### DIFF
--- a/docs/userGuide/plugins/algolia.mbdf
+++ b/docs/userGuide/plugins/algolia.mbdf
@@ -32,7 +32,7 @@ site.json
 To connect the `searchbar` component to Algolia DocSearch, add the `algolia` key.
 
 ```html
-<searchbar placeholder="Search" algolia menu-align-right>
+<searchbar placeholder="Search" algolia menu-align-right></searchbar>
 ```
 
 Alternatively, if you are using a custom search bar, you can assign the input field the id `algolia-search-input` to connect it to Algolia DocSearch.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] Bug fix

**What changes did you make? (Give an overview)**
`searchbar` example in Algolia plugin docs was missing a closing tag. I've added the closing tag.
