### PR TITLE
docs/variables.md: fix font-awesome typo

### DIFF
--- a/docs/_markbind/variables.md
+++ b/docs/_markbind/variables.md
@@ -9,7 +9,7 @@
 <variable name="icon_arrow_down">:fas-arrow-down:</variable>
 <variable name="icon_arrow_right">:fas-arrow-right:</variable>
 <variable name="icon_check_blue"><span style="color: {{ markbind_blue }}">:fas-check-circle:</span></variable>
-<variable name="icon_bulb_blue"><span style="color: {{ markbind_blue }}">:fas-lightbulb</span></variable>
+<variable name="icon_bulb_blue"><span style="color: {{ markbind_blue }}">:fas-lightbulb:</span></variable>
 <variable name="icon_dislike">:fas-thumbs-down:</variable>
 <variable name="icon_example"><big><span class='badge badge-pill badge-light' style="background-color: #d9d9d9; color: #737373; position:relative; left:-10px">Example:</span></big></variable>
 <variable name="icon_examples"><big><span class='badge badge-pill badge-light' style="background-color: #d9d9d9; color: #737373; position:relative; left:-10px">Examples:</span></big></variable>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Typo in https://github.com/MarkBind/markbind/pull/696/files#diff-7c74a6f69e3deb70d98d690a2e89a0c1R12

<img width="802" alt="Screenshot 2019-03-14 at 4 36 43 PM" src="https://user-images.githubusercontent.com/9073504/54342441-6ae5ac00-4677-11e9-87d9-e059378409b1.png">


**What changes did you make? (Give an overview)**
Corrected the typo

**Testing instructions:**
Build locally and see that the lightbulb icon shows up correctly after the change