### PR TITLE
Allow inclusion/exclusion of headings for indexing

### DIFF
--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -37,6 +37,7 @@ If you do not wish to use MarkBind's searchbar (e.g. you have an external servic
 
 <include src="syntax/searchBars.mbdf" />
 <include src="syntax/keywords.mbdf" />
+<include src="syntax/indexing.mbdf" />
 
 {% from "njk/common.njk" import previous_next %}
 {{ previous_next('reusingContents', 'deployingTheSite') }}

--- a/docs/userGuide/syntax/indexing.mbdf
+++ b/docs/userGuide/syntax/indexing.mbdf
@@ -1,0 +1,16 @@
+## Including or Excluding Headings
+
+**You can specify headings which are to be included or excluded from the index built by MarkBind's built-in search feature** using the `.always-index` or `.no-index` attributes.
+
+If you wish to index a specific heading outside the specified `headingIndexLevel`, you may add the `.always-index` attribute to the heading. Similarly, if you wish for a specific heading inside the specified `headingIndexLevel` not to be indexed, you may add the `.no-index` attribute to the heading.
+
+<div class="indented">
+
+{{ icon_example }}
+
+```md
+###### Heading outside heading index level that will be indexed {.always-index}
+
+# Heading inside heading index level that will not be indexed {.no-index}
+```
+</div>

--- a/src/Page.js
+++ b/src/Page.js
@@ -205,15 +205,17 @@ function formatSiteNav(renderedSiteNav, src) {
 }
 
 /**
- * Generates a heading selector based on the indexing level
+ * Generates a selector for headings with level inside the headingIndexLevel
+ * or with the index attribute, that do not also have the noindex attribute
  * @param headingIndexingLevel to generate
  */
 function generateHeadingSelector(headingIndexingLevel) {
-  let headingsSelector = 'h1';
+  let headingsSelectors = ['.always-index:header', 'h1'];
   for (let i = 2; i <= headingIndexingLevel; i += 1) {
-    headingsSelector += `, h${i}`;
+    headingsSelectors.push(`h${i}`);
   }
-  return headingsSelector;
+  headingsSelectors = headingsSelectors.map(selector => `${selector}:not(.no-index)`);
+  return headingsSelectors.join(',');
 }
 
 function unique(array) {

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -147,6 +147,10 @@
     </nav>
     <a class="nav-link py-1" href="#test-plugin-in-markbind-plugins">Test plugin in markbind/plugins&#x200E;</a>
     <a class="nav-link py-1" href="#markbind-plugin-pre-render">Markbind Plugin Pre-render&#x200E;</a>
+    <a class="nav-link py-1" href="#test-search-indexing">Test search indexing&#x200E;</a>
+    <nav class="nav nav-pills flex-column my-0" style="margin-left: 5%; flex-wrap: nowrap;">
+      <a class="nav-link py-1" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed&#x200E;</a>
+    </nav>
 
   </nav>
 </nav>
@@ -557,6 +561,9 @@ specification that specifies how the product will address the requirements. </sp
           <h1 id="markbind-plugin-pre-render">Markbind Plugin Pre-render<a class="fa fa-anchor" href="#markbind-plugin-pre-render"></a></h1>
           <p>Node Modules Plugin Post-render</p>
         </div>
+        <h1 id="test-search-indexing">Test search indexing<a class="fa fa-anchor" href="#test-search-indexing"></a></h1>
+        <h2 class="no-index" id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed">Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed</h2>
+        <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed<a class="fa fa-anchor" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed"></a></h6>
       </div>
     </div>
   </div>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -104,7 +104,9 @@
         "modal-with-panel-inside": "Modal with panel inside",
         "unexpanded-panel": "Unexpanded panel",
         "test-plugin-in-markbind-plugins": "Test plugin in markbind/plugins",
-        "markbind-plugin-pre-render": "Markbind Plugin Pre-render"
+        "markbind-plugin-pre-render": "Markbind Plugin Pre-render",
+        "test-search-indexing": "Test search indexing",
+        "level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed": "Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed"
       },
       "title": "Hello World",
       "footer": "footer.md",

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -219,3 +219,9 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 <div id="test-markbind-plugin">
   Markbind Plugin Pre-render Placeholder
 </div>
+
+# Test search indexing
+
+## Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed {.no-index}
+
+###### Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed {.always-index}


### PR DESCRIPTION


**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes #737.

**What is the rationale for this request?**

When using the built-in markbind search, users are able to set the heading level to be indexed. We want to users to be able to specify that certain headings should be indexed or not be indexed regardless of the heading index level.

To support this, we allow users to add the `{.index}` or `{.noindex}` attributes to headings to indicate that the heading should either be indexed or not be indexed.

**What changes did you make? (Give an overview)**

Update heading selectors to include any heading with the `index` class, and exclude any heading with the `noindex` class.

**Provide some example code that this change will affect:**

```md
###### This will always be indexed {.index}

# This will never be indexed {.noindex}

```

**Testing instructions:**

See related headings in the test site.