### PR TITLE
Fix site nav padding

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -115,8 +115,11 @@ footer {
 
 /* Side Navigation menus */
 
-.spacer-top {
-    /* This class is to ensure adequate spacing of contents from the top of the page */
+.site-nav-spacer {
+    /* This class is to ensure adequate spacing of contents from the top and
+    sides of the site nav */
+    padding-left: 20px;
+    padding-right: 20px;
     padding-top: 1rem;
 }
 

--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -6,8 +6,8 @@
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-bottom: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 0px;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;
@@ -60,7 +60,6 @@
 
 .site-nav-list {
     list-style-type: none;
-    margin-left: -1em;
 }
 
 /* Navigation dropdown menu */

--- a/docs/_markbind/navigation/devGuideSections.md
+++ b/docs/_markbind/navigation/devGuideSections.md
@@ -1,6 +1,6 @@
 <navigation>
 
-<span class="indented lead">**Developer Guide**</span>
+<span class="lead">**Developer Guide**</span>
 
 * [Developer Guide]({{baseUrl}}/devGuide/devGuide.html)
 * [Maintainer Guide]({{baseUrl}}/devGuide/maintainerGuide.html)

--- a/docs/_markbind/navigation/userGuideSections.md
+++ b/docs/_markbind/navigation/userGuideSections.md
@@ -1,6 +1,6 @@
 <navigation>
 
-<span class="indented lead">**User Guide**</span>
+<span class="lead">**User Guide**</span>
 
 * [Getting Started]({{baseUrl}}/userGuide/gettingStarted.html)
 * [Authoring Contents]({{baseUrl}}/userGuide/authoringContents.html)

--- a/src/Page.js
+++ b/src/Page.js
@@ -587,13 +587,14 @@ Page.prototype.insertSiteNav = function (pageData) {
     const siteNavHtml = md.render(siteNavDataSelector('navigation').html().trim().replace(/\n\s*\n/g, '\n'));
     // Add Bootstrap padding class to rendered unordered list
     const siteNavHtmlSelector = cheerio.load(siteNavHtml, { xmlMode: false });
-    siteNavHtmlSelector('ul').first().addClass('px-3');
+    siteNavHtmlSelector('ul').first().addClass('px-0');
+    siteNavHtmlSelector('ul ul').addClass('pl-3');
     const formattedSiteNav = formatSiteNav(siteNavHtmlSelector.html(), this.src);
     siteNavDataSelector('navigation').replaceWith(formattedSiteNav);
   }
   // Wrap sections
   const wrappedSiteNav = `<nav id="${SITE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
-    + '<div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">'
+    + '<div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">'
     + `${siteNavDataSelector.html()}\n`
     + '</div>\n'
     + '</nav>';

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -45,8 +45,8 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">
-          <ul class="px-3 site-nav-list">
+        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+          <ul class="px-0 site-nav-list">
             <li class="mt-2">
               <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation"></a></h2>
             </li>
@@ -59,13 +59,13 @@
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
               <div class="dropdown-container dropdown-container-open">
-                <ul class="site-nav-list">
+                <ul class="pl-3 site-nav-list">
                   <li class="mt-2"><a href="https://www.google.com/" class="site-nav__a">Dropdown link one</a></li>
                   <li class="mt-2"><button class="dropdown-btn">Nested Dropdown title 📐
  <i class="dropdown-btn-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
                     <div class="dropdown-container">
-                      <ul class="site-nav-list">
+                      <ul class="pl-3 site-nav-list">
                         <li class="mt-2"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link one</a></li>
                         <li class="mt-2"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link two</a></li>
                       </ul>
@@ -77,13 +77,13 @@
             </li>
             <li class="mt-2"><a href="https://www.google.com/" class="site-nav__a"><mark>Third Link</mark> 📋</a></li>
             <li class="mt-2">Filler text <a href="https://www.youtube.com/" class="site-nav__a"><span aria-hidden="true" class="glyphicon glyphicon-facetime-video"></span> Youtube 📺</a> filler text
-              <ul class="site-nav-list">
+              <ul class="pl-3 site-nav-list">
                 <li class="mt-2"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="site-nav__a">The answer to everything in the universe</a></li>
                 <li class="mt-2"><button class="dropdown-btn dropdown-btn-open"><mark>Dropdown title</mark> <span aria-hidden="true" class="glyphicon glyphicon-comment"></span> ✏️ 
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
                   <div class="dropdown-container dropdown-container-open">
-                    <ul class="site-nav-list">
+                    <ul class="pl-3 site-nav-list">
                       <li class="mt-2"><a href="https://www.google.com/" class="site-nav__a"><strong>Nested</strong> Dropdown link one</a></li>
                     </ul>
                   </div>
@@ -94,7 +94,7 @@
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
               <div class="dropdown-container dropdown-container-open">
-                <ul class="site-nav-list">
+                <ul class="pl-3 site-nav-list">
                   <li class="mt-2">Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long
                     Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really
                     Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really
@@ -103,7 +103,7 @@
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
                     <div class="dropdown-container dropdown-container-open">
-                      <ul class="site-nav-list">
+                      <ul class="pl-3 site-nav-list">
                         <li class="mt-2">Hello Doge Hello Doge 🐶</li>
                         <li class="mt-2"><a href="/test_site/index.html" class="site-nav__a current"><strong>NESTED LINK</strong> Home 🏠</a></li>
                         <li class="mt-2">Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off
@@ -119,10 +119,10 @@
  <i class="dropdown-btn-icon rotate-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
               <div class="dropdown-container dropdown-container-open">
-                <ul class="site-nav-list">
+                <ul class="pl-3 site-nav-list">
                   <li class="mt-2">Nested line break text ✂️</li>
                   <li class="mt-2"><a href="/test_site/index.html" class="site-nav__a current">Nested line break href</a>
-                    <ul class="site-nav-list">
+                    <ul class="pl-3 site-nav-list">
                       <li class="mt-2">Nested Nested line break text ✂️</li>
                     </ul>
                   </li>
@@ -130,7 +130,7 @@
  <i class="dropdown-btn-icon">
 <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></button>
                     <div class="dropdown-container">
-                      <ul class="site-nav-list">
+                      <ul class="pl-3 site-nav-list">
                         <li class="mt-2">Line break item 2 📘</li>
                       </ul>
                     </div>

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -115,8 +115,11 @@ footer {
 
 /* Side Navigation menus */
 
-.spacer-top {
-    /* This class is to ensure adequate spacing of contents from the top of the page */
+.site-nav-spacer {
+    /* This class is to ensure adequate spacing of contents from the top and
+    sides of the site nav */
+    padding-left: 20px;
+    padding-right: 20px;
     padding-top: 1rem;
 }
 

--- a/test/functional/test_site/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site/expected/markbind/css/site-nav.css
@@ -6,8 +6,8 @@
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-bottom: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 0px;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;
@@ -60,7 +60,6 @@
 
 .site-nav-list {
     list-style-type: none;
-    margin-left: -1em;
 }
 
 /* Navigation dropdown menu */

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -26,8 +26,8 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">
-          <ul class="px-3 site-nav-list">
+        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+          <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>
         </div>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -26,8 +26,8 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">
-          <ul class="px-3 site-nav-list">
+        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+          <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>
         </div>

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -26,8 +26,8 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">
-          <ul class="px-3 site-nav-list">
+        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+          <ul class="px-0 site-nav-list">
             <li class="mt-2"><a href="/test_site_algolia_plugin/index.html" class="site-nav__a current">Home <span aria-hidden="true" class="glyphicon glyphicon-home"></span></a></li>
           </ul>
         </div>

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -115,8 +115,11 @@ footer {
 
 /* Side Navigation menus */
 
-.spacer-top {
-    /* This class is to ensure adequate spacing of contents from the top of the page */
+.site-nav-spacer {
+    /* This class is to ensure adequate spacing of contents from the top and
+    sides of the site nav */
+    padding-left: 20px;
+    padding-right: 20px;
     padding-top: 1rem;
 }
 

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
@@ -6,8 +6,8 @@
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-bottom: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 0px;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;
@@ -60,7 +60,6 @@
 
 .site-nav-list {
     list-style-type: none;
-    margin-left: -1em;
 }
 
 /* Navigation dropdown menu */


### PR DESCRIPTION
The padding in the site nav is causing the title to be indented further than the list of contents, as well as creating a gap between the scrollbar and the right side of the site nav.

Let's change the padding to fix these issues.

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #800.

**What is the rationale for this request?**

The title in the site nav is misindented, and the scroll bar is mispositioned.

The padding was placed on the outer `<nav>` element, which causes the padding to be applied to both the scrollbar and title. 

<img width="315" alt="Screenshot 2019-04-01 at 4 34 22 PM" src="https://user-images.githubusercontent.com/17447681/55314120-03fc2b80-549c-11e9-9a05-c8b0a5fae125.png">

**What changes did you make? (Give an overview)**

- Remove padding from the `<nav>` element and move it to the inner div containing the scrollbar. This way, padding is not applied when calculating scrollbar position and consistent adding is applied to all content within the site nav, including title and content
- Update styles for `site-nav-list` to maintain consistent spacing with other content outside the list
  - Remove `margin-left: -1em` from `.site-nav-list`
  - For outermost `ul`, replace the `px-3` class with `px-0` so that the outermost list uses padding from the parent div
  - For nested `ul`, add `pl-3` to reduce indentation of nested lists (without this, the indentation looks a little too big)
- Remove `indented` class from the title of the `userGuideSections.md` and `devGuideSections.md`

<img width="315" alt="Screenshot 2019-04-01 at 4 37 38 PM" src="https://user-images.githubusercontent.com/17447681/55314309-78cf6580-549c-11e9-9cc2-d56a72a542df.png">

**Testing instructions:**

In the Netlify preview titles in the site nav should appear correctly indented, and scrollbars should be correctly positioned.

**Proposed commit message: (wrap lines at 72 characters)**

Fix site nav padding

The padding in the site nav causes the title to be indented further
right than the list of contents, and creates a gap between the
scrollbar and the right side of the site nav.

Let's move the padding to the inner div that wraps the content
so that the padding is not applied for the scrollbar, and applied
for all content within the site nav.

Let's also update the bootstrap spacing classes for the list
elements inside the site nav to ensure that it is consistent
with the padding of other content in the site nav.