### PR TITLE
Fix algolia-no-index for various components

### DIFF
--- a/src/plugins/algolia.js
+++ b/src/plugins/algolia.js
@@ -26,6 +26,8 @@ function addNoIndexClasses(content) {
     'modal',
     'panel:not([expanded])',
     'popover div[slot=content]',
+    'question div[slot=hint]',
+    'question div[slot=answer]',
     'tab:not(:first-child)',
     'tab-group:not(:first-child)',
   ].join(', ');

--- a/src/plugins/algolia.js
+++ b/src/plugins/algolia.js
@@ -25,10 +25,9 @@ function addNoIndexClasses(content) {
     'dropdown',
     'modal',
     'panel:not([expanded])',
-    'popover',
+    'popover div[slot=content]',
     'tab:not(:first-child)',
     'tab-group:not(:first-child)',
-    'tooltip',
   ].join(', ');
   $(noIndexSelectors).addClass('algolia-no-index');
   return $.html();

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -40,11 +40,11 @@
           <li><a class="dropdown-item" href="/">One</a></li>
           <li><a class="dropdown-item" href="/">Two</a></li>
         </dropdown>
-        <h2 id="modals-should-have-algolia-no-index-class">Modals should have algolia-no-index class<a class="fa fa-anchor" href="#modals-should-have-algolia-no-index-class"></a></h2>
+        <h2 id="modal-content-should-have-algolia-no-index-class">Modal content should have algolia-no-index class<a class="fa fa-anchor" href="#modal-content-should-have-algolia-no-index-class"></a></h2>
         <modal title="Modal" id="modal:trigger_id" class="algolia-no-index">
-          Content
+          Content should have `algolia-no-index` class
         </modal>
-        <trigger for="modal:trigger_id">Trigger</trigger>
+        <trigger for="modal:trigger_id">Trigger should not have `algolia-no-index` class</trigger>
         <h2 id="panels-that-are-not-expanded-should-have-algolia-no-index-class">Panels that are not expanded should have algolia-no-index class<a class="fa fa-anchor" href="#panels-that-are-not-expanded-should-have-algolia-no-index-class"></a></h2>
         <panel header="Panel" class="algolia-no-index">
           Content
@@ -52,9 +52,12 @@
         <panel header="Panel" expanded="">
           Content
         </panel>
-        <h2 id="popover-should-have-algolia-no-index-class">Popover should have algolia-no-index class<a class="fa fa-anchor" href="#popover-should-have-algolia-no-index-class"></a></h2>
-        <popover effect="fade" content="Content" placement="top" class="algolia-no-index">
-          <button class="btn btn-secondary">Popover</button></popover>
+        <h2 id="popover-content-should-have-algolia-no-index-class">Popover content should have algolia-no-index class<a class="fa fa-anchor" href="#popover-content-should-have-algolia-no-index-class"></a></h2>
+        <popover effect="fade" title="Title" placement="top">
+          <div slot="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
+          <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></popover>
+        <popover effect="fade" title="Title" content="Content as attribute does not require `algolia-no-index` class" placement="top">
+          <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></popover>
         <h2 id="tabs-except-first-tab-should-have-algolia-no-index-class">Tabs except first tab should have algolia-no-index class<a class="fa fa-anchor" href="#tabs-except-first-tab-should-have-algolia-no-index-class"></a></h2>
         <tabs>
           <tab header="First Tab">
@@ -95,9 +98,6 @@
             Content<br>Content<br>Content<br>Content
           </tab>
         </tabs>
-        <h2 id="tooltip-should-have-algolia-no-index-class">Tooltip should have algolia-no-index class<a class="fa fa-anchor" href="#tooltip-should-have-algolia-no-index-class"></a></h2>
-        <tooltip header="" content="Content" placement="top" class="algolia-no-index">
-          <button class="btn btn-secondary">Tooltip</button></tooltip>
       </div>
     </div>
     <footer>

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -58,6 +58,12 @@
           <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></popover>
         <popover effect="fade" title="Title" content="Content as attribute does not require `algolia-no-index` class" placement="top">
           <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></popover>
+        <h2 id="question-hint-and-answer-should-have-algolia-no-index-class">Question hint and answer should have algolia-no-index class<a class="fa fa-anchor" href="#question-hint-and-answer-should-have-algolia-no-index-class"></a></h2>
+        <question>
+          Question should not have `algolia-no-index` class
+          <div slot="hint" class="algolia-no-index">Hint should have `algolia-no-index` class</div>
+          <div slot="answer" class="algolia-no-index">Answer should have `algolia-no-index` class</div>
+        </question>
         <h2 id="tabs-except-first-tab-should-have-algolia-no-index-class">Tabs except first tab should have algolia-no-index class<a class="fa fa-anchor" href="#tabs-except-first-tab-should-have-algolia-no-index-class"></a></h2>
         <tabs>
           <tab header="First Tab">

--- a/test/functional/test_site_algolia_plugin/expected/siteData.json
+++ b/test/functional/test_site_algolia_plugin/expected/siteData.json
@@ -8,6 +8,7 @@
         "modal-content-should-have-algolia-no-index-class": "Modal content should have algolia-no-index class",
         "panels-that-are-not-expanded-should-have-algolia-no-index-class": "Panels that are not expanded should have algolia-no-index class",
         "popover-content-should-have-algolia-no-index-class": "Popover content should have algolia-no-index class",
+        "question-hint-and-answer-should-have-algolia-no-index-class": "Question hint and answer should have algolia-no-index class",
         "tabs-except-first-tab-should-have-algolia-no-index-class": "Tabs except first tab should have algolia-no-index class"
       },
       "title": "Hello World",

--- a/test/functional/test_site_algolia_plugin/expected/siteData.json
+++ b/test/functional/test_site_algolia_plugin/expected/siteData.json
@@ -5,11 +5,10 @@
       "headings": {
         "test-algolia-plugin-adds-algolia-no-index-classes": "Test Algolia plugin adds algolia-no-index classes",
         "dropdowns-should-have-algolia-no-index-class": "Dropdowns should have algolia-no-index class",
-        "modals-should-have-algolia-no-index-class": "Modals should have algolia-no-index class",
+        "modal-content-should-have-algolia-no-index-class": "Modal content should have algolia-no-index class",
         "panels-that-are-not-expanded-should-have-algolia-no-index-class": "Panels that are not expanded should have algolia-no-index class",
-        "popover-should-have-algolia-no-index-class": "Popover should have algolia-no-index class",
-        "tabs-except-first-tab-should-have-algolia-no-index-class": "Tabs except first tab should have algolia-no-index class",
-        "tooltip-should-have-algolia-no-index-class": "Tooltip should have algolia-no-index class"
+        "popover-content-should-have-algolia-no-index-class": "Popover content should have algolia-no-index class",
+        "tabs-except-first-tab-should-have-algolia-no-index-class": "Tabs except first tab should have algolia-no-index class"
       },
       "title": "Hello World",
       "footer": "footer.md",

--- a/test/functional/test_site_algolia_plugin/index.md
+++ b/test/functional/test_site_algolia_plugin/index.md
@@ -13,12 +13,12 @@
   <li><a class="dropdown-item" href="/">Two</a></li>
 </dropdown>
 
-## Modals should have algolia-no-index class
+## Modal content should have algolia-no-index class
 
 <modal title="Modal" id="modal:trigger_id">
-  Content
+  Content should have `algolia-no-index` class
 </modal>
-<trigger for="modal:trigger_id">Trigger</trigger>
+<trigger for="modal:trigger_id">Trigger should not have `algolia-no-index` class</trigger>
 
 ## Panels that are not expanded should have algolia-no-index class
 
@@ -30,10 +30,15 @@
   Content
 </panel>
 
-## Popover should have algolia-no-index class
+## Popover content should have algolia-no-index class
 
-<popover effect="fade" content="Content" placement="top">
-  <button class="btn btn-secondary">Popover</button>
+<popover effect="fade" title="Title" placement="top">
+  <div slot="content">Content should have `algolia-no-index` class</div>
+  <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
+</popover>
+
+<popover effect="fade" title="Title" content="Content as attribute does not require `algolia-no-index` class" placement="top">
+  <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
 ## Tabs except first tab should have algolia-no-index class
@@ -79,9 +84,3 @@
     Content<br />Content<br />Content<br />Content
   </tab>
 </tabs>
-
-## Tooltip should have algolia-no-index class
-
-<tooltip header content="Content" placement="top">
-  <button class="btn btn-secondary">Tooltip</button>
-</tooltip>

--- a/test/functional/test_site_algolia_plugin/index.md
+++ b/test/functional/test_site_algolia_plugin/index.md
@@ -41,6 +41,14 @@
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
+## Question hint and answer should have algolia-no-index class
+
+<question>
+  Question should not have `algolia-no-index` class
+  <div slot="hint">Hint should have `algolia-no-index` class</div>
+  <div slot="answer">Answer should have `algolia-no-index` class</div>
+</question>
+
 ## Tabs except first tab should have algolia-no-index class
 
 <tabs>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fix #807.

**What is the rationale for this request?**

At the moment, the `algolia-no-index` class is added to the top-level `<popover>` and `<tooltip>` elements. However, the trigger may be embedded within the element, and will thus also be affected by the class. This is not desirable as they are visible and should be indexed.

Also, the `algolia-no-index` class is not added to the hint and answer sections of `<question>`, even though they are hidden in the initial render.

**What changes did you make? (Give an overview)**

- [x] Apply `algolia-no-index` class to the content div nested in the `<popover>` element. (content specified as an attribute is ignored by default)
- [x] Do not apply `algolia-no-index` class from `<tooltip>`element. (content is specified **only** via attribute, and will be ignored)
- [x] Apply `algolia-no-index` class to the `hint` and `answer` divs for `<question>` element.

**Provide some example code that this change will affect:**
**Input**
```html
<popover effect="fade" title="Title" placement="top">
  <div slot="content">Content</div>
  <button class="btn btn-secondary">Popover</button>
</popover>

<question>
  Question
  <div slot="hint">Hint</div>
  <div slot="answer">Answer</div>
</question>
```
**Output**
```html
<popover effect="fade" title="Title" placement="top">
  <div slot="content" class="algolia-no-index">Content</div>
  <button class="btn btn-secondary">Popover</button>
</popover>

<question>
  Question
  <div slot="hint" class="algolia-no-index">Hint</div>
  <div slot="answer" class="algolia-no-index">Answer</div>
</question>
```

**Is there anything you'd like reviewers to focus on?**
- Are there any other elements that have hidden sections that should not be indexed?

**Testing instructions:**
Output for `test_site_algolia_plugin` should be correct.

**Proposed commit message: (wrap lines at 72 characters)**

I've added the commit messages to the commits itself 🙂 Do let me know if they are okay!