### PR TITLE
Fix Anti-FOUC styles for Dropdowns

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -59,11 +59,14 @@ function removeTemporaryStyles() {
   jQuery('.temp-dropdown-placeholder').remove();
 }
 
+function executeAfterCreatedRoutines() {
+  removeTemporaryStyles();
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
   setupAnchors();
-  removeTemporaryStyles();
   MarkBind.executeAfterSetupScripts.resolve();
 }
 
@@ -100,6 +103,9 @@ function setup() {
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
+    created() {
+      executeAfterCreatedRoutines();
+    },
     mounted() {
       executeAfterMountedRoutines();
     },
@@ -127,6 +133,9 @@ function setupWithSearch() {
         const anchor = match.heading ? `#${match.heading.id}` : '';
         window.location = `${page}${anchor}`;
       },
+    },
+    created() {
+      executeAfterCreatedRoutines();
     },
     mounted() {
       executeAfterMountedRoutines();

--- a/docs/userGuide/syntax/dropdowns.mbdf
+++ b/docs/userGuide/syntax/dropdowns.mbdf
@@ -1,5 +1,7 @@
 ## Dropdowns
 
+**You can use Dropdowns as a top level component.**
+
 <include src="outputBox.md" boilerplate >
 <span id="code">
 
@@ -22,7 +24,35 @@
 <dropdown text="Right aligned list" type="primary" menu-align-right>
   <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
 </dropdown>
+```
+</span>
+<span id="output">
 
+<dropdown text="Action" type="primary">
+  <li><a href="#dropdown" class="dropdown-item">Action</a></li>
+  <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
+  <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
+  <li role="separator" class="dropdown-divider"></li>
+  <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
+</dropdown>
+
+<dropdown type="info">
+  <button slot="before" type="button" class="btn btn-info">Segmented</button>
+  <li><a href="#dropdown" class="dropdown-item">...</a></li>
+</dropdown>
+
+<dropdown text="Right aligned list" type="primary" menu-align-right>
+  <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
+</dropdown>
+</span>
+</include>
+
+**You can also use Dropdowns as a nested component (e.g. part of a button group).**
+
+<include src="outputBox.md" boilerplate >
+<span id="code">
+
+```html
 <!-- In a button group -->
 <div class="btn-group d-flex" role="group">
   <a href="#dropdown" class="btn btn-danger w-100" role="button">Left</a>
@@ -46,65 +76,23 @@
 </span>
 <span id="output">
 
-<dropdown>
-      <button slot="button" type="button" class="btn btn-secondary dropdown-toggle">
-        Action
-        <span class="caret"></span>
-      </button>
-      <ul slot="dropdown-menu" class="dropdown-menu">
-        <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-        <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
-        <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-        <li role="separator" class="dropdown-divider"></li>
-        <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-      </ul>
-    </dropdown>
-    <dropdown text="Action" type="primary">
+<div class="btn-group d-flex" role="group">
+  <a href="#dropdown" class="btn btn-danger w-100" role="button">Left</a>
+  <dropdown class="w-100">
+    <button slot="button" type="button" class="btn btn-warning dropdown-toggle w-100">
+      Action
+      <span class="caret"></span>
+    </button>
+    <ul slot="dropdown-menu" class="dropdown-menu">
       <li><a href="#dropdown" class="dropdown-item">Action</a></li>
       <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
       <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
       <li role="separator" class="dropdown-divider"></li>
       <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-    </dropdown>
-    <dropdown>
-      <button slot="button" type="button" class="btn btn-success dropdown-toggle">
-        Action <span class="caret"></span>
-      </button>
-      <ul slot="dropdown-menu" class="dropdown-menu">
-        <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-        <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
-        <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-        <li role="separator" class="dropdown-divider"></li>
-        <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-      </ul>
-    </dropdown>
-    <dropdown text="Disabled" type="warning" disabled>
-      <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-    </dropdown>
-    <dropdown type="info">
-      <button slot="before" type="button" class="btn btn-info">Segmented</button>
-      <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-    </dropdown>
-    <dropdown text="Right aligned list" type="primary" menu-align-right>
-      <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-    </dropdown>
-    <div><br></div>
-    <div class="btn-group d-flex" role="group">
-      <a href="#dropdown" class="btn btn-danger w-100" role="button">Left</a>
-      <dropdown class="w-100">
-        <a slot="button" href="#dropdown" class="btn btn-warning dropdown-toggle w-100">
-          Dropdown <span class="caret"></span>
-        </a>
-        <ul slot="dropdown-menu" class="dropdown-menu">
-          <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-          <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
-          <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-          <li role="separator" class="dropdown-divider"></li>
-          <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-        </ul>
-      </dropdown>
-      <a href="#dropdown" class="btn btn-success w-100" role="button">Right</a>
-    </div>
+    </ul>
+  </dropdown>
+  <a href="#dropdown" class="btn btn-success w-100" role="button">Right</a>
+</div>
 </span>
 </include>
 

--- a/src/Page.js
+++ b/src/Page.js
@@ -755,9 +755,11 @@ Page.prototype.insertTemporaryStyles = function (pageData) {
   // inject temporary dropdown styles
   $('dropdown').each((i, element) => {
     const attributes = element.attribs;
-    const placeholder = `<span class=${attributes.class}>${attributes.text}</span>`;
+    const placeholder = `<div>${attributes.text || ''}</div>`;
     $(element).before(placeholder);
-    $(element).prev().addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
+    $(element).prev()
+      .addClass(attributes.class)
+      .addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
     $(element).addClass(TEMP_DROPDOWN_CLASS);
   });
   return $.html();

--- a/test/functional/test_site/expected/markbind/js/setup.js
+++ b/test/functional/test_site/expected/markbind/js/setup.js
@@ -59,11 +59,14 @@ function removeTemporaryStyles() {
   jQuery('.temp-dropdown-placeholder').remove();
 }
 
+function executeAfterCreatedRoutines() {
+  removeTemporaryStyles();
+}
+
 function executeAfterMountedRoutines() {
   flattenModals();
   scrollToUrlAnchorHeading();
   setupAnchors();
-  removeTemporaryStyles();
   MarkBind.executeAfterSetupScripts.resolve();
 }
 
@@ -100,6 +103,9 @@ function setup() {
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
+    created() {
+      executeAfterCreatedRoutines();
+    },
     mounted() {
       executeAfterMountedRoutines();
     },
@@ -127,6 +133,9 @@ function setupWithSearch() {
         const anchor = match.heading ? `#${match.heading.id}` : '';
         window.location = `${page}${anchor}`;
       },
+    },
+    created() {
+      executeAfterCreatedRoutines();
     },
     mounted() {
       executeAfterMountedRoutines();

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -178,6 +178,16 @@
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
       "src": "testLayoutsOverride.md"
+    },
+    {
+      "headings": {
+        "test-dropdown-in-body-with-text-and-class-attributes": "Test dropdown in body with text and class attributes",
+        "test-dropdown-in-body-without-text-and-class-attributes": "Test dropdown in body without text and class attributes",
+        "filler-text": "Filler text"
+      },
+      "src": "testAntiFOUCStyles.md",
+      "title": "Hello World",
+      "layout": "default"
     }
   ]
 }

--- a/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="default-head-top">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="generator" content="MarkBind 1.21.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Hello World</title>
+    <link rel="stylesheet" href="markbind/css/bootstrap.min.css">
+    <link rel="stylesheet" href="markbind/css/bootstrap-vue.min.css">
+    <link rel="stylesheet" href="markbind/fontawesome/css/all.min.css" >
+    <link rel="stylesheet" href="markbind/glyphicons/css/bootstrap-glyphicons.min.css" >
+    <link rel="stylesheet" href="markbind/css/github.min.css">
+    <link rel="stylesheet" href="markbind/css/markbind.css">
+    <link rel="stylesheet" href="STYLESHEET_LINK">
+    <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+    
+    
+    <meta name="default-head-bottom">
+    <link rel="icon" href="/test_site/favicon.png">
+</head>
+<body>
+<div id="app">
+    <div id="content-wrapper">
+
+  <navbar placement="top" type="inverse" class="temp-navbar">
+    <li><a href="/" class="nav-link">One</a></li>
+    <li><a href="/" class="nav-link">Two</a></li>
+    <div class="nav-link temp-dropdown-placeholder">Dropdown</div>
+    <dropdown text="Dropdown" class="nav-link temp-dropdown">
+      <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+      <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+    </dropdown>
+  </navbar>
+
+  <h1 id="test-dropdown-in-body-with-text-and-class-attributes">Test dropdown in body with text and class attributes<a class="fa fa-anchor" href="#test-dropdown-in-body-with-text-and-class-attributes"></a></h1>
+  <div class="test-class temp-dropdown-placeholder">Test One</div>
+  <dropdown text="Test One" class="test-class temp-dropdown">
+    <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+    <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+  </dropdown>
+
+  <h1 id="test-dropdown-in-body-without-text-and-class-attributes">Test dropdown in body without text and class attributes<a class="fa fa-anchor" href="#test-dropdown-in-body-without-text-and-class-attributes"></a></h1>
+  <div class="temp-dropdown-placeholder"></div>
+  <dropdown class="temp-dropdown">
+    <button slot="button" type="button" class="btn dropdown-toggle">
+    Test Two
+    <span class="caret"></span></button>
+    <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+    <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+  </dropdown>
+
+  <h1 id="filler-text">Filler text<a class="fa fa-anchor" href="#filler-text"></a></h1>
+  <p><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br></p>
+  <p>Some text</p>
+</div>
+<div id="flex-div"></div>
+<footer>
+  <div class="text-center">
+    Default footer
+  </div>
+</footer>
+</div>
+</body>
+<script src="markbind/js/vue.min.js"></script>
+<script src="markbind/js/vue-strap.min.js"></script>
+<script src="markbind/js/bootstrap-utility.min.js"></script>
+<script src="markbind/js/polyfill.min.js"></script>
+<script src="markbind/js/bootstrap-vue.min.js"></script>
+<script>
+    const baseUrl = '/test_site'
+    const enableSearch = true
+</script>
+<script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
+<script>alert("hello")</script>
+<script src="markbind/layouts/default/scripts.js"></script>
+</html>

--- a/test/functional/test_site/site.json
+++ b/test/functional/test_site/site.json
@@ -39,6 +39,10 @@
     },
     {
       "glob" : "**/test_md_fragment.md"
+    },
+    {
+      "src": "testAntiFOUCStyles.md",
+      "title": "Hello World"
     }
   ],
   "ignore": [

--- a/test/functional/test_site/testAntiFOUCStyles.md
+++ b/test/functional/test_site/testAntiFOUCStyles.md
@@ -1,0 +1,39 @@
+<!-- Anti-FOUC styles should be applied to navbar and dropdown in navbar. -->
+
+<navbar placement="top" type="inverse">
+  <li><a href="/" class="nav-link">One</a></li>
+  <li><a href="/" class="nav-link">Two</a></li>
+  <dropdown text="Dropdown" class="nav-link">
+    <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+    <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+  </dropdown>
+</navbar>
+
+<!-- Anti-FOUC styles should be applied to dropdown. -->
+# Test dropdown in body with text and class attributes
+
+<dropdown text="Test One" class="test-class">
+  <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+  <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+</dropdown>
+
+<!-- Anti-FOUC styles should be correctly applied to dropdown with no text or class. -->
+
+# Test dropdown in body without text and class attributes
+
+<dropdown>
+  <button slot="button" type="button" class="btn dropdown-toggle">
+    Test Two
+    <span class="caret"></span>
+  </button>
+  <li><a class="dropdown-item" href="/">Dropdown One</a></li>
+  <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
+</dropdown>
+
+<!-- Filler text to increase page length. -->
+
+# Filler text
+
+<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
+
+Some text


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #704.

**What is the rationale for this request?**

There were some errors with the dropdown anti-FOUC styles:
- [x] Generation of placeholder span elements for dropdowns produce <span class="undefined temp-dropdown-placeholder">undefined</span> when the dropdown does not have a class and text. 
- [x] Stray `<p>` tags being inserted before the placeholder <span>.
- [x] Anti-FOUC styles not removed upon render for collapsed components.

**What changes did you make? (Give an overview)**

- Handled cases for dropdowns with no class or text attributes
- Changed placeholder element from `span` to `div` to avoid `markdown-it` recognising it as a new paragraph
- Remove anti-FOUC style earlier in the Vue lifecycle (from `mounted` to `created`) so that temporary styles are removed before any other manipulation to the DOM.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->

Given Input:
```html
<dropdown></dropdown>
```

Previously:
```html
<span class="undefined temp-dropdown-placeholder">undefined</span>
<dropdown class="temp-dropdown"></dropdown>
```

Now:
```html
<div class="temp-dropdown-placeholder"></div>
<dropdown class="temp-dropdown"></dropdown>
```

**Testing instructions:**
- Dropdown-related pages on netlify preview should be correct: [#1](https://deploy-preview-760--markbind-master.netlify.com/userguide/usingcomponents#dropdowns) [#2](https://deploy-preview-760--markbind-master.netlify.com/userguide/fullsyntaxreference#dropdowns) [#3](https://deploy-preview-760--markbind-master.netlify.com/userguide/readerfacingfeatures#dropdowns)
- Inspecting the HTML output generated for `<dropdowns>` should reflect the above changes. Sample page: `usingComponents.html`

Thanks again to @Xenonym for identifying the issue.