### PR TITLE
Make Site.js default layout comply with eslint

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -167,7 +167,8 @@ const TOP_NAV_DEFAULT = '<header><navbar placement="top" type="inverse">\n'
   + '  </li>\n'
   + '</navbar></header>';
 
-const LAYOUT_SCRIPTS_DEFAULT = 'MarkBind.afterSetup(() => {\n'
+const LAYOUT_SCRIPTS_DEFAULT = '// eslint-disable-next-line no-undef\n'
+  + 'MarkBind.afterSetup(() => {\n'
   + '  // Include code to be called after MarkBind setup here.\n'
   + '});\n';
 

--- a/test/unit/utils/data.js
+++ b/test/unit/utils/data.js
@@ -6,7 +6,8 @@ module.exports.LAYOUT_FILES_DEFAULT = [
   'styles.css',
 ];
 
-module.exports.LAYOUT_SCRIPTS_DEFAULT = 'MarkBind.afterSetup(() => {\n'
+module.exports.LAYOUT_SCRIPTS_DEFAULT = '// eslint-disable-next-line no-undef\n'
++ 'MarkBind.afterSetup(() => {\n'
 + '  // Include code to be called after MarkBind setup here.\n'
 + '});\n';
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

- [x] Bug fix

Resolves #840 

**What is the rationale for this request?**
Default layout in Site.js is not compliant with MarkBind's eslint rules.

**What changes did you make? (Give an overview)**
Add a comment disabling the rule
