### PR TITLE
Use Sets instead of Javascript objects for Site.baseUrlMap, builtFiles, Page.includedFiles

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -110,9 +110,9 @@ function calculateNewBaseUrl(filePath, root, lookUp) {
       return undefined;
     }
     const parent = path.dirname(file);
-    if (lookUp[parent] && result.length === 1) {
+    if (lookUp.has(parent) && result.length === 1) {
       return path.relative(root, result[0]);
-    } else if (lookUp[parent]) {
+    } else if (lookUp.has(parent)) {
       return calculate(parent, [parent]);
     }
     return calculate(parent, result);

--- a/src/Page.js
+++ b/src/Page.js
@@ -945,12 +945,11 @@ Page.prototype.resolveDependency = function (dependency, builtFiles) {
     const resultDir = path.dirname(path.resolve(this.resultPath, path.relative(this.sourcePath, file)));
     const resultPath = path.join(resultDir, FsUtil.setExtension(path.basename(file), '._include_.html'));
 
-    if (builtFiles[resultPath]) {
+    if (builtFiles.has(resultPath)) {
       return resolve();
     }
 
-    // eslint-disable-next-line no-param-reassign
-    builtFiles[resultPath] = true;
+    builtFiles.add(resultPath);
 
     /*
      * We create a local instance of Markbind for an empty dynamicIncludeSrc

--- a/src/Page.js
+++ b/src/Page.js
@@ -83,7 +83,7 @@ function Page(pageConfig) {
   this.headFileTopContent = '';
   this.headings = {};
   this.headingIndexingLevel = pageConfig.headingIndexingLevel;
-  this.includedFiles = {};
+  this.includedFiles = new Set();
   this.keywords = {};
   this.navigableHeadings = {};
   this.pageSectionsHtml = {};
@@ -453,9 +453,7 @@ Page.prototype.concatenateHeadingsAndKeywords = function () {
  * @param dependencies array of maps of the external dependency and where it is included
  */
 Page.prototype.collectIncludedFiles = function (dependencies) {
-  dependencies.forEach((dependency) => {
-    this.includedFiles[dependency.to] = true;
-  });
+  dependencies.forEach(dependency => this.includedFiles.add(dependency.to));
 };
 
 /**
@@ -528,7 +526,7 @@ Page.prototype.insertHeaderFile = function (pageData) {
   // Retrieve Markdown file contents
   const headerContent = fs.readFileSync(headerPath, 'utf8');
   // Set header file as an includedFile
-  this.includedFiles[headerPath] = true;
+  this.includedFiles.add(headerPath);
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -555,7 +553,7 @@ Page.prototype.insertFooterFile = function (pageData) {
   // Retrieve Markdown file contents
   const footerContent = fs.readFileSync(footerPath, 'utf8');
   // Set footer file as an includedFile
-  this.includedFiles[footerPath] = true;
+  this.includedFiles.add(footerPath);
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -588,7 +586,7 @@ Page.prototype.insertSiteNav = function (pageData) {
   }
   this.hasSiteNav = true;
   // Set siteNav file as an includedFile
-  this.includedFiles[siteNavPath] = true;
+  this.includedFiles.add(siteNavPath);
   // Map variables
   const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
   const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -723,7 +721,7 @@ Page.prototype.collectHeadFiles = function (baseUrl, hostBaseUrl) {
     }
     const headFileContent = fs.readFileSync(headFilePath, 'utf8');
     // Set head file as an includedFile
-    this.includedFiles[headFilePath] = true;
+    this.includedFiles.add(headFilePath);
     // Map variables
     const newBaseUrl = calculateNewBaseUrl(this.sourcePath, this.rootPath, this.baseUrlMap) || '';
     const userDefinedVariables = this.userDefinedVariablesMap[path.join(this.rootPath, newBaseUrl)];
@@ -781,8 +779,7 @@ Page.prototype.collectAllPageSections = function () {
 };
 
 Page.prototype.generate = function (builtFiles) {
-  this.includedFiles = {};
-  this.includedFiles[this.sourcePath] = true;
+  this.includedFiles = new Set([this.sourcePath]);
 
   const markbinder = new MarkBind({
     errorHandler: logger.error,

--- a/src/Site.js
+++ b/src/Site.js
@@ -1032,7 +1032,7 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
   }
   this._setTimestampVariable();
   this.pages.forEach((page) => {
-    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
+    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
       // eslint-disable-next-line no-param-reassign
       page.userDefinedVariablesMap = this.userDefinedVariablesMap;
       processingFiles.push(page.generate(builtFiles)
@@ -1064,7 +1064,7 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
 Site.prototype.updateSiteData = function (filePaths) {
   const generateForAllPages = filePaths === undefined;
   this.pages.forEach((page) => {
-    if (generateForAllPages || filePaths.some(filePath => page.includedFiles[filePath])) {
+    if (generateForAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
       page.collectHeadingsAndKeywords();
       page.concatenateHeadingsAndKeywords();
     }

--- a/src/Site.js
+++ b/src/Site.js
@@ -960,7 +960,7 @@ Site.prototype.generatePages = function () {
   // Render the final rendered page to the output folder.
   const { baseUrl, faviconPath } = this.siteConfig;
   const addressablePages = this.addressablePages || [];
-  const builtFiles = {};
+  const builtFiles = new Set();
   const processingFiles = [];
 
   let faviconUrl;
@@ -1024,7 +1024,7 @@ Site.prototype.generatePages = function () {
  * @param filePaths array of paths corresponding to files that have changed
  */
 Site.prototype.regenerateAffectedPages = function (filePaths) {
-  const builtFiles = {};
+  const builtFiles = new Set();
   const processingFiles = [];
   const shouldRebuildAllPages = this.collectUserDefinedVariablesMapIfNeeded(filePaths) || this.forceReload;
   if (shouldRebuildAllPages) {

--- a/src/Site.js
+++ b/src/Site.js
@@ -195,7 +195,7 @@ function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfig
 
   // Other properties
   this.addressablePages = [];
-  this.baseUrlMap = {};
+  this.baseUrlMap = new Set();
   this.forceReload = forceReload;
   this.onePagePath = onePagePath;
   this.plugins = {};
@@ -652,11 +652,7 @@ Site.prototype.collectBaseUrl = function () {
       .filter(x => x.endsWith(this.siteConfigPath))
       .map(x => path.resolve(this.rootPath, x));
 
-  this.baseUrlMap = candidates.reduce((pre, now) => {
-    // eslint-disable-next-line no-param-reassign
-    pre[path.dirname(now)] = true;
-    return pre;
-  }, {});
+  this.baseUrlMap = new Set(candidates.map(candidate => path.dirname(candidate)));
 
   return Promise.resolve();
 };
@@ -671,7 +667,7 @@ Site.prototype.collectUserDefinedVariablesMap = function () {
   const iconsMap = getIconsMap();
   const markbindVariable = { MarkBind: MARKBIND_LINK_HTML };
 
-  Object.keys(this.baseUrlMap).forEach((base) => {
+  this.baseUrlMap.forEach((base) => {
     const userDefinedVariables = {};
     Object.assign(userDefinedVariables, iconsMap, markbindVariable);
 

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -46,9 +46,9 @@ function calculateNewBaseUrls(filePath, root, lookUp) {
       return { relative: path.relative(root, root), parent: root };
     }
     const parent = path.dirname(file);
-    if (lookUp[parent] && result.length === 1) {
+    if (lookUp.has(parent) && result.length === 1) {
       return { relative: path.relative(parent, result[0]), parent };
-    } else if (lookUp[parent]) {
+    } else if (lookUp.has(parent)) {
       return calculate(parent, [parent]);
     }
     return calculate(parent, result);

--- a/test/unit/Page.test.js
+++ b/test/unit/Page.test.js
@@ -4,19 +4,19 @@ test('Page#collectIncludedFiles collects included files from 1 dependency object
   const page = new Page({});
   page.collectIncludedFiles([{ to: 'somewhere' }]);
 
-  expect(page.includedFiles).toEqual({ somewhere: true });
+  expect(page.includedFiles).toEqual(new Set(['somewhere']));
 });
 
 test('Page#collectIncludedFiles ignores other keys in dependency', () => {
   const page = new Page({});
   page.collectIncludedFiles([{ to: 'somewhere', from: 'somewhere else' }]);
 
-  expect(page.includedFiles).toEqual({ somewhere: true });
+  expect(page.includedFiles).toEqual(new Set(['somewhere']));
 });
 
 test('Page#collectIncludedFiles collects nothing', () => {
   const page = new Page({});
   page.collectIncludedFiles([]);
 
-  expect(page.includedFiles).toEqual({});
+  expect(page.includedFiles).toEqual(new Set());
 });

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -207,11 +207,7 @@ test('Site baseurls are correct for sub nested subsites', async () => {
   };
   fs.vol.fromJSON(json, '');
 
-  const baseUrlMapExpected = {};
-  baseUrlMapExpected[path.resolve('')] = true;
-  baseUrlMapExpected[path.resolve('sub')] = true;
-  baseUrlMapExpected[path.resolve('sub/sub')] = true;
-  baseUrlMapExpected[path.resolve('otherSub/sub')] = true;
+  const baseUrlMapExpected = new Set(['', 'sub', 'sub/sub', 'otherSub/sub'].map(url => path.resolve(url)));
 
   const site = new Site('./', '_site');
   await site.collectBaseUrl();

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -33,8 +33,7 @@ test('includeFile replaces <include> with <div>', async () => {
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -74,8 +73,7 @@ test('includeFile replaces <include src="exist.md" optional> with <div>', async 
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -111,8 +109,7 @@ test('includeFile replaces <include src="doesNotExist.md" optional> with empty <
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -151,8 +148,7 @@ test('includeFile replaces <include src="include.md#exists"> with <div>', async 
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -196,8 +192,7 @@ test('includeFile replaces <include src="include.md#exists" inline> with inline 
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -237,8 +232,7 @@ test('includeFile replaces <include src="include.md#exists" trim> with trimmed c
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -281,8 +275,7 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind({
     errorHandler: (e) => {
@@ -325,8 +318,7 @@ test('includeFile replaces <include src="include.md#exists" optional> with <div>
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -366,8 +358,7 @@ test('includeFile replaces <include src="include.md#doesNotExist" optional> with
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -411,8 +402,7 @@ test('includeFile detects cyclic references for static cyclic includes', async (
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const expectedErrorMessage = [
     'Cyclic reference detected.',
@@ -462,8 +452,7 @@ test('includeFile processes successfully for dynamic cyclic includes', async () 
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[ROOT_PATH] = true;
+  const baseUrlMap = new Set([ROOT_PATH]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -502,8 +491,7 @@ test('includeFile replaces <include dynamic> with <panel>', async () => {
   };
 
   fs.vol.fromJSON(json, '');
-  const baseUrlMap = {};
-  baseUrlMap[rootPath] = true;
+  const baseUrlMap = new Set([rootPath]);
 
   const markbinder = new MarkBind();
   const result = await markbinder.includeFile(indexPath, {
@@ -535,8 +523,7 @@ test('renderFile converts markdown headers to <h1>', async () => {
 
   fs.vol.fromJSON(json, '');
 
-  const baseUrlMap = {};
-  baseUrlMap[rootPath] = true;
+  const baseUrlMap = new Set([rootPath]);
 
   const result = await markbinder.renderFile(indexPath, {
     baseUrlMap,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [x] Other, please explain: Coding style "fix"

Resolves #772

**What is the rationale for this request?**

Sets are a more idiomatic way of keeping track of present items.

**What changes did you make? (Give an overview)**

Previously, an object was used:
`object[key] = true` if key exists
and
`object[key]` to check if the key exists

Now, sets are used:
`set.add(key)` if key exists
and
`set.has(key)` to check if the the key exists