### PR TITLE
Add <meta name="generator"> tags to generated HTML

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -17,6 +17,8 @@ const logger = require('./util/logger');
 const MarkBind = require('./lib/markbind/src/parser');
 const md = require('./lib/markbind/src/lib/markdown-it');
 
+const CLI_VERSION = require('../package.json').version;
+
 const FOOTERS_FOLDER_PATH = '_markbind/footers';
 const HEAD_FOLDER_PATH = '_markbind/head';
 const LAYOUT_DEFAULT_NAME = 'default';
@@ -238,6 +240,7 @@ Page.prototype.prepareTemplateData = function () {
     faviconUrl: this.faviconUrl,
     headFileBottomContent: this.headFileBottomContent,
     headFileTopContent: this.headFileTopContent,
+    markBindVersion: `MarkBind ${CLI_VERSION}`,
     pageNav: this.isPageNavigationSpecifierValid(),
     siteNav: this.frontMatter.siteNav,
     title: prefixedTitle,

--- a/src/template/page.ejs
+++ b/src/template/page.ejs
@@ -4,6 +4,7 @@
     <%- headFileTopContent %>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="<%- markBindVersion %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><%= title %></title>
     <link rel="stylesheet" href="<%- asset.bootstrap %>">

--- a/test/functional/test_site/expected/bugs/index.html
+++ b/test/functional/test_site/expected/bugs/index.html
@@ -4,6 +4,7 @@
     <meta name="default-head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Open Bugs</title>
     <link rel="stylesheet" href="../markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -9,6 +9,7 @@
     <!-- End of top level head file content insertion -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/index.html
@@ -4,6 +4,7 @@
     <meta name="default-head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title></title>
     <link rel="stylesheet" href="../markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/testAfterSetup.html
+++ b/test/functional/test_site/expected/testAfterSetup.html
@@ -4,6 +4,7 @@
     <meta name="head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -4,6 +4,7 @@
     <meta name="default-head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/testExternalScripts.html
+++ b/test/functional/test_site/expected/testExternalScripts.html
@@ -4,6 +4,7 @@
     <meta name="default-head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -4,6 +4,7 @@
     
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -4,6 +4,7 @@
     
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Hello World</title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">

--- a/test/functional/test_site/expected/test_md_fragment.html
+++ b/test/functional/test_site/expected/test_md_fragment.html
@@ -4,6 +4,7 @@
     <meta name="default-head-top">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.20.0">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title></title>
     <link rel="stylesheet" href="markbind/css/bootstrap.min.css">


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #754.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
As per #754, the Agolia team has asked us to include a `<meta name="generator">` tag to identify sites generated by MarkBind.

**What changes did you make? (Give an overview)**
I added a `<meta name="generator">` tag to the page template as requested:

```html
<meta name="generator" content="MarkBind 1.19.2">
```

**Is there anything you'd like reviewers to focus on?**
Since the current version number is now included in generated HTML, the `test_site` will need to be updated for each new version.

**Testing instructions:**
1. `markbind build` a MarkBind site. The new `<meta>` tag should be in the header.