### PR TITLE
Add script to update expected folder for test sites

### DIFF
--- a/docs/devGuide/devGuide.md
+++ b/docs/devGuide/devGuide.md
@@ -120,8 +120,8 @@ A: If your npm version is v6.0.0 or higher, there is a change in behaviour on ho
 Our test script does the following:
 
 1. Lints the code for any code and style errors using ESLint.
-1. Builds the test site found in `test/test_site/`.
-1. Compares the HTML files generated with the HTML files in `test/test_site/expected/`.
+1. Builds the test sites whose directory names are listed in `test/functional/test_sites`.
+1. For each test site, compares the HTML files generated with the HTML files in its `expected` directory.
 
 #### Running tests
 
@@ -136,20 +136,37 @@ $ npm run test
 For Windows users:
 
 ```
-$ npm run testwin
+> npm run testwin
 ```
 
 #### Updating tests
 
-When adding new features, updating existing features or fixing bugs, you should update the expected site to reflect the changes.
+Whether you are adding a new feature, updating existing features or fixing bugs, make sure to update the test sites to reflect the changes.
 
-##### Changes to existing features
+You may use the following script to do this:
 
-Simply update the expected HTML files in `test/test_site/expected/` to reflect the changes.
+On Unix:
+
+```
+$ npm run updatetest
+```
+
+On Windows:
+
+```
+> npm run updatetestwin
+```
+<box type="warning">
+  You should always check that the generated output is correct before committing any changes to the test sites.
+</box>
 
 ##### New features
 
-Add new site content into the `test/test_site/` folder to demonstrate the new feature. Ensure that the new content is included in the test site so that your feature will be tested when `markbind build` is run on the test site. Remember to update the expected HTML files in `test/test_site/expected/`.
+When adding new features, you should also add new site content into an existing test site or create a new test site to demonstrate the new feature. This is to ensure that your feature can be tested by building that test site.
+
+<box type="info">
+  When creating a new test site, the directory name of the new test site should be added to <code>test/functional/test_sites</code>.
+</box>
 
 ### Using ESLint
 

--- a/docs/devGuide/maintainerGuide.md
+++ b/docs/devGuide/maintainerGuide.md
@@ -115,13 +115,11 @@ $ git commit -m 'Update vue-strap version to v2.0.1-markbind.XYZ'
 2. Rebuild the test files.
 
 ```
-$ cd test/functional/
+# on Unix
+$ npm run updatetest
 
-# for each test site
-$ cd <TEST_SITE_NAME>
-$ markbind build
-$ cp _site/* expected/
-$ cd ..
+# on Windows
+> npm run updatetestwin
 ```
 
 When rebuilding the expected test files, ensure that **only** the version number is updated. For example, this is correct:

--- a/package.json
+++ b/package.json
@@ -62,12 +62,14 @@
   },
   "scripts": {
     "csslint": "./node_modules/.bin/stylelint \"**/*.css\" \"!**/*.min.css\"",
+    "jest": "jest",
     "lint": "./node_modules/.bin/eslint .",
     "pretest": "npm run lint && npm run csslint",
     "pretestwin": "npm run lint && npm run csslint",
-    "testwin": "jest && cd test/functional && test.bat",
     "test": "jest && cd test/functional && ./test.sh",
-    "jest": "jest"
+    "testwin": "jest && cd test/functional && test.bat",
+    "updatetest": "cd test/functional && ./update.sh",
+    "updatetestwin": "cd test/functional && update.bat"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/test/functional/test.bat
+++ b/test/functional/test.bat
@@ -1,8 +1,6 @@
 @ECHO off
 
-set sites=test_site test_site_algolia_plugin
-
-for %%a in (%sites%) do (
+for /f "tokens=* delims=" %%a in (test_sites) do (
 
     echo(
     echo Running %%a tests
@@ -17,9 +15,7 @@ for %%a in (%sites%) do (
     )
 )
 
-set sites_convert=test_site_convert
-
-for %%a in (%sites_convert%) do (
+for /f "tokens=* delims=" %%a in (test_convert_sites) do (
 
     echo(
     echo Running %%a tests

--- a/test/functional/test.sh
+++ b/test/functional/test.sh
@@ -21,35 +21,43 @@ done
 
 function cleanup_convert {
     # delete generated files
-    rm -rf "$site_convert"/_site
-    rm -rf "$site_convert"/non_markbind_site/_markbind "$site_convert"/non_markbind_site/_site
-    rm "$site_convert"/non_markbind_site/about.md "$site_convert"/non_markbind_site/index.md "$site_convert"/non_markbind_site/site.json
+    rm -rf $site_convert/_site
+    rm -rf $site_convert/non_markbind_site/_markbind $site_convert/non_markbind_site/_site
+    rm -f $site_convert/non_markbind_site/about.md $site_convert/non_markbind_site/index.md $site_convert/non_markbind_site/site.json
 }
-trap cleanup_convert EXIT
 
-declare -r site_convert="test_site_convert"
+for site_convert in $(cat test_convert_sites);
+do
+    # print site name
+    echo "Running $site_convert test"
 
-# print site name
-echo
-echo "Running $site_convert test"
+    # set cleanup trap
+    trap cleanup_convert EXIT
 
-# convert site
-node ../../index.js init "$site_convert"/non_markbind_site -c
+    # convert site
+    node ../../index.js init $site_convert/non_markbind_site -c
 
-# build site
-node ../../index.js build "$site_convert"/non_markbind_site
+    # build site
+    node ../../index.js build $site_convert/non_markbind_site
 
-# copy generated site
-cp -r "$site_convert"/non_markbind_site/_site "$site_convert"
+    # copy generated site
+    cp -r $site_convert/non_markbind_site/_site $site_convert
 
-# run our test script to compare html files
-node testUtil/test.js "$site_convert"
+    # run our test script to compare html files
+    node testUtil/test.js $site_convert
 
-if [ $? -ne 0 ]
-then
-    echo "Test result: $site FAILED"
-    exit 1
-fi
+    if [ $? -ne 0 ]
+    then
+        echo "Test result: $site_convert FAILED"
+        exit 1
+    fi
+
+    # cleanup generated files
+    cleanup_convert
+
+    # remove trap
+    trap - EXIT
+done
 
 # if there were no diffs
 echo "Test result: PASSED"

--- a/test/functional/test.sh
+++ b/test/functional/test.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-declare -a sites=("test_site" "test_site_algolia_plugin")
-
-for site in "${sites[@]}"
+for site in $(cat test_sites);
 do
     # print site name
     echo

--- a/test/functional/test_convert_sites
+++ b/test/functional/test_convert_sites
@@ -1,0 +1,1 @@
+test_site_convert

--- a/test/functional/test_sites
+++ b/test/functional/test_sites
@@ -1,0 +1,2 @@
+test_site
+test_site_algolia_plugin

--- a/test/functional/update.bat
+++ b/test/functional/update.bat
@@ -1,0 +1,33 @@
+@ECHO off
+
+for /f "tokens=* delims=" %%a in (test_sites) do (
+
+    echo(
+    echo Updating %%a
+
+    node ../../index.js build %%a
+
+    rmdir /s /q %%a\expected
+    xcopy /e /y /i /q %%a\_site %%a\expected
+)
+
+for /f "tokens=* delims=" %%a in (test_convert_sites) do (
+
+    echo(
+    echo Updating %%a
+
+    node ../../index.js init %%a\non_markbind_site -c
+
+    node ../../index.js build %%a\non_markbind_site
+
+    rmdir /s /q %%a\expected
+    xcopy /e /y /i /q %%a\non_markbind_site\_site %%a\expected
+
+    rmdir /s /q %%a\_site
+    rmdir /q %%a\non_markbind_site\_markbind
+    rmdir /s /q %%a\non_markbind_site\_site
+    del %%a\non_markbind_site\about.md %%a\non_markbind_site\index.md %%a\non_markbind_site\site.json
+)
+
+echo Updated all test sites
+exit /b %errorlevel%

--- a/test/functional/update.sh
+++ b/test/functional/update.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+for site in $(cat test_sites);
+do
+    # print site name
+    echo "Updating $site"
+
+    # build site
+    node ../../index.js build "$site"
+
+    # replace the expected folder with the newly generated files
+    rm -rf $site/expected
+    cp -r $site/_site $site/expected
+done
+
+function cleanup_convert {
+    # delete generated files
+    rm -rf $site_convert/_site
+    rm -rf $site_convert/non_markbind_site/_markbind $site_convert/non_markbind_site/_site
+    rm -f $site_convert/non_markbind_site/about.md $site_convert/non_markbind_site/index.md "$site_convert"/non_markbind_site/site.json
+}
+
+for site_convert in $(cat test_convert_sites);
+do
+    # print site name
+    echo "Updating $site_convert test"
+
+    # set cleanup trap
+    trap cleanup_convert EXIT
+
+    # convert site
+    node ../../index.js init $site_convert/non_markbind_site -c
+
+    # build site
+    node ../../index.js build $site_convert/non_markbind_site
+
+    # replace the expected folder with the newly generated files
+    rm -rf $site_convert/expected
+    cp -r $site_convert/non_markbind_site/_site $site_convert/expected
+
+    # cleanup generated files
+    cleanup_convert
+
+    # remove trap
+    trap - EXIT
+done
+
+echo "Updated all test sites"
+exit 0


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: workflow improvement

Resolves #761.

**What is the rationale for this request?**

Presently, developers have to update the expected output for the test sites by hand. As the number of test sites increase, rebuilding the test sites and updating the expected folders of each site becomes more unwieldy.

Being able to automatically updated the expected folders would help reduce the time spent on this process.

**What changes did you make? (Give an overview)**

- Moved declaration of test site directory names to a separate file to reduce duplication
- Add `update.sh` and `update.bat` which rebuilds all test sites and updates their expected folders.


**Is there anything you'd like reviewers to focus on?**

I don't have a Windows machine, so it would be great if a windows user can help to test both `test.bat` and `update.bat` to ensure they are behaving as expected 🙂 

**Testing instructions:**

Run `npm run updatetest` or `npm run updatetestwin`. All test sites should be rebuilt, and the output in `_site` should be copied over to `expected`.

**Proposed commit message: (wrap lines at 72 characters)**

I've split the PR into 2 commits, each with their own commit message. Do let me know if I should change them!