### PR TITLE
Remove sticky-top class from side navigations

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -131,6 +131,10 @@ footer {
     max-height: 90vh;
 }
 
+.position-top {
+    top: 0;
+}
+
 /* Bootstrap small(sm) responsive breakpoint */
 @media (max-width: 767.98px) {
     .dropdown-menu > li > a {

--- a/src/Page.js
+++ b/src/Page.js
@@ -594,7 +594,7 @@ Page.prototype.insertSiteNav = function (pageData) {
   }
   // Wrap sections
   const wrappedSiteNav = `<nav id="${SITE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
-    + '<div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">'
+    + '<div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">'
     + `${siteNavDataSelector.html()}\n`
     + '</div>\n'
     + '</nav>';
@@ -681,7 +681,7 @@ Page.prototype.buildPageNav = function () {
     const pageNavHeadingHTML = this.generatePageNavHeadingHtml();
     this.pageSectionsHtml[`#${PAGE_NAV_ID}`] = htmlBeautify(
       `<nav id="${PAGE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
-      + '<div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">\n'
+      + '<div class="position-sticky position-top spacer-top viewport-height-90 scrollable slim-scroll">\n'
       + `${pageNavTitleHtml}\n`
       + '<nav class="nav nav-pills flex-column my-0 small no-flex-wrap">\n'
       + `${pageNavHeadingHTML}\n`

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -45,7 +45,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">
               <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation"></a></h2>
@@ -454,7 +454,7 @@ specification that specifies how the product will address the requirements. </sp
         <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed</h6>
       </div>
       <nav id="page-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top spacer-top viewport-height-90 scrollable slim-scroll">
+        <div class="position-sticky position-top spacer-top viewport-height-90 scrollable slim-scroll">
           <a class="navbar-brand page-nav-title" href="#">Testing Page Navigation</a>
           <nav class="nav nav-pills flex-column my-0 small no-flex-wrap">
             <a class="nav-link py-1" href="#variables-that-reference-another-variable">Variables that reference another variable&#x200E;</a>

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -131,6 +131,10 @@ footer {
     max-height: 90vh;
 }
 
+.position-top {
+    top: 0;
+}
+
 /* Bootstrap small(sm) responsive breakpoint */
 @media (max-width: 767.98px) {
     .dropdown-menu > li > a {

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="sticky-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2"><a href="/test_site_algolia_plugin/index.html" class="site-nav__a current">Home <span aria-hidden="true" class="glyphicon glyphicon-home"></span></a></li>
           </ul>

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -131,6 +131,10 @@ footer {
     max-height: 90vh;
 }
 
+.position-top {
+    top: 0;
+}
+
 /* Bootstrap small(sm) responsive breakpoint */
 @media (max-width: 767.98px) {
     .dropdown-menu > li > a {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fix #818.

**What is the rationale for this request?**

The side navigations have unnecessarily high `z-index`, which causes it to be layered on top of other components.

**What changes did you make? (Give an overview)**

Remove the `sticky-top` bootstrap class which adds the high `z-index`, and use other css classes to retain the same positioning without increasing `z-index`.

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**
 Build the TE3201 website with this branch, and navigate to `http://127.0.0.1:8080/se-book-adapted/chapters/refactoring.html#refactoring`. Use the searchbar. The page navigation should not appear above the search results.

<img width="347" alt="Screenshot 2019-04-10 at 12 19 32 PM" src="https://user-images.githubusercontent.com/17447681/55851401-fe34d300-5b8a-11e9-91a3-e37a36ba20a7.png">

<img width="355" alt="Screenshot 2019-04-10 at 12 22 10 PM" src="https://user-images.githubusercontent.com/17447681/55851476-4a801300-5b8b-11e9-8a68-fa998c558aa6.png">


**Proposed commit message: (wrap lines at 72 characters)**

Remove sticky-top class from side navigations

The sticky-top class increases the z-index of the side navigations to
1030. The high z-index is not necessary for the side navigations, and
has caused it to be layered on top of the dropdowns of other components.

Let's remove the sticky-top class from the side navigations, and use
other css classes to achieve the same positioning without the high
z-index.