### PR TITLE
Allow any frontmatter property to be overridden by site.json

### DIFF
--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -106,7 +106,7 @@ _(Optional)_ **The theme for the generated site.** Uses the default Bootstrap th
 * **`layout`**: The [layout](tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.
 * **`externalScripts`**: An array of external scripts to be referenced on the page. Scripts referenced will be run before the layout script.
-* **`frontMatter`**: Specifies properties to add to the front matter of a page or glob of pages. Overrides any existing properties if they have the same name.
+* **`frontMatter`**: Specifies properties to add to the front matter of a page or glob of pages. Overrides any existing properties if they have the same name, and overrides any front matter properties specified in `globalOverride`.
 
 <span id="page-property-overriding">
 <box type="warning">
@@ -161,7 +161,7 @@ The following properties will apply to `index.md`:
 
 #### **`globalOverride`**
 
-**Globally overrides properties in the front matter of all pages.** Any property included in the global override will automatically be merged with the front matter of every single page, and override them if the property exists. Also overrides front matter properties specified in `pages`.
+**Globally overrides properties in the front matter of all pages.** Any property included in the global override will automatically be merged with the front matter of every single page, and override them if the property exists.
 
 #### **`ignore`**
 

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -29,7 +29,10 @@ Here is a typical `site.json` file:
       "searchable": "no",
       "externalScripts": [
         "https://cdn.plot.ly/plotly-latest.min.js"
-      ]
+      ],
+      "frontmatter": {
+        "header": "header.md"
+      }
     },
     {
       "glob": "**/index.md"
@@ -42,6 +45,9 @@ Here is a typical `site.json` file:
     "message": "Site Update.",
     "repo": "https://github.com/myorg/myrepo.git",
     "branch": "gh-pages"
+  },
+  "globalOverride": {
+    "footer": "my-footer.md"
   },
   "ignore": [
     "_site/*",
@@ -100,6 +106,7 @@ _(Optional)_ **The theme for the generated site.** Uses the default Bootstrap th
 * **`layout`**: The [layout](tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.
 * **`externalScripts`**: An array of external scripts to be referenced on the page. Scripts referenced will be run before the layout script.
+* **`frontMatter`**: Specifies properties to add to the front matter of a page or glob of pages. Overrides any existing properties if they have the same name.
 
 <span id="page-property-overriding">
 <box type="warning">
@@ -151,6 +158,10 @@ The following properties will apply to `index.md`:
 #### **`externalScripts`**
 
 **An array of external scripts to be referenced on all pages.** To reference an external script only on specific pages, `externalScripts` should be specified in `pages` instead. Scripts referenced will be run before the layout script.
+
+#### **`globalOverride`**
+
+**Globally overrides properties in the front matter of all pages.** Any property included in the global override will automatically be merged with the front matter of every single page, and override them if the property exists. Also overrides front matter properties specified in `pages`.
 
 #### **`ignore`**
 

--- a/src/Page.js
+++ b/src/Page.js
@@ -56,10 +56,12 @@ function Page(pageConfig) {
   this.baseUrlMap = pageConfig.baseUrlMap;
   this.content = pageConfig.content || '';
   this.faviconUrl = pageConfig.faviconUrl;
+  this.frontmatterOverride = pageConfig.frontmatter || {};
   this.layout = pageConfig.layout;
   this.layoutsAssetPath = pageConfig.layoutsAssetPath;
   this.rootPath = pageConfig.rootPath;
   this.enableSearch = pageConfig.enableSearch;
+  this.globalOverride = pageConfig.globalOverride;
   this.plugins = pageConfig.plugins;
   this.pluginsContext = pageConfig.pluginsContext;
   this.searchable = pageConfig.searchable;
@@ -470,18 +472,24 @@ Page.prototype.collectFrontMatter = function (includedPage) {
     const frontMatterWrapped = `${FRONT_MATTER_FENCE}\n${frontMatterData}\n${FRONT_MATTER_FENCE}`;
     // Parse front matter data
     const parsedData = fm(frontMatterWrapped);
-    this.frontMatter = parsedData.attributes;
+    this.frontMatter = { ...parsedData.attributes };
     this.frontMatter.src = this.src;
     // Title specified in site.json will override title specified in front matter
     this.frontMatter.title = (this.title || this.frontMatter.title || '');
     // Layout specified in site.json will override layout specified in the front matter
     this.frontMatter.layout = (this.layout || this.frontMatter.layout || LAYOUT_DEFAULT_NAME);
+    this.frontMatter = { ...this.frontMatter, ...this.globalOverride, ...this.frontmatterOverride };
   } else {
     // Page is addressable but no front matter specified
-    this.frontMatter = {
+    const defaultAttributes = {
       src: this.src,
       title: this.title || '',
       layout: LAYOUT_DEFAULT_NAME,
+    };
+    this.frontMatter = {
+      ...defaultAttributes,
+      ...this.globalOverride,
+      ...this.frontmatterOverride,
     };
   }
   this.title = this.frontMatter.title;

--- a/src/Site.js
+++ b/src/Site.js
@@ -405,6 +405,8 @@ Site.prototype.createPage = function (config) {
     content: '',
     pluginsContext: this.siteConfig.pluginsContext || {},
     faviconUrl: config.faviconUrl,
+    frontmatter: config.frontmatter,
+    globalOverride: this.siteConfig.globalOverride || {},
     pageTemplate: this.pageTemplate,
     plugins: this.plugins || {},
     rootPath: this.rootPath,
@@ -627,6 +629,7 @@ Site.prototype.collectAddressablePages = function () {
       src: globPath,
       searchable: addressableGlob.searchable,
       layout: addressableGlob.layout,
+      frontmatter: addressableGlob.frontmatter,
     }))), []);
   // Add pages collected by walkSync and merge properties for pages
   const filteredPages = {};
@@ -981,6 +984,7 @@ Site.prototype.generatePages = function () {
       pageSrc: page.src,
       title: page.title,
       layout: page.layout,
+      frontmatter: page.frontmatter,
       searchable: page.searchable !== 'no',
       externalScripts: page.externalScripts,
     }));
@@ -990,6 +994,7 @@ Site.prototype.generatePages = function () {
       pageSrc: page.src,
       title: page.title,
       layout: page.layout,
+      frontmatter: page.frontmatter,
       searchable: page.searchable !== 'no',
       externalScripts: page.externalScripts,
     }));

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -10,7 +10,9 @@
       "title": "Open Bugs",
       "header": "header.md",
       "src": "bugs/index.md",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {
@@ -118,6 +120,9 @@
       "siteNav": "site-nav.md",
       "pageNav": "default",
       "pageNavTitle": "Testing Page Navigation",
+      "globalOverrideProperty": "Overridden by global override",
+      "frontMatterOverrideProperty": "Overridden by front matter override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by front matter override",
       "head": "myCustomHead.md, myCustomHead2.md",
       "tags": [
         "tag-frontmatter-shown",
@@ -136,7 +141,9 @@
       },
       "src": "sub_site/index.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {
@@ -144,25 +151,33 @@
       },
       "src": "test_md_fragment.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {},
       "layout": "testAfterSetup",
       "src": "testAfterSetup.md",
-      "title": "Hello World"
+      "title": "Hello World",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {},
       "src": "testEmptyFrontmatter.md",
       "title": "Hello World",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {},
       "src": "testExternalScripts.md",
       "title": "Hello World",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {
@@ -171,7 +186,9 @@
       "title": "Hello World",
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
-      "src": "testLayouts.md"
+      "src": "testLayouts.md",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {
@@ -180,7 +197,9 @@
       "title": "Hello World",
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
-      "src": "testLayoutsOverride.md"
+      "src": "testLayoutsOverride.md",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     },
     {
       "headings": {
@@ -190,7 +209,9 @@
       },
       "src": "testAntiFOUCStyles.md",
       "title": "Hello World",
-      "layout": "default"
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     }
   ]
 }

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -5,6 +5,9 @@ footer: footer.md
 siteNav: site-nav.md
 pageNav: "default"
 pageNavTitle: "Testing Page Navigation"
+globalOverrideProperty: "To be overridden by global override"
+frontMatterOverrideProperty: "To be overridden by frontmatter override"
+globalAndFrontMatterOverrideProperty: "To be overridden by frontmatter and global override"
 head: myCustomHead.md, myCustomHead2.md
 tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidden", "-tag-site-override-shown", "-tag-site-override-specific*"]
 </frontmatter>

--- a/test/functional/test_site/site.json
+++ b/test/functional/test_site/site.json
@@ -5,7 +5,11 @@
   "pages": [
     {
       "src": "index.md",
-      "title": "Hello World"
+      "title": "Hello World",
+      "frontmatter": {
+        "frontMatterOverrideProperty": "Overridden by front matter override",
+        "globalAndFrontMatterOverrideProperty":  "Overridden by front matter override"
+      }
     },
     {
       "src": "testAfterSetup.md",
@@ -58,6 +62,10 @@
   ],
   "deploy": {
     "message": "Site Update."
+  },
+  "globalOverride": {
+    "globalOverrideProperty": "Overridden by global override",
+    "globalAndFrontMatterOverrideProperty": "Overridden by global override"
   },
   "headingIndexingLevel": 4,
   "plugins": [


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #647 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

We want to be able to globally override all frontmatter properties in a page

**What changes did you make? (Give an overview)**

Allow any property in the frontmatter to be overriden by `globalOverride` if specified in the site.json,

```
{
  "globalOverride": {
      "arbitraryProperty": "..."
  }
}
```

**Proposed commit message:**
```
Allow any frontmatter property to be overridden by site.json

Some front matter properties can be overridden by site.json, but not 
all.

Let's allow any front matter property to be overriden by specifying 
them at the site.json level. Additionally, let's allow the user to 
define global front matter properties that will be applied to all 
pages.
```