### PR TITLE
Use Sets instead of Dictionaries for Page.includedFiles

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -89,7 +89,7 @@ function Page(pageConfig) {
   this.headFileTopContent = '';
   this.headings = {};
   this.headingIndexingLevel = pageConfig.headingIndexingLevel;
-  this.includedFiles = {};
+  this.includedFiles = new Set();
   this.keywords = {};
   this.navigableHeadings = {};
 }
@@ -484,7 +484,7 @@ Page.prototype.addAnchors = function (content) {
  */
 Page.prototype.collectIncludedFiles = function (dependencies) {
   dependencies.forEach((dependency) => {
-    this.includedFiles[dependency.to] = true;
+    this.includedFiles.add(dependency.to);
   });
 };
 
@@ -552,7 +552,7 @@ Page.prototype.insertFooter = function (pageData) {
   // Retrieve Markdown file contents
   const footerContent = fs.readFileSync(footerPath, 'utf8');
   // Set footer file as an includedFile
-  this.includedFiles[footerPath] = true;
+  this.includedFiles.add(footerPath);
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -582,7 +582,7 @@ Page.prototype.insertSiteNav = function (pageData) {
     return pageData;
   }
   // Set siteNav file as an includedFile
-  this.includedFiles[siteNavPath] = true;
+  this.includedFiles.add(siteNavPath);
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -723,7 +723,7 @@ Page.prototype.collectHeadFiles = function (baseUrl, hostBaseUrl) {
     }
     const headFileContent = fs.readFileSync(headFilePath, 'utf8');
     // Set head file as an includedFile
-    this.includedFiles[headFilePath] = true;
+    this.includedFiles.add(headFilePath);
     // Map variables
     const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
     const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -762,8 +762,8 @@ Page.prototype.insertTemporaryStyles = function (pageData) {
 };
 
 Page.prototype.generate = function (builtFiles) {
-  this.includedFiles = {};
-  this.includedFiles[this.sourcePath] = true;
+  this.includedFiles = new Set();
+  this.includedFiles.add(this.sourcePath);
 
   const markbinder = new MarkBind({
     errorHandler: logger.error,

--- a/src/Site.js
+++ b/src/Site.js
@@ -773,7 +773,7 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
   }
   this._setTimestampVariable();
   this.pages.forEach((page) => {
-    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
+    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
       // eslint-disable-next-line no-param-reassign
       page.userDefinedVariablesMap = this.userDefinedVariablesMap;
       processingFiles.push(page.generate(builtFiles)
@@ -805,7 +805,7 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
 Site.prototype.updateSiteData = function (filePaths) {
   const generateForAllPages = filePaths === undefined;
   this.pages.forEach((page) => {
-    if (generateForAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
+    if (generateForAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
       page.collectHeadingsAndKeywords();
       page.concatenateHeadingsAndKeywords();
     }

--- a/test/unit/Page.test.js
+++ b/test/unit/Page.test.js
@@ -4,19 +4,19 @@ test('Page#collectIncludedFiles collects included files from 1 dependency object
   const page = new Page({});
   page.collectIncludedFiles([{ to: 'somewhere' }]);
 
-  expect(page.includedFiles).toEqual({ somewhere: true });
+  expect(page.includedFiles).toEqual(new Set().add('somewhere'));
 });
 
 test('Page#collectIncludedFiles ignores other keys in dependency', () => {
   const page = new Page({});
   page.collectIncludedFiles([{ to: 'somewhere', from: 'somewhere else' }]);
 
-  expect(page.includedFiles).toEqual({ somewhere: true });
+  expect(page.includedFiles).toEqual(new Set().add('somewhere'));
 });
 
 test('Page#collectIncludedFiles collects nothing', () => {
   const page = new Page({});
   page.collectIncludedFiles([]);
 
-  expect(page.includedFiles).toEqual({});
+  expect(page.includedFiles).toEqual(new Set());
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: Coding style "fix"

Resolves #772 

**What is the rationale for this request?**
We use includedFiles to check what pages we need to rebuild when a page is updated. When a file is included, we do something similar to `this.includedFiles[dependency.to] = true;`. includedFiles is essentially a dictionary containing all {file: true} values.

Let's use the ES6 Set data structure to store this information. 

**What changes did you make? (Give an overview)**
Use ES6 Set data structure instead of a dictionary.
This allows us to use `page.includedFiles.has(filePath)` when checking for existence, which is semantically clearer (it clearly returns a boolean) as compared to `page.includedFiles[filePath]`.

**Is there anything you'd like reviewers to focus on?**
Hmm... Hopefully nothing breaks? 😓 

**Testing instructions:**
