### PR TITLE
Remove anchor generation dependency on indexing level

### DIFF
--- a/src/plugins/default/markbind-plugin-anchors.js
+++ b/src/plugins/default/markbind-plugin-anchors.js
@@ -2,39 +2,24 @@ const cheerio = module.parent.require('cheerio');
 const md = require('./../../lib/markbind/src/lib/markdown-it');
 
 const ANCHOR_HTML = '<a class="fa fa-anchor" href="#"></a>';
-
-/**
- * Generates a heading selector based on the indexing level
- * @param headingIndexingLevel to generate
- */
-function generateHeadingSelector(headingIndexingLevel) {
-  let headingsSelector = 'h1';
-  for (let i = 2; i <= headingIndexingLevel; i += 1) {
-    headingsSelector += `, h${i}`;
-  }
-  return headingsSelector;
-}
-
+const HEADER_TAGS = 'h1, h2, h3, h4, h5, h6';
 /**
  * Adds anchor links to headers
  */
 module.exports = {
-  postRender: (content, pluginContext, frontMatter, pageConfig) => {
+  postRender: (content) => {
     const $ = cheerio.load(content, { xmlMode: false });
-    if (pageConfig.headingIndexingLevel > 0) {
-      const headingsSelector = generateHeadingSelector(pageConfig.headingIndexingLevel);
-      $(headingsSelector).each((i, heading) => {
-        $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
-      });
-      $('panel[header]').each((i, panel) => {
-        const panelHeading = cheerio.load(md.render(panel.attribs.header), { xmlMode: false });
-        if (panelHeading(headingsSelector).length >= 1) {
-          const headingId = $(panelHeading(headingsSelector)[0]).attr('id');
-          const anchorIcon = ANCHOR_HTML.replace(/"/g, "'").replace('#', `#${headingId}`);
-          $(panel).attr('header', `${$(panel).attr('header')}${anchorIcon}`);
-        }
-      });
-    }
+    $(HEADER_TAGS).each((i, heading) => {
+      $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
+    });
+    $('panel[header]').each((i, panel) => {
+      const panelHeading = cheerio.load(md.render(panel.attribs.header), { xmlMode: false });
+      if (panelHeading(HEADER_TAGS).length >= 1) {
+        const headingId = $(panelHeading(HEADER_TAGS)[0]).attr('id');
+        const anchorIcon = ANCHOR_HTML.replace(/"/g, "'").replace('#', `#${headingId}`);
+        $(panel).attr('header', `${$(panel).attr('header')}${anchorIcon}`);
+      }
+    });
     return $.html();
   },
 };

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -456,7 +456,7 @@ specification that specifies how the product will address the requirements. </sp
         </div>
         <h1 id="test-search-indexing">Test search indexing<a class="fa fa-anchor" href="#test-search-indexing"></a></h1>
         <h2 class="no-index" id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed">Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed<a class="fa fa-anchor" href="#level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed"></a></h2>
-        <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed</h6>
+        <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed<a class="fa fa-anchor" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed"></a></h6>
       </div>
       <nav id="page-nav" class="navbar navbar-light bg-transparent">
         <div class="position-sticky position-top spacer-top viewport-height-90 scrollable slim-scroll">

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -213,6 +213,33 @@
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
       "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+    },
+    {
+      "headings": {
+        "should-have-anchor": "should have anchor",
+        "should-have-anchor-7": "should have anchor",
+        "should-have-anchor-8": "should have anchor",
+        "should-have-anchor-9": "should have anchor",
+        "should-have-anchor-10": "should have anchor",
+        "should-have-anchor-19": "should have anchor",
+        "should-have-anchor-20": "should have anchor",
+        "should-have-anchor-21": "should have anchor",
+        "should-have-anchor-22": "should have anchor",
+        "root-file": "Root file",
+        "should-have-anchor-2": "should have anchor",
+        "should-have-anchor-3": "should have anchor",
+        "should-have-anchor-4": "should have anchor",
+        "included-file": "Included File",
+        "should-have-anchor-13": "should have anchor",
+        "should-have-anchor-14": "should have anchor",
+        "should-have-anchor-15": "should have anchor",
+        "should-have-anchor-16": "should have anchor"
+      },
+      "title": "Anchor Generation Test",
+      "src": "testAnchorGeneration.md",
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
     }
   ]
 }

--- a/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/test/functional/test_site/expected/testAnchorGeneration.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta name="default-head-top">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="generator" content="MarkBind 2.4.1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Anchor Generation Test</title>
+  <link rel="stylesheet" href="markbind/css/bootstrap.min.css">
+  <link rel="stylesheet" href="markbind/css/bootstrap-vue.min.css">
+  <link rel="stylesheet" href="markbind/fontawesome/css/all.min.css">
+  <link rel="stylesheet" href="markbind/glyphicons/css/bootstrap-glyphicons.min.css">
+  <link rel="stylesheet" href="markbind/css/github.min.css">
+  <link rel="stylesheet" href="markbind/css/markbind.css">
+  <link rel="stylesheet" href="STYLESHEET_LINK">
+  <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+
+
+  <meta name="default-head-bottom">
+  <link rel="icon" href="/test_site/favicon.png">
+</head>
+
+<body>
+  <div id="app">
+    <div id="flex-body">
+      <div id="content-wrapper">
+        <h1 id="root-file">Root file<a class="fa fa-anchor" href="#root-file"></a></h1>
+        <h1 id="should-have-anchor">should have anchor<a class="fa fa-anchor" href="#should-have-anchor"></a></h1>
+        <h2 id="should-have-anchor-2">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-2"></a></h2>
+        <h3 id="should-have-anchor-3">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-3"></a></h3>
+        <h4 id="should-have-anchor-4">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-4"></a></h4>
+        <h5 id="should-have-anchor-5">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-5"></a></h5>
+        <h6 id="should-have-anchor-6">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-6"></a></h6>
+        <panel header="#### should have anchor<a class='fa fa-anchor' href='#should-have-anchor'></a>">
+          Lorem ipsum
+        </panel>
+        <panel header="Collapsed">
+          <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
+          <h1 id="should-not-have-anchor">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor"></a></h1>
+          <h2 id="should-not-have-anchor-2">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-2"></a></h2>
+          <h3 id="should-not-have-anchor-3">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-3"></a></h3>
+          <h4 id="should-not-have-anchor-4">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-4"></a></h4>
+          <h5 id="should-not-have-anchor-5">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-5"></a></h5>
+          <h6 id="should-not-have-anchor-6">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-6"></a></h6>
+        </panel>
+        <panel header="Expanded" expanded="">
+          <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
+          <h1 id="should-have-anchor-7">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-7"></a></h1>
+          <h2 id="should-have-anchor-8">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-8"></a></h2>
+          <h3 id="should-have-anchor-9">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-9"></a></h3>
+          <h4 id="should-have-anchor-10">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-10"></a></h4>
+          <h5 id="should-have-anchor-11">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-11"></a></h5>
+          <h6 id="should-have-anchor-12">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-12"></a></h6>
+        </panel>
+        <hr>
+        <div>
+          <h1 id="included-file">Included File<a class="fa fa-anchor" href="#included-file"></a></h1>
+          <br>
+          <h1 id="should-have-anchor-13">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-13"></a></h1>
+          <h2 id="should-have-anchor-14">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-14"></a></h2>
+          <h3 id="should-have-anchor-15">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-15"></a></h3>
+          <h4 id="should-have-anchor-16">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-16"></a></h4>
+          <h5 id="should-have-anchor-17">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-17"></a></h5>
+          <h6 id="should-have-anchor-18">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-18"></a></h6>
+          <panel header="#### should have anchor<a class='fa fa-anchor' href='#should-have-anchor'></a>">
+            Lorem ipsum
+          </panel>
+          <panel header="Collapsed">
+            <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
+            <h1 id="should-not-have-anchor-7">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-7"></a></h1>
+            <h2 id="should-not-have-anchor-8">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-8"></a></h2>
+            <h3 id="should-not-have-anchor-9">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-9"></a></h3>
+            <h4 id="should-not-have-anchor-10">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-10"></a></h4>
+            <h5 id="should-not-have-anchor-11">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-11"></a></h5>
+            <h6 id="should-not-have-anchor-12">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-12"></a></h6>
+          </panel>
+          <panel header="Expanded" expanded="">
+            <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
+            <h1 id="should-have-anchor-19">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-19"></a></h1>
+            <h2 id="should-have-anchor-20">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-20"></a></h2>
+            <h3 id="should-have-anchor-21">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-21"></a></h3>
+            <h4 id="should-have-anchor-22">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-22"></a></h4>
+            <h5 id="should-have-anchor-23">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-23"></a></h5>
+            <h6 id="should-have-anchor-24">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-24"></a></h6>
+          </panel>
+        </div>
+      </div>
+    </div>
+    <footer>
+      <div class="text-center">
+        Default footer
+      </div>
+    </footer>
+  </div>
+</body>
+<script src="markbind/js/vue.min.js"></script>
+<script src="markbind/js/vue-strap.min.js"></script>
+<script src="markbind/js/bootstrap-utility.min.js"></script>
+<script src="markbind/js/polyfill.min.js"></script>
+<script src="markbind/js/bootstrap-vue.min.js"></script>
+<script>
+  const baseUrl = '/test_site'
+  const enableSearch = true
+</script>
+<script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
+<script>
+  alert("hello")
+</script>
+<script src="markbind/layouts/default/scripts.js"></script>
+
+</html>

--- a/test/functional/test_site/site.json
+++ b/test/functional/test_site/site.json
@@ -47,6 +47,10 @@
     {
       "src": "testAntiFOUCStyles.md",
       "title": "Hello World"
+    },
+    {
+      "src": "testAnchorGeneration.md",
+      "title": "Anchor Generation Test"
     }
   ],
   "ignore": [

--- a/test/functional/test_site/sub_site/testAnchorGenerationInclude.md
+++ b/test/functional/test_site/sub_site/testAnchorGenerationInclude.md
@@ -1,0 +1,38 @@
+# Included File
+<br>
+
+# should have anchor
+## should have anchor
+### should have anchor
+#### should have anchor
+##### should have anchor
+###### should have anchor
+
+
+<panel header="#### should have anchor">
+Lorem ipsum
+</panel>
+
+
+<panel header="Collapsed">
+    
+Headings in a collapsed-by-default panel should **not** have anchors
+# should not have anchor
+## should not have anchor
+### should not have anchor
+#### should not have anchor
+##### should not have anchor
+###### should not have anchor
+</panel>
+
+
+<panel header="Expanded" expanded>
+    
+Headings in a expanded-by-default panel **should** have anchors
+# should have anchor
+## should have anchor
+### should have anchor
+#### should have anchor
+##### should have anchor
+###### should have anchor
+</panel>

--- a/test/functional/test_site/testAnchorGeneration.md
+++ b/test/functional/test_site/testAnchorGeneration.md
@@ -1,0 +1,44 @@
+<frontmatter>
+  title: "Anchor Generation Test"
+</frontmatter>
+
+# Root file
+
+# should have anchor
+## should have anchor
+### should have anchor
+#### should have anchor
+##### should have anchor
+###### should have anchor
+
+<panel header="#### should have anchor">
+Lorem ipsum
+</panel>
+
+
+<panel header="Collapsed">
+    
+Headings in a collapsed-by-default panel should **not** have anchors
+# should not have anchor
+## should not have anchor
+### should not have anchor
+#### should not have anchor
+##### should not have anchor
+###### should not have anchor
+</panel>
+
+
+<panel header="Expanded" expanded>
+    
+Headings in a expanded-by-default panel **should** have anchors
+# should have anchor
+## should have anchor
+### should have anchor
+#### should have anchor
+##### should have anchor
+###### should have anchor
+</panel>
+
+
+---
+<include src="sub_site/testAnchorGenerationInclude.md" />


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Bug fix

Fixes #775 and fixes #776 

**What is the rationale for this request?**
Anchors were only generated if the indexing level was greater than the
heading level, resulting in missing anchors and inconsistent behaviour

**What changes did you make? (Give an overview)**
Removed check for `headingIndexingLevel` 
Anchors are generated for all heading tags, except those hidden in panels
Added test pages

**Is there anything you'd like reviewers to focus on?**
There's currently a bug due to how vue handles collapsing panels that make anchors in panels disappear after collapsing and uncollapsing the panel.

**Testing instructions:**
1. Access test_site/testAnchorGeneration.html
2. Check that every heading labeled "should have anchor" indeed have anchors
3. Check that heading s  explicitly labeled "should not have anchor" do not have anchors

**Proposed commit message: (wrap lines at 72 characters)**
Anchor generation was dependent on the heading indexing level as 
defined in site.json, which resulted in missing anchors for some
headings.

Let's decouple anchor generation from heading indexing level, by
enabling anchor generation for all headings regardless of heading 
indexing level.