### PR TITLE
Fix site-nav.css not being added when layout contains site nav

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -87,6 +87,9 @@ function Page(pageConfig) {
   this.keywords = {};
   this.navigableHeadings = {};
   this.pageSectionsHtml = {};
+
+  // Flag to indicate whether this page has a site nav
+  this.hasSiteNav = false;
 }
 
 /**
@@ -231,7 +234,7 @@ Page.prototype.prepareTemplateData = function () {
     markBindVersion: `MarkBind ${CLI_VERSION}`,
     pageNav: this.isPageNavigationSpecifierValid(),
     pageNavHtml: this.pageSectionsHtml[`#${PAGE_NAV_ID}`] || '',
-    siteNav: this.frontMatter.siteNav,
+    siteNav: this.hasSiteNav,
     siteNavHtml: this.pageSectionsHtml[`#${SITE_NAV_ID}`] || '',
     title: prefixedTitle,
     enableSearch: this.enableSearch,
@@ -575,12 +578,15 @@ Page.prototype.insertSiteNav = function (pageData) {
   // Retrieve Markdown file contents
   const siteNavPath = path.join(this.rootPath, siteNavFile);
   if (!fs.existsSync(siteNavPath)) {
+    this.hasSiteNav = false;
     return pageData;
   }
   const siteNavContent = fs.readFileSync(siteNavPath, 'utf8');
   if (siteNavContent === '') {
+    this.hasSiteNav = false;
     return pageData;
   }
+  this.hasSiteNav = true;
   // Set siteNav file as an includedFile
   this.includedFiles[siteNavPath] = true;
   // Map variables

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="STYLESHEET_LINK">
   <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
   <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
   <link rel="icon" href="/test_site/favicon.png">

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="STYLESHEET_LINK">
   <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
   <script src="/test_site/headFiles/overwriteLayoutScript.js"></script>
   <link rel="icon" href="/test_site/favicon.png">

--- a/test/functional/test_site_convert/expected/Home.html
+++ b/test/functional/test_site_convert/expected/Home.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 

--- a/test/functional/test_site_convert/expected/Page-1.html
+++ b/test/functional/test_site_convert/expected/Page-1.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 

--- a/test/functional/test_site_convert/expected/_Footer.html
+++ b/test/functional/test_site_convert/expected/_Footer.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 

--- a/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/test/functional/test_site_convert/expected/_Sidebar.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 

--- a/test/functional/test_site_convert/expected/about.html
+++ b/test/functional/test_site_convert/expected/about.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 

--- a/test/functional/test_site_convert/expected/index.html
+++ b/test/functional/test_site_convert/expected/index.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="markbind/css/github.min.css">
   <link rel="stylesheet" href="markbind/css/markbind.css">
   <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
 
 
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #528.

**What is the rationale for this request?**

When a page has a site nav specified in the layout, but not in the frontmatter, the site-nav.css file is not added to the site. This causes the styling of the side nav to break.

**What changes did you make? (Give an overview)**

- [x] Abstract method to get the path to the site nav file from `insertSiteNav`
- [x] Use abstracted method `getSiteNavPath` to check if a site nav is specified in either layout or frontmatter when preparing template data

**Is there anything you'd like reviewers to focus on?**

~~By default, the default layout contains a blank `navigation.md` file. The site-nav.css file is thus added even though the `navigation.md` file is empty - is this behaviour okay?~~

After updating the logic to use a flag instead, we are able to avoid this issue as we only update the flag after checking that the file is not empty.

**Testing instructions:**

See instructions in #739. The site nav should be styled correctly.

**Proposed commit message: (wrap lines at 72 characters)**

When passing data to the page template, the siteNav variable only checks
for the existence of the site nav specified in the frontmatter. The
site-nav.css file is thus only added when the site nav is specified in
the frontmatter.

When a page has a layout with a site nav, but no site nav is specified
in the frontmatter, the site-nav.css file is not added, which causes the
styling of the site nav to break.

Let's update the logic when forming template data to check for the
existence of a site nav in the template when determining the value of
the siteNav variable.