### PR TITLE
Parser: Fix relative src bug involving hostBaseUrl

### DIFF
--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -187,7 +187,9 @@ Parser.prototype._preprocess = function (node, context, config) {
   let actualFilePath;
   if (hasSrc && shouldProcessSrc) {
     isUrl = utils.isUrl(element.attribs.src);
-    isAbsolutePath = path.isAbsolute(element.attribs.src) || element.attribs.src.includes('{{baseUrl}}');
+    isAbsolutePath = path.isAbsolute(element.attribs.src)
+                         || element.attribs.src.includes('{{baseUrl}}')
+                         || element.attribs.src.includes('{{hostBaseUrl}}');
     includeSrc = url.parse(element.attribs.src);
     filePath = isUrl
       ? element.attribs.src

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -352,6 +352,16 @@ specification that specifies how the product will address the requirements. </sp
               <a href="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
               <a id="namedAnchor">Named Anchor</a>
               <a>Anchor with no attributes</a></p>
+            <p>Within DIV tag:</p>
+            <div id="imageTest">
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+              <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+            </div>
+          </div>
+          <h1 id="include-segment-from-another-markbind-site">Include segment from another Markbind site<a class="fa fa-anchor" href="#include-segment-from-another-markbind-site"></a></h1>
+          <div>
+            <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+            <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
           </div>
           <h1 id="trimmed-include">Trimmed include<a class="fa fa-anchor" href="#trimmed-include"></a></h1>
           <h2 id="fragment-with-leading-spaces-and-newline"><span>Fragment with leading spaces and newline</span><a class="fa fa-anchor" href="#fragment-with-leading-spaces-and-newline"></a></h2>
@@ -501,6 +511,7 @@ specification that specifies how the product will address the requirements. </sp
             <nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">
               <a class="nav-link py-1" href="#feature-list">Feature list&#x200E;</a>
             </nav>
+            <a class="nav-link py-1" href="#include-segment-from-another-markbind-site">Include segment from another Markbind site&#x200E;</a>
             <a class="nav-link py-1" href="#trimmed-include">Trimmed include&#x200E;</a>
             <nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">
               <a class="nav-link py-1" href="#fragment-with-leading-spaces-and-newline">Fragment with leading spaces and newline&#x200E;</a>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -81,6 +81,7 @@
         "html-include": "HTML include",
         "mbd-mbdf-include": "Mbd, Mbdf include",
         "include-from-another-markbind-site": "Include from another Markbind site",
+        "include-segment-from-another-markbind-site": "Include segment from another Markbind site",
         "trimmed-include": "Trimmed include",
         "fragment-with-leading-spaces-and-newline": "Fragment with leading spaces and newline",
         "trimmed-include-fragment": "Trimmed include fragment",

--- a/test/functional/test_site/expected/sub_site/testReuse._include_.html
+++ b/test/functional/test_site/expected/sub_site/testReuse._include_.html
@@ -19,3 +19,8 @@
   <a href="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
   <a id="namedAnchor">Named Anchor</a>
   <a>Anchor with no attributes</a></p>
+<p>Within DIV tag:</p>
+<div id="imageTest">
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+  <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
+</div>

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -128,6 +128,9 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 <include src="sub_site/index.md" />
 <include src="sub_site/testReuse.md" />
 
+# Include segment from another Markbind site
+<include src="sub_site/testReuse.md#imageTest" />
+
 # Trimmed include
 
 ## <include src="testTrimInclude.md" trim inline />

--- a/test/functional/test_site/sub_site/testReuse.md
+++ b/test/functional/test_site/sub_site/testReuse.md
@@ -24,3 +24,9 @@ Anchor:
 <a href="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png">Link to picture</a>
 <a id="namedAnchor">Named Anchor</a>
 <a>Anchor with no attributes</a>
+
+Within DIV tag:
+<div id="imageTest">
+  <img src="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png">
+  <pic src="{{baseUrl}}/images/I'm not allowed to use my favorite tool.png"></pic>
+</div>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [x] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes #803 

**What is the rationale for this request?**
When including a file from another site, the {{baseUrl}} variables
in src attributes are sometimes rewritten as {{hostBaseUrl}}.
{{hostBaseUrl}} also refers to an absolute path, so we should not
treat it as a relative path and rewrite the URL.

This {{hostBaseUrl}} issue arises when we have a file including content using div ID references from another file within a sub-site.
For example, index.md includes sub_site/inner.md#imageDiv. Then if inner.md#imageDiv references any local resources within the subsite with {{baseUrl}}, this {{baseUrl}} will be rewritten to {{hostBaseUrl}}/sub_site.

**What changes did you make? (Give an overview)**
Let's teach parser to avoid rewriting URLs that contain
{{hostBaseUrl}}.

**Provide some example code that this change will affect:**
See TE3201 website linked from #803 

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**
Check out TE3201 github page, and build the website using MarkBind from this PR. You can verify that the `chromeSaveAsPdf` images displays correctly.
