### PR TITLE
Parser: Fix crash if no href given to anchor or link tag

### DIFF
--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -389,7 +389,7 @@ Parser.prototype._preprocess = function (node, context, config) {
         element.attribs.src = utils.ensurePosix(resultPath);
       }
     } else if (['a', 'link'].includes(element.name)) {
-      if (!isUrl && !isAbsolutePath) {
+      if (!isUrl && !isAbsolutePath && hasHref) {
         const resultPath = path.join('{{hostBaseUrl}}', path.relative(config.rootPath, filePath));
         element.attribs.href = utils.ensurePosix(resultPath);
       }

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -471,8 +471,11 @@ specification that specifies how the product will address the requirements. </sp
               <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
               <pic src="https://dummyimage.com/600x400/000/fff"></pic>
             </p>
-            <p>Anchor link:
-              <a href="https://dummyimage.com/600x400/000/fff">External Image</a></p>
+            <p>Anchor:
+              <a href="https://dummyimage.com/600x400/000/fff">External Image</a>
+              <a href="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
+              <a id="namedAnchor">Named Anchor</a>
+              <a>Anchor with no attributes</a></p>
           </div>
           <h1 id="trimmed-include">Trimmed include<a class="fa fa-anchor" href="#trimmed-include"></a></h1>
           <h2 id="fragment-with-leading-spaces-and-newline"><span>Fragment with leading spaces and newline</span><a class="fa fa-anchor" href="#fragment-with-leading-spaces-and-newline"></a></h2>

--- a/test/functional/test_site/expected/sub_site/testReuse._include_.html
+++ b/test/functional/test_site/expected/sub_site/testReuse._include_.html
@@ -14,5 +14,8 @@
   <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
   <pic src="https://dummyimage.com/600x400/000/fff"></pic>
 </p>
-<p>Anchor link:
-  <a href="https://dummyimage.com/600x400/000/fff">External Image</a></p>
+<p>Anchor:
+  <a href="https://dummyimage.com/600x400/000/fff">External Image</a>
+  <a href="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
+  <a id="namedAnchor">Named Anchor</a>
+  <a>Anchor with no attributes</a></p>

--- a/test/functional/test_site/sub_site/testReuse.md
+++ b/test/functional/test_site/sub_site/testReuse.md
@@ -19,5 +19,8 @@ PIC tags:
 <pic src="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png"></pic>
 <pic src="https://dummyimage.com/600x400/000/fff"></pic>
 
-Anchor link:
+Anchor:
 <a href="https://dummyimage.com/600x400/000/fff">External Image</a>
+<a href="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
+<a id="namedAnchor">Named Anchor</a>
+<a>Anchor with no attributes</a>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix
Fixes #779 

**What is the rationale for this request?**
As per #779, markbind crashes if no href is given to an anchor or link tag. This is because Markbind will try to rewrite a non-existent URL.

**What changes did you make? (Give an overview)**
This commit fixes the bug by introducing an extra check for the href attribute. Only if the href attribute is present, do we proceed to rewrite URL to their absolute paths.
I have also included some additional functional tests to protect against regression for this bug.

**Is there anything you'd like reviewers to focus on?**
Are there any more such cases? img and pic are okay because they must contain a src tag. Otherwise markbind will raise an intended error.

**Testing instructions:**
Create a md file containing
```
<a>Some anchor</a>
```
and ensure that markbind does not crash when processing this file.