### PR TITLE
Support building and deploying from multiple json configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ language: node_js
 node_js:
   - '8'
 deploy:
-  provider: script
-  script: cd docs && ../index.js build && ../index.js deploy --travis
-  skip_cleanup: true
-  on:
-    repo: MarkBind/markbind
-    tags: true
-    condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+
+  # deploy on release, to markbind.org
+  - provider: script
+    script: cd docs && ../index.js build -s ug-site.json && ../index.js deploy -s ug-site.json --travis
+    skip_cleanup: true
+    on:
+      repo: MarkBind/markbind
+      tags: true
+      condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+
+  # deploy on any commit to master, to markbind.org/devdocs
+  - provider: script
+    script: cd docs && ../index.js build -s dg-site.json && ../index.js deploy -s dg-site.json --travis
+    skip_cleanup: true
+    on:
+      repo: MarkBind/markbind
 cache:
   directories:
     - node_modules

--- a/docs/_markbind/headers/header.md
+++ b/docs/_markbind/headers/header.md
@@ -3,10 +3,10 @@
   <navbar type="dark">
     <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand"><img src="{{baseUrl}}/images/logo-darkbackground.png" height="20" /></a>
     <li><a href="{{baseUrl}}/index.html" class="nav-link">HOME</a></li>
-    <li><a href="{{baseUrl}}/userGuide/index.html" class="nav-link">USER GUIDE</a></li>
+    <div tags="environment--ug"><li><a href="{{baseUrl}}/userGuide/index.html" class="nav-link">USER GUIDE</a></li></div>
+    <div tags="environment--dg"><li><a href="{{baseUrl}}/devGuide/index.html" class="nav-link">DEVELOPER GUIDE</a></li></div>
     <li><a href="{{baseUrl}}/showcase.html" class="nav-link">SHOWCASE</a></li>
     <li><a href="{{baseUrl}}/about.html" class="nav-link">ABOUT</a></li>
-    <li><a href="{{baseUrl}}/devGuide/index.html" class="nav-link">DEVELOPER GUIDE</a></li>
     <li>
       <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link"><md>:fab-github:</md></a>
     </li>

--- a/docs/dg-site.json
+++ b/docs/dg-site.json
@@ -1,0 +1,46 @@
+{
+  "baseUrl": "/devdocs",
+  "titlePrefix": "MarkBind",
+  "pages": [
+    {
+      "glob": "**/*.mbd"
+    },
+    {
+      "glob": "*.md"
+    },
+    {
+      "src": "index.md",
+      "searchable": "no"
+    },
+    {
+      "glob": "devGuide/*.md"
+    }
+  ],
+  "headingIndexingLevel": 6,
+  "ignore": [
+    "_markbind",
+    "_site/*",
+    "lib/*",
+    "*.json",
+    "*.md",
+    "*.mbd",
+    "*.mbdf",
+    "*.njk",
+    ".git/*",
+    "*.pptx",
+    "CNAME"
+  ],
+  "plugins" : [
+    "filterTags"
+  ],
+  "pluginsContext" : {
+    "filterTags" : {
+      "tags": ["environment--dg"]
+    }
+  },
+  "deploy": {
+    "message": "Dev Site Update.",
+    "repo": "https://github.com/MarkBind/devdocs.git",
+    "branch": "gh-pages"
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@
   footer: footer.md
 </frontmatter>
 
+<div tags="environment--ug">
+
 <h1 class="display-3"><md>**MarkBind**</md></h1>
 
 <span class="lead">
@@ -166,3 +168,19 @@ Installing MarkBind takes just one command. Creating a new MarkBind site too tak
 As MarkBind is also optimized for project documentation, it can easily [integrate with the workflow of a software project](userGuide/markBindInTheProjectWorkflow.html).
 
 <b-btn variant="primary" href="userGuide/">Get Started</b-btn>
+
+</div>
+
+<div tags="environment--dg">
+
+## Developer Guide
+
+<box type="warning">
+    If you are a user, please visit <a href="https://markbind.org">MarkBind.org</a> instead.
+</box>
+
+This is the latest Developer Guide for MarkBind.
+
+For contributors: please access the Developer Guide [here](devGuide/index.html)
+
+</div>

--- a/docs/ug-site.json
+++ b/docs/ug-site.json
@@ -26,9 +26,6 @@
     {
       "src": "userGuide/readerFacingFeatures.md",
       "searchable": "no"
-    },
-    {
-      "glob": "devGuide/*.md"
     }
   ],
   "plugins" : [
@@ -36,7 +33,7 @@
   ],
   "pluginsContext" : {
     "filterTags" : {
-      "tags": ["environment--ug", "environment--dg"]
+      "tags": ["environment--ug"]
     }
   },
   "headingIndexingLevel": 6,
@@ -50,10 +47,11 @@
     "*.mbdf",
     "*.njk",
     ".git/*",
-    "*.pptx",
-    "CNAME"
+    "*.pptx"
   ],
   "deploy": {
-    "message": "Site Update."
+    "message": "Site Update.",
+    "repo": "https://github.com/MarkBind/markbind.github.io.git",
+    "branch": "master"
   }
 }

--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -42,6 +42,9 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
 * `--baseUrl <base>`<br>
   Override the `baseUrl` property (read from the `site.json`) with the give `<base>` value.<br>
   {{ icon_example }} `--baseUrl staging`
+* `-s <file>`, `--site-config <file>`<br>
+  Specify the site config file (default: `site.json`)<br>
+  {{ icon_example }} `-s otherSite.json`
 
 **{{ icon_examples }}**
 * `markbind build`

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -18,7 +18,16 @@ Generic steps for deploying a MarkBind site:
 1. Set the [`baseUrl` property of the `site.json` file](siteConfiguration.html#baseUrl) to match the deploy location.
 1. (Optional) Use the [`markbind serve` command](cliCommands.html#serve-command) to stage the site locally and confirm the contents are as expected.
 1. Use the [`markbind build` command](cliCommands.html#build-command) to generate the site from source files. That command puts the generated site files in a directory named `_site` (you can change the output directory using parameters supplied to the command).
-1. Upload the site files to the Web server. The sections below explains how to automate this step for when deploying to some online platforms.
+1. Upload the site files to the Web server. The sections below explain how to automate this step if you are deploying to some online platforms.
+
+
+Steps for deploying multiple MarkBind sites:
+1. Create multiple `site.json` files. Ensure that the [`baseUrl` property of each `site.json` file](siteConfiguration.html#baseUrl) matches its deploy location.
+1. (Optional) Use the [`markbind serve -s <file>` command](cliCommands.html#serve-command) to stage each site locally and confirm the contents are as expected.
+1. For each site:
+    1. Use the [`markbind build -s <file>` command](cliCommands#build-command) to generate the site from source files.
+    1. Upload the site files to the Web server. The sections below explain how to automate this step if you are deploying to some online platforms.
+
 
 ## Deploying to Github Pages
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ program
   .action((userSpecifiedRoot, options) => {
     let rootFolder;
     try {
-      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
+      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot, options.siteConfig);
     } catch (err) {
       handleError(err);
     }
@@ -189,10 +189,11 @@ program
   .alias('d')
   .description('deploy the site to the repo\'s Github pages.')
   .option('-t, --travis [tokenVar]', 'deploy the site in Travis [GITHUB_TOKEN]')
+  .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
   .action((options) => {
     const rootFolder = path.resolve(process.cwd());
     const outputRoot = path.join(rootFolder, '_site');
-    new Site(rootFolder, outputRoot).deploy(options.travis)
+    new Site(rootFolder, outputRoot, undefined, undefined, options.siteConfig).deploy(options.travis)
       .then(() => {
         logger.info('Deployed!');
       })
@@ -205,20 +206,21 @@ program
   .alias('b')
   .option('--baseUrl [baseUrl]',
           'optional flag which overrides baseUrl in site.json, leave argument empty for empty baseUrl')
+  .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
   .description('build a website')
   .action((userSpecifiedRoot, output, options) => {
     // if --baseUrl contains no arguments (options.baseUrl === true) then set baseUrl to empty string
     const baseUrl = _.isBoolean(options.baseUrl) ? '' : options.baseUrl;
     let rootFolder;
     try {
-      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot);
+      rootFolder = cliUtil.findRootFolder(userSpecifiedRoot, options.siteConfig);
     } catch (err) {
       handleError(err);
     }
     const defaultOutputRoot = path.join(rootFolder, '_site');
     const outputFolder = output ? path.resolve(process.cwd(), output) : defaultOutputRoot;
     printHeader();
-    new Site(rootFolder, outputFolder)
+    new Site(rootFolder, outputFolder, undefined, undefined, options.siteConfig)
       .generate(baseUrl)
       .then(() => {
         logger.info('Build success!');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] New feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Follow-up from #793, fixes #833, fixes #832. Supersedes #799.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
MarkBind only supports building and deploying from site.json

As per [this comment](https://github.com/MarkBind/markbind/pull/793#issuecomment-478414584), it is useful to keep our user and developer guides
separate, as they are updated with different release cadences.
While the user guide should only be updated on release, the developer
guide needs to be up-to-date with each commit merged into master.

Thus, we require a mechanism to be able to build with different configurations for different deployments.

| Site | What to build | What to deploy | Where to deploy | Config File | Special | Mechanism |
| ------------- | ---------- | ------ | ----- | --------- | ------ | ---------- |
| markbind.org | UG only | UG only | markbind.github.io.git | ug-site.json | CNAME | Travis |
| markbind.org/devdocs | DG only | DG only | devdocs.git | dg-site.json | Ignore CNAME | Travis |
| Netlify Preview | UG and DG | - | - | site.json | Ignore CNAME | Netlify |
| PR Preview | UG and DG | - | - | site.json | Ignore CNAME | Netlify |

**What changes did you make? (Give an overview)**
* Update site.json to use the tags plugin, offering support for selectively deploying content based on tags/"environments".
* MarkBind now supports building from multiple json configs, and
* MarkBind now supports deploying from multiple json configs, so that we can build and deploy different versions to different sites.
* Added a new deployment command to our travis config to trigger a deployment to the developer site upon any commit to the master branch.
* Updated index.md to selectively show content of developer guide, user guide, or both, depending on deployment context.

**Is there anything you'd like reviewers to focus on?**
I've tested on the devdocs gh-pages. Looks fine :O
Please help me double-check my site.json and .travis.yml configurations - I don't want Site Update V2 :P

**Testing instructions:**
Create a fork(?) and test with Travis...

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
