### PR TITLE
docs: Migrate developer docs to MarkBind's website

### DIFF
--- a/docs/_markbind/headers/header.md
+++ b/docs/_markbind/headers/header.md
@@ -3,9 +3,10 @@
   <navbar type="inverse">
     <a slot="brand" href="../index.html" title="Home" class="navbar-brand"><img src="../images/logo-darkbackground.png" height="20" /></a>
     <li><a href="../index.html" class="nav-link">HOME</a></li>
-    <li><a href="../userGuide/index.html" class="nav-link">DOCS</a></li>
+    <li><a href="../userGuide/index.html" class="nav-link">USER GUIDE</a></li>
     <li><a href="../showcase.html" class="nav-link">SHOWCASE</a></li>
     <li><a href="../about.html" class="nav-link">ABOUT</a></li>
+    <li><a href="../devGuide/index.html" class="nav-link">DEVELOPER GUIDE</a></li>
     <li>
       <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link"><md>:fab-github:</md></a>
     </li>

--- a/docs/_markbind/navigation/devGuideSections.md
+++ b/docs/_markbind/navigation/devGuideSections.md
@@ -1,0 +1,7 @@
+<navigation>
+
+<span class="indented lead">**Developer Guide**</span>
+
+* [Developer Guide]({{baseUrl}}/devGuide/devGuide.html)
+* [Maintainer Guide]({{baseUrl}}/devGuide/maintainerGuide.html)
+</navigation>

--- a/docs/devGuide/devGuide.md
+++ b/docs/devGuide/devGuide.md
@@ -1,0 +1,190 @@
+<frontmatter>
+  title: "Developer Guide"
+  header: header.md
+  footer: footer.md
+  pageNav: default
+  siteNav: devGuideSections.md
+</frontmatter>
+
+## Requirement
+
+We expect contributors for MarkBind to have basic knowledge of the following:
+
+* JavaScript (ES6)
+* Node.js (LTS or higher) [with npm version of 5.8.0]
+* HTML & CSS
+* Markdown
+* Command-line environment
+
+## Environment
+
+The MarkBind project should be developed with Node.js version 8.0 or higher.
+
+We recommend you to use WebStorm for a better development experience.
+
+Use JavaScript ES6 features if possible for better performance, e.g. Promise instead of callback.
+
+## Project Structure
+
+MarkBind project consists of two repos:
+
+* [MarkBind](https://github.com/MarkBind/markbind)
+
+  * The command-line interface (CLI) application that accepts commands from users, and uses the core library to parse and generate web pages resides in the root.
+
+  * The core library that resolves the content include path, and the rendering of Markdown contents resides in the `lib/markbind/` directory.
+
+  Stack used: *Node.js*
+
+* [VueStrap library (forked version modified for MarkBind)](https://github.com/MarkBind/vue-strap)
+
+  * The UI components library used in MarkBind project. Users could use it in their contents to create complex and interactive structure.
+
+  Stack used: *Vue.js*
+
+### MarkBind Core Library
+
+The core library parses the given Markdown file, processes all the content include, and renders all Markdown into HTML so that it could be displayed in a browser.
+
+All the core logic resides inside the `lib/parser.js` file. It exposes two important APIs: **include** and **render**.
+
+*Include* and *Render* will first parse the given file as a DOM tree, and then recursively visit every node to check if it needs special handling.
+
+In the *Include* stage, it will check if the node will include new contents (for example, if it is an "include" tag (`<include />`), and then load the file/content to be included into the current working context. For the new content included, the *Include* step will be run recursively until all the content to be included are resolved and loaded.
+
+*Render* is a similar process to *Include*, but it will render the content recursively to ensure all Markdown are converted to HTML.
+
+MarkBind uses [markdown-it](https://github.com/markdown-it/markdown-it) to do the Markdown parsing and rendering. There are also several customized markdown-it plugins used in MarkBind, which are located inside the `lib/markdown-it/` directory.
+
+### MarkBind CLI
+
+The CLI application handles the site generation logic. It contains the command handling logic, as well as the Site and Page models.
+
+The site generation logic is as follows:
+
+1. Read the project's `site.json` file to collect all pages that will be generated.
+2. Create a Site model, where the site's root path is where `site.json` is located. The site model knows all the pages it contains, as well as the static assets. Static assets, such as stylesheets and JavaScript libraries, will be scanned and filtered, and then copied to the generated site folder (`_site/`).
+3. The Site model will create different Page models, and each Page model will generate a HTML page at the designated file location by calling MarkBind core library's *include* and *render* APIs.
+
+The generated page is rendered using [EJS](https://github.com/mde/ejs) and [nunjucks](https://mozilla.github.io/nunjucks/), and the page template could be found at `lib/template/page.ejs`.
+
+Static assets of MarkBind, such as stylesheets and JavaScript libraries, are located in `asset/` folder. They will be copied to the generated site and used in the generated pages. For each version update of VueStrap, copy the built library file to overwrite `asset/js/vue-strap.min.js`.
+
+The CLI program is built using [commander.js](https://github.com/tj/commander.js/).
+
+The auto deployment library used is [gh-pages](https://github.com/tschaub/gh-pages).
+
+### VueStrap
+
+The VueStrap library is [Bootstrap](getbootstrap.com/components/) components rewritten in [Vue.js](vuejs.org). We forked it from the original repo, and changed it based on our needs for educational websites.
+
+You can find more information at the [VueStrap repo](https://github.com/MarkBind/vue-strap).
+
+## Development Process
+
+### Development
+
+1. Fork and clone the MarkBind repo.
+
+2. In the folder of your cloned repo, run
+
+	```
+	$ npm install
+	```
+
+  to install the project dependencies.
+
+3. To make sure you are using the cloned CLI program in your own terminal/console, in the cloned CLI repo, run
+
+	```
+	$ npm link
+	```
+
+  to bind the local MarkBind CLI program to the cloned development version.
+
+4. Now you can start making changes.
+
+#### Troubleshooting
+
+**Q: When I build a MarkBind website, I get strange errors relating to HTML tags in .md/.mbd files. For example:**
+
+```
+TypeError: Cannot set property 'src' of null
+    at Page.collectFrontMatter (~\markbind\src\Page.js:399:26)
+```
+
+A: If your npm version is v6.0.0 or higher, there is a change in behaviour on how npm install dependencies (see https://github.com/MarkBind/markbind/issues/582). To resolve this issue, discard the changes made by npm in `package-lock.json`, and redo `npm install`.
+
+### Testing
+
+Our test script does the following:
+
+1. Lints the code for any code and style errors using ESLint.
+1. Builds the test site found in `test/test_site/`.
+1. Compares the HTML files generated with the HTML files in `test/test_site/expected/`.
+
+#### Running tests
+
+To execute the tests, simply run:
+
+For Unix:
+
+```
+$ npm run test
+```
+
+For Windows users:
+
+```
+$ npm run testwin
+```
+
+#### Updating tests
+
+When adding new features, updating existing features or fixing bugs, you should update the expected site to reflect the changes.
+
+##### Changes to existing features
+
+Simply update the expected HTML files in `test/test_site/expected/` to reflect the changes.
+
+##### New features
+
+Add new site content into the `test/test_site/` folder to demonstrate the new feature. Ensure that the new content is included in the test site so that your feature will be tested when `markbind build` is run on the test site. Remember to update the expected HTML files in `test/test_site/expected/`.
+
+### Using ESLint
+
+Our projects follow a [coding standard](https://github.com/oss-generic/process/blob/master/docs/CodingStandards.adoc). Using a linter will help check and fix some of the code style errors in your code. It will save time for both you and your code reviewer. The linting tool we use is [ESLint](https://eslint.org/). Here is a [gist](https://gist.github.com/nicholaschuayunzhi/bfe53dbb5f1a0f02d545d55956f9ab7e) with an explanation of the ESLint rules chosen in markbind-cli.
+
+#### Installation
+
+Install developer dependencies (ESLint, related plugins) in your cloned markbind and markbind-cli repositories.
+
+```
+$ npm install --only=dev
+```
+
+#### Lint your code
+
+Before making a commit or pull request, you should lint your code.
+
+To lint a specific file, go to the root directory of the cloned repo and run
+
+```
+$ ./node_modules/.bin/eslint path/to/specificfile.js
+```
+
+To lint all files, run
+
+```
+$ ./node_modules/.bin/eslint .
+```
+
+You can add the `--fix` flag to correct any fixable style errors.
+
+```
+$ ./node_modules/.bin/eslint . --fix
+```
+
+#### Integration with editors
+
+ESLint has [integrations with popular editors](https://eslint.org/docs/user-guide/integrations). They offer features such as "fix errors on save", which will make developement more convenient.

--- a/docs/devGuide/index.md
+++ b/docs/devGuide/index.md
@@ -1,0 +1,1 @@
+<include src="devGuide.md" />

--- a/docs/devGuide/maintainerGuide.md
+++ b/docs/devGuide/maintainerGuide.md
@@ -1,0 +1,323 @@
+<frontmatter>
+  title: "Maintainer Guide"
+  header: header.md
+  footer: footer.md
+  pageNav: default
+  siteNav: devGuideSections.md
+</frontmatter>
+
+# PR Merging Workflow
+
+## Approval
+
+* Once the first approval is given from a developer, assign a version milestone to the PR (this is usually the next version, unless there is a justification for delaying the merging to future versions).
+    * **Note:** Should there be a subsequent rejection by other reviewers (or an error is spotted), the version milestone is removed immediately. The version milestone should only be restored once the new approvals come in.
+* Once the second approval is given from a senior developer (or there are >= 3 approvals given from anyone), the PR can be merged immediately.
+    * If there is no second approval yet, please wait for a day before merging the PR without the second approval.
+    * **Rationale:** This is to allow other developers the chance to review the PR, and delay the merge if there's any significant problems. Not everyone is available all of the time, so please be patient.
+    * **Note:** If the PR is too simple (e.g. correcting a simple typo), one approval is sufficient for merging, and this requirement is relaxed.
+
+## Actual Merging
+
+1. Re-run the Travis build for the current PR's `continuous-integration/travis-ci/pr`.
+    * **Rationale:** This is because we do not ask PR authors to rebase their PRs, but the master branch may have since been updated. It is possible for tests to pass on their branch, only to fail when integrating the changes with the master (**Note:** This is possible even if GitHub _doesn't_ complain about any merge conflict!)
+2. Merge the PR. Depending on the PR:
+    * Use "Squash and Merge" if the PR is a simple feature.
+    * Use "Create a Merge Commit" if the PR is non-trivial, and the author has tidied up the commit organization so that each commit is a logical change.
+    
+    a. Regardless of the option chosen above, ensure that your commit title is of the form `<PR_TITLE> (#PR_NUMBER)`. For example, for PR #745, it is of the form:
+    
+    `Add built-in support for light themes from bootswatch (#745)`
+    
+    b. For non-trivial PRs, ensure that there is a sensible commit message accompanied by it. **Rationale:** So that future developers have an idea of what is going on for this PR without having to go back to the GitHub website.
+
+Please follow the [commit message convention](https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message). For example, for PR #745, the commit message is as follows:
+
+    ```
+    To use any custom Bootstrap themes, authors must manually copy over the
+    theme's .css files to the website's asset folders, and configure the
+    layout's head.md to use the .css files.
+
+    Let's add built-in support for bootswatch light themes, by providing a
+    "theme" option in site.json, so that authors can just directly specify
+    the name of the theme in order to use it. For example:
+
+      {        
+        "theme": "bootswatch-cerulean"
+      }
+
+    Dark themes from Bootswatch are not yet supported because they require
+    our custom MarkBind components to inherit the Bootstrap styling classes,
+    to be done in #782.
+    ```
+
+3. Ensure that a version milestone is tagged to the PR. **Reason:** We may have missed it during the "Approval" stage, so please add the version milestone if it is missing, so that the drafting of the release notes during the release process will be easier.
+
+# Doing a Release
+
+## Building Vue-Strap
+
+1. Ensure that you are on the root directory on vue-strap, then execute:
+
+```
+$ npm run build
+```
+
+You should see changes in `vue.min.js`, `vue-strap.js.map` and `vue-strap.min.js`.
+
+* **Note:** Building vue-strap is optional if there's no changes since the last release of MarkBind. If there are no changes to the three files mentioned above, skip to the "Building MarkBind" section.
+
+* **Note:** Do take a glance at the diff for `vue.min.js` to see if there's any strange changes (e.g. the version of jQuery changes even though no one upgraded it).
+
+2. Commit the new changes.
+
+```
+$ git commit -m 'Update dist'
+```
+
+3. Tag the new commit with the new version number, whereby `XYZ` is the incremented number of the previous release.
+
+```
+$ git tag v2.0.1-markbind.XYZ
+```
+
+* **Note:** The tag used is a lightweight tag. _Don't_ use an annotated tag.
+
+4. Push everything to the main vue-strap repository (replace `XYZ` with version number).
+
+```
+$ git push upstream master
+$ git push upstream v2.0.1-markbind.XYZ
+```
+
+## Building MarkBind
+
+1. If we did a new vue-strap release, then:
+
+    a. Copy `vue-strap.min.js` from the vue-strap repository to the main asset folder, and to each of the test site's `expected/` folder.
+        
+```
+# copy to main asset folder
+$ cp <VUE_STRAP_REPO>/dist/vue-strap.min.js <MARKBIND_REPO>/asset/js/vue-strap.mins.js
+
+# for each test site's expected folder:
+$ cp <VUE_STRAP_REPO>/dist/vue-strap.min.js <MARKBIND_REPO>/test/functional/<TEST_SITE_NAME>/expected/markbind/js/vue-strap.min.js
+```
+
+b. Commit the new vue-strap assets (replace `XYZ` with version number).
+    
+```
+$ git commit -m 'Update vue-strap version to v2.0.1-markbind.XYZ'
+```
+
+* **Note:** We uniquely do this for each MarkBind release (rather than spontaneously update the vue-strap files for each affected PR), in order to reduce unnecessary merge conflicts. It also makes it easier for the maintainers to vet the changes.
+
+2. Rebuild the test files.
+
+```
+$ cd test/functional/
+
+# for each test site
+$ cd <TEST_SITE_NAME>
+$ markbind build
+$ cp _site/* expected/
+$ cd ..
+```
+
+When rebuilding the expected test files, ensure that **only** the version number is updated. For example, this is correct:
+
+```diff
+diff --git a/test/functional/test_site/expected/bugs/index.html b/test/functional/test_site/expected/bugs/index.html
+index 779f279..bb3c602 100644
+--- a/test/functional/test_site/expected/bugs/index.html
++++ b/test/functional/test_site/expected/bugs/index.html
+@@ -4,7 +4,7 @@
+     <meta name="default-head-top">
+     <meta charset="utf-8">
+     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+-    <meta name="generator" content="MarkBind 1.20.0">
++    <meta name="generator" content="MarkBind 1.21.0">
+     <meta name="viewport" content="width=device-width, initial-scale=1">
+     <title>Open Bugs</title>
+     <link rel="stylesheet" href="../markbind/css/bootstrap.min.css">
+```
+
+However, if there are any extra lines changed, that means that someone screwed up the functional tests, and needs to be fixed accordingly! 
+
+Only when it is fixed do you proceed with the next step of the release procedure.
+
+3. Do an `npm version` to increment the version number. Which to increment (`patch`, `minor` or `major`) depends on what PRs are merged for the new version, which means you must know beforehand about the changes.
+
+* If there are no significant changes, a `patch` is sufficient:
+
+```
+$ npm version patch
+```
+
+* If there are significant changes (e.g. breaking changes, new release), a `minor` release is needed:
+
+a. Update the version number inside `src/lib/markbind/package-lock.json` and `src/lib/markbind/package.json` manually. This is because `npm version` will not automatically update the numbers from the outside.
+
+b. Do a `npm version minor` as per normal.
+
+```
+$ npm version minor
+```
+
+* We rarely do `major` releases, but if necessary, the steps are the same as the `minor` release (just change `minor` to `major`).
+
+4. Push the new commit and version tag generated by `npm` (change `vA.B.C` to the new version's string accordingly).
+
+```
+$ git push upstream master
+$ git push upstream vA.B.C
+```
+
+5. Do an `npm publish`. You should receive a notification by `npm` that the publish is successful.
+
+```
+$ npm publish
+```
+
+6. If you used `npm link` for your project, ensure that you try the new release on another platform that doesn't use `npm link`, so that we can be sure the end-users can install and use the new version.
+
+    a. Just do `npm i -g markbind-cli@A.B.C` on the different platform and...
+
+    b. ... play around with the new MarkBind version to ensure that it works.
+    
+7. Ensure that the documentation at markbind.org is deployed correctly.
+
+Since #701, the deployment is automated.
+
+However, if it doesn't deploy properly for the release, do the following:
+
+```
+$ cd docs
+$ markbind build
+$ markbind deploy
+```
+
+8. Draft a new release on GitHub.
+
+    a. Go to the Markbind release page at https://github.com/MarkBind/markbind/releases.
+
+    b. Click "Draft a new release".
+
+    c. For the tag version, enter `vA.B.C`. (The newly released version should be recognized by GitHub, with an "Existing Tag" indicator, otherwise, ensure that you have pushed the version commit and tag in step 4).
+
+    d. For the release title, leave it blank.
+
+    e. For the main body, use the following template:
+
+```markdown
+# markbind-cli
+
+<!-- List out each of the PR for this version in the following format: -->
+<!-- #ISSUE_NUMBER ISSUE_TITLE (#PR_NUMBER) -->
+
+### Breaking Changes
+
+<!-- Any feature that is made obsolete -->
+
+> Also give a brief explanation note about:
+>   - what was the old feature that was made obsolete
+>   - any replacement feature (if any), and
+>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
+
+### Features
+
+<!-- Features enable users (authors/readers) to do something new. -->
+
+### Enhancements
+
+<!-- Enhances any existing features --> 
+
+### Fixes
+
+<!-- Fixes correct a programming error/assumption. -->
+
+### Documentation
+
+<!-- Pure changes to the documentation, such as typo, restructuring, etc -->
+
+### Code Quality
+
+<!-- DevOps, refactoring, etc. -->
+
+### Dependencies
+
+<!-- Replace `OLD` with the previous version and `NEW` with the current version -->
+
+[MarkBind/vue-strap](https://github.com/MarkBind/vue-strap): v2.0.1-markbind.OLD → v2.0.1-markbind.NEW
+
+```
+
+Use the list of PRs merged in the milestone to write the release notes. You may omit any sections that do not have a single PR under it.
+
+An example of a release note draft (taken from v1.18.0):
+
+```
+# markbind-cli
+
+### Breaking Changes
+
+#653 Disable decamelize for anchor ID generation (#667, MarkBind/vue-strap#95)
+
+> Headings with PascalCase wordings now generate a different anchor ID
+in order to be more compatible with anchor IDs generated by Github
+Flavored Markdown.
+>
+> For example, if we have the following heading:
+>
+> ```markdown
+> # MarkBind docs
+> ```
+>
+> Old anchor id:
+>
+> ```
+> mark-bind-docs
+> ```
+>
+> **New** anchor id:
+>
+> ```
+> markbind-docs
+> ```
+>
+
+### Features
+
+#457 Add `deploy -t/--travis` to deploy via Travis (#649)
+#470 Support custom MarkBind plugins (#474)
+#642 Support specifying include variables inline (#681)
+
+### Enhancements
+
+#369 Seamless panels: omit caret if not expandable (MarkBind/vue-strap#96)
+#657 Add temporary styles to prevent FOUC (#664)
+
+### Fixes
+
+#651 Exit MarkBind with non-zero exit code on fatal error (#679)
+
+### Documentation
+
+Restructure user docs on MarkBind syntax (#668)
+Add documentation for badges (#686)
+Fix filename capitalization for syntax documentation (#685)
+
+### Code Quality
+
+test: Add diff printing for easier debugging (#632)
+
+### Dependencies
+
+[MarkBind/vue-strap](https://github.com/MarkBind/vue-strap): v2.0.1-markbind.20 → v2.0.1-markbind.21
+```
+
+f. Click "Publish release".
+
+9. Finally, announce the new release on our Slack channel (replace `A.B.C` with the new version). Congrats!
+
+* Published: `npm i -g markbind-cli@A.B.C`

--- a/docs/site.json
+++ b/docs/site.json
@@ -26,6 +26,21 @@
     {
       "src": "userGuide/readerFacingFeatures.md",
       "searchable": "no"
+    },
+    {
+      "glob": "devGuide/*.md"
+    },
+    {
+      "src": "devGuide/index.md",
+      "searchable": "no"
+    },
+    {
+      "src": "devGuide/devGuide.md",
+      "searchable": "no"
+    },
+    {
+      "src": "devGuide/maintainerGuide.md",
+      "searchable": "no"
     }
   ],
   "headingIndexingLevel": 6,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
Migrate our dev guide from markbind-cli wiki to this repository alongside other documentation.

• [X] Documentation update

Resolves #625 

**What is the rationale for this request?**
Our Dev Guide is hosted on a wiki page on a separate repository,
and is difficult for contributors to locate.

The Dev Guide is a good way for us to demonstrate the capabilities
of MarkBind too, so let's feature our Dev Guide together with the
User Guide.

**What changes did you make? (Give an overview)**
The "Docs" section of the existing MarkBind homepage is now renamed
to User Guide.
Added a new item: "Developer Guide" to the nav bar.

**Is there anything you'd like reviewers to focus on?**
All that I've done is just to port the existing wiki over, no content changes are made.
Maybe we might want to improve the content too?

**Testing instructions:**
Open the auto-built netlify site and have a look :)