### PR TITLE
Add npm script that runs linters with the --fix tag

### DIFF
--- a/docs/devGuide/devGuide.md
+++ b/docs/devGuide/devGuide.md
@@ -202,6 +202,12 @@ You can add the `--fix` flag to correct any fixable style errors.
 $ ./node_modules/.bin/eslint . --fix
 ```
 
+You may also correct fixable style errors for both JavaScript and CSS, by running this npm script
+
+```
+$ npm run autolint
+```
+
 #### Integration with editors
 
 ESLint has [integrations with popular editors](https://eslint.org/docs/user-guide/integrations). They offer features such as "fix errors on save", which will make developement more convenient.

--- a/package.json
+++ b/package.json
@@ -61,9 +61,12 @@
     "url": "https://github.com/MarkBind/markbind.git"
   },
   "scripts": {
-    "csslint": "./node_modules/.bin/stylelint \"**/*.css\" \"!**/*.min.css\"",
+    "autolint": "npm run lintfix && npm run csslintfix",
+    "csslint": "./node_modules/.bin/stylelint **/*.css !**/*.min.css",
+    "csslintfix": "./node_modules/.bin/stylelint **/*.css !**/*.min.css --fix",
     "jest": "jest",
     "lint": "./node_modules/.bin/eslint .",
+    "lintfix": "./node_modules/.bin/eslint . --fix",
     "pretest": "npm run lint && npm run csslint",
     "pretestwin": "npm run lint && npm run csslint",
     "test": "jest && cd test/functional && ./test.sh",


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: DevOps/QoL

Fixes #856  

**Rationale**
QoL script for devs to save time

**Changes**
Add npm script that runs eslint and stylelint with the `--fix` tag

**Testing Instructions**
1. Check that some of the project files contains errors that can be fixed by linters - [eslint](https://eslint.org/docs/user-guide/command-line-interface#--fix-type), [stylelint](https://stylelint.io/user-guide/rules/)
2. Run `npm run autolint`
3. The errors from step 1 should be gone