### PR TITLE
Fix incorrect regex for matching icon syntax

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it/markdown-it-icons.js
+++ b/src/lib/markbind/src/lib/markdown-it/markdown-it-icons.js
@@ -1,5 +1,5 @@
 module.exports = require('markdown-it-regexp')(
-    /:(fa[brs]|glyphicon)-([a-z-]+):/m,
+    /:(fa[brs]|glyphicon)-([a-z-]+):/,
     (match, utils) => {
         let iconFontType = match[1];
         let iconFontName = match[2];

--- a/test/unit/markdown-it-icons.test.js
+++ b/test/unit/markdown-it-icons.test.js
@@ -1,0 +1,35 @@
+const markdownIt = require('markdown-it')()
+  .use(require('../../src/lib/markbind/src/lib/markdown-it/markdown-it-icons'));
+
+test('markdown-it-icons renders icon syntax correctly', () => {
+  const source = ':fab-font-awesome: :glyphicon-home:';
+
+  const result = markdownIt.renderInline(source);
+  const expected = [
+    '<span aria-hidden="true" class="fab fa-font-awesome"></span>',
+    '<span aria-hidden="true" class="glyphicon glyphicon-home"></span>',
+  ].join(' ');
+
+  expect(result).toEqual(expected);
+});
+
+test('markdown-it-icons renders icon syntax in multi-line source correctly', () => {
+  const source = [
+    'text with special characters: before icons',
+    ':fab-font-awesome:',
+    'text with special characters: between icons',
+    ':glyphicon-home:',
+    'text with special characters: after icons',
+  ].join('\n');
+
+  const result = markdownIt.renderInline(source);
+  const expected = [
+    'text with special characters: before icons',
+    '<span aria-hidden="true" class="fab fa-font-awesome"></span>',
+    'text with special characters: between icons',
+    '<span aria-hidden="true" class="glyphicon glyphicon-home"></span>',
+    'text with special characters: after icons',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #764.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The current regex for matching icon syntax has the `m` multi-line flag turned on, which causes unexpected results in Markdown with special characters.

**What changes did you make? (Give an overview)**
Remove the `m` flag.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
In `variables.md`:
```html
<variable name="cs3281_time">MON 1200 - 1400</variable>
<variable name="icon_dislike">:fas-thumbs-down:</variable>
```

In a MarkBind page:
```md
{{ cs3281_time }}<br>
{{ icon_dislike }}<br>
```

**Testing instructions:**
The above sample code should render correctly:
<img height=50 src="https://user-images.githubusercontent.com/1782590/54185612-6e94f980-44e4-11e9-946d-e671dc8d9fde.png">

