### PR TITLE
Deploy user docs only from main MarkBind repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ deploy:
   script: cd docs && ../index.js build && ../index.js deploy --travis
   skip_cleanup: true
   on:
+    repo: MarkBind/markbind
     tags: true
     condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+
 cache:

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -108,9 +108,9 @@ Since May 2018, Travis CI has been [undergoing migration to `travis-ci.com`](htt
 1. Once the build succeeds, your MarkBind site should be online at `http://<username|org>.github.io/<repo>` e.g., http://se-edu.github.io/se-book. Travis CI will automatically build and deploy changes to your site as you push new changes to the repository after a few seconds.<br>
   %%{{ icon_info }} You might have to go to the `Settings` of your repo and configure it to publish GitHub Pages from the `gh-pages` branch as MarkBind deploys to that branch by default.%%
 
-<box>
+##### Configuring Travis CI to use a specific MarkBind version
 
-{{ icon_info }} Note that when Travis CI is set up as explained above, it will use the latest version of MarkBind which may be a later version than the one you use locally.
+When Travis CI is set up as explained above, it will use the latest version of MarkBind which may be a later version than the one you use locally.
 * If you want Travis CI to use a specific version of MarkBind (eg. `v1.6.3`), change the `install` step in the `.travis.yml` given above to:
   ```yaml
   install:
@@ -121,7 +121,19 @@ Since May 2018, Travis CI has been [undergoing migration to `travis-ci.com`](htt
   install:
     - npm i -g markbind-cli@^1.63
   ```
-</box>
+##### Configuring Travis CI to only deploy from a specific repository
+
+When Travis CI is set up as explained above, Travis CI will attempt to deploy the site from any repository it is in, including forks. If you want Travis CI to only deploy from a specific repository (eg. only from your main site repository), you can set a [`deploy` phase with an `on` condition](https://docs.travis-ci.com/user/deployment#conditional-releases-with-on).
+
+For example, if you only want Travis CI to deploy the site when it is run from the `se-edu/se-book` repository, the folllowing `deploy` phase with the `on` condition should be added to `.travis.yml`:
+
+```yaml
+deploy:
+  on:
+    repo: se-edu/se-book
+```
+
+The `repo` value can be changed to your specific repository as desired.
 
 <hr>
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain: DevOps enhancement

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Closes #749.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Our Travis CI configuration will attempt to deploy our user docs from any repository, including forks. This can lead to accidental overwriting of the user docs from developer forks if they have write access to the user docs repository.

**What changes did you make? (Give an overview)**
I added a `on` condition to only attempt to deploy user docs when Travis CI runs on the `MarkBind/markbind` repository. Since this is a common use case, I have also added instructions on how to restrict Travis CI to only deploy from a a specific repository to the user documentation.

**Is there anything you'd like reviewers to focus on?**
Is the [user documentation for restricting Travis CI to only deploy from a a specific repository](https://deploy-preview-817--markbind-master.netlify.com/userguide/deployingthesite#configuring-travis-ci-to-only-deploy-from-a-specific-repository) clear?

**Testing instructions:**
1. Pull this PR to your own fork, and test with Travis CI enabled. It should not deploy even when on a tagged commit that matches `vx.x.x`.

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->

```
Deploy user docs only from main MarkBind repo

Our Travis CI configuration will attempt to deploy our user docs from
any repository, including forks. This can lead to accidental overwriting
of the user docs from developer forks if they have write access to the
user docs repository.

Let's add a `on` condition to our Travis CI configuration to specify
that deployment of the user docs should only be done when run from the
main MarkBind repository.
```
```
Docs: add steps for deploying from specific repo

Restricting Travis CI to only deploy a MarkBind site from a main project
repository should be quite a common use case for projects using
MarkBind.

Let's document how to restrict Travis CI deployment to a specific
repository in our user documentation.
```