### PR TITLE
header.md: Use absolute path instead of ../

### DIFF
--- a/docs/_markbind/headers/header.md
+++ b/docs/_markbind/headers/header.md
@@ -1,12 +1,12 @@
 <header>
-  <link rel="stylesheet" href="../css/main.css">
+  <link rel="stylesheet" href="{{baseUrl}}/css/main.css">
   <navbar type="dark">
-    <a slot="brand" href="../index.html" title="Home" class="navbar-brand"><img src="../images/logo-darkbackground.png" height="20" /></a>
-    <li><a href="../index.html" class="nav-link">HOME</a></li>
-    <li><a href="../userGuide/index.html" class="nav-link">USER GUIDE</a></li>
-    <li><a href="../showcase.html" class="nav-link">SHOWCASE</a></li>
-    <li><a href="../about.html" class="nav-link">ABOUT</a></li>
-    <li><a href="../devGuide/index.html" class="nav-link">DEVELOPER GUIDE</a></li>
+    <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand"><img src="{{baseUrl}}/images/logo-darkbackground.png" height="20" /></a>
+    <li><a href="{{baseUrl}}/index.html" class="nav-link">HOME</a></li>
+    <li><a href="{{baseUrl}}/userGuide/index.html" class="nav-link">USER GUIDE</a></li>
+    <li><a href="{{baseUrl}}/showcase.html" class="nav-link">SHOWCASE</a></li>
+    <li><a href="{{baseUrl}}/about.html" class="nav-link">ABOUT</a></li>
+    <li><a href="{{baseUrl}}/devGuide/index.html" class="nav-link">DEVELOPER GUIDE</a></li>
     <li>
       <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link"><md>:fab-github:</md></a>
     </li>

--- a/docs/userGuide/syntax/links.mbdf
+++ b/docs/userGuide/syntax/links.mbdf
@@ -86,6 +86,11 @@ or by including `subsite.md`:
 ```
 <include src="textbook/subsite.md" />
 ```
+
+<box type="important">
+To ensure that links in the _markbind/ folder work correctly across the entire site, they should be written as absolute paths, prepended with <span>{</span>{ baseUrl }}. 
+</box>
+
 </div>
 </div>
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

Resolves #820 

**What is the rationale for this request?**
Header contains link references such as ../index.html. This is so
that the links are correct when referring both the main site and
from a nested directory such as userGuide/. However, this approach
is incorrect if we have more deeply nested directories.
For a more detailed explanation, refer to https://github.com/MarkBind/markbind/issues/820#issuecomment-480574703



**What changes did you make? (Give an overview)**
Instead of relative references, let's use absolute references w.r.t.
the root directory instead.

**Testing instructions:**
Open the netlify preview site and ensure that there are no broken links.