### PR TITLE
Fix tagging documentation under plugins

### DIFF
--- a/docs/userGuide/plugins/filterTags.mbdf
+++ b/docs/userGuide/plugins/filterTags.mbdf
@@ -15,12 +15,19 @@ Tags are specified by the `tags` attribute, **and can be attached to any HTML el
 <p tags="language--python">print("Hello world")</p>
 ```
 
-You need to specify the tags to include in `site.json`, under the `tags` option:
+You need to specify the tags to include in the `pluginsContext`, under `tags`:
 
 ```json
 {
   ...
-  "tags": ["language--java"]
+  "plugins" : [
+    "filterTags"
+  ],
+  "pluginsContext" : {
+    "filterTags" : {
+      "tags": ["language--java"]
+    }
+  }
 }
 ```
 
@@ -28,7 +35,7 @@ All other tagged elements will be filtered out. In this case, only the element w
 
 </div>
 
-If the `tags` option is not specified in `site.json`, all tagged elements will be rendered.
+If the `filterTags` plugin is not enabled in `site.json`, all tagged elements will be rendered.
 
 **You can also use multiple tags in a single HTML element. Specify each tag in the `tags` attribute** separated by a space. An element will be rendered if **any of the tags** matches the one in `site.json`.
 
@@ -121,7 +128,14 @@ site.json
 
 {
   ...
-  "tags": ["-language--*", "language--C#"]
+  "plugins" : [
+    "filterTags"
+  ],
+  "pluginsContext" : {
+    "filterTags" : {
+      "tags": ["-language--*", "language--C#"]
+    }
+  }
 }
 ```
 

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -50,7 +50,14 @@ Here is a typical `site.json` file:
     "*.mbd",
     ".git/*"
   ],
-  "tags": ["tag1", "tag2"],
+  "plugins" : [
+    "filterTags"
+  ],
+  "pluginsContext" : {
+    "filterTags" : {
+      "tags": ["tag1", "tag2"]
+    }
+  },
   "headingIndexingLevel": 4
 }
 ```
@@ -164,9 +171,11 @@ The ignore pattern follows the [glob pattern used in .gitignore](https://git-scm
   The branch that will be deployed to in the remote repo.
 </div>
 
-#### **`tags`**
+#### **`plugins`**,  **`pluginsContext`**
 
-**A list of tags to filter page elements.**  Page elements with the specified tags are retained, while elements tagged with other tags are removed. Do not specify this option if you want to show everything. See [_User Guide: Tweaking the Page Structure → Using Tags_](tweakingThePageStructure.html#using-tags) section for more information.
+**A list of plugins to load.** Plugins are user-defined extensions that can add custom features to MarkBind. `pluginsContext` contains settings to be applied to the loaded plugins. See [User Guide: Using Plugins](usingPlugins.html) for more details.
+
+The example above uses tags as an example of configuring plugin settings, refer to the [`filterTags` plugin](tweakingThePageStructure.html#filtertags-toggling-alternative-contents-in-a-page) for more details.
 
 #### **`headingIndexingLevel`**
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Somehow during the documentation restructuring the filterTags documentation was changed to the older, incorrect one (#474). It should be the one from #689.

**What changes did you make? (Give an overview)**

Replaced it with the newer one (#689)