### PR TITLE
Change page and site nav border line to follow its content length

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -115,23 +115,24 @@ footer {
 
 /* Side Navigation menus */
 
-.site-nav-spacer {
-    /* This class is to ensure adequate spacing of contents from the top and
-    sides of the site nav */
+.border-left-grey {
+    border-left: 1px solid lightgrey;
+}
+
+.border-right-grey {
+    border-right: 1px solid lightgrey;
+}
+
+.nav-inner {
+    /* This class is used in both site and page navigation menus,
+       specifically for the sticky container to ensure adequate
+       spacing between itself and the boundaries of the menus
+     */
+    max-height: 90vh;
+    overflow-y: auto;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 1rem;
-}
-
-.scrollable {
-    overflow-y: auto;
-}
-
-.viewport-height-90 {
-    max-height: 90vh;
-}
-
-.position-top {
     top: 0;
 }
 

--- a/asset/css/page-nav.css
+++ b/asset/css/page-nav.css
@@ -1,10 +1,10 @@
 /* Page navigation */
 
 #page-nav {
-    border-left: solid 1px lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -2,12 +2,10 @@
 
 #site-nav {
     background: white;
-    border-right: 1px solid lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/src/Page.js
+++ b/src/Page.js
@@ -693,7 +693,7 @@ Page.prototype.buildPageNav = function () {
     const pageNavHeadingHTML = this.generatePageNavHeadingHtml();
     this.pageSectionsHtml[`#${PAGE_NAV_ID}`] = htmlBeautify(
       `<nav id="${PAGE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
-      + '<div class="position-sticky position-top spacer-top viewport-height-90 scrollable slim-scroll">\n'
+      + '<div class="border-left-grey nav-inner position-sticky slim-scroll">\n'
       + `${pageNavTitleHtml}\n`
       + '<nav class="nav nav-pills flex-column my-0 small no-flex-wrap">\n'
       + `${pageNavHeadingHTML}\n`

--- a/src/Page.js
+++ b/src/Page.js
@@ -606,7 +606,7 @@ Page.prototype.insertSiteNav = function (pageData) {
   }
   // Wrap sections
   const wrappedSiteNav = `<nav id="${SITE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
-    + '<div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">'
+    + '<div class="border-right-grey nav-inner position-sticky slim-scroll">'
     + `${siteNavDataSelector.html()}\n`
     + '</div>\n'
     + '</nav>';

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -45,7 +45,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">
               <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation"></a></h2>
@@ -459,7 +459,7 @@ specification that specifies how the product will address the requirements. </sp
         <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed</h6>
       </div>
       <nav id="page-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top spacer-top viewport-height-90 scrollable slim-scroll">
+        <div class="border-left-grey nav-inner position-sticky slim-scroll">
           <a class="navbar-brand page-nav-title" href="#">Testing Page Navigation</a>
           <nav class="nav nav-pills flex-column my-0 small no-flex-wrap">
             <a class="nav-link py-1" href="#variables-that-reference-another-variable">Variables that reference another variable&#x200E;</a>

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -115,23 +115,24 @@ footer {
 
 /* Side Navigation menus */
 
-.site-nav-spacer {
-    /* This class is to ensure adequate spacing of contents from the top and
-    sides of the site nav */
+.border-left-grey {
+    border-left: 1px solid lightgrey;
+}
+
+.border-right-grey {
+    border-right: 1px solid lightgrey;
+}
+
+.nav-inner {
+    /* This class is used in both site and page navigation menus,
+       specifically for the sticky container to ensure adequate
+       spacing between itself and the boundaries of the menus
+     */
+    max-height: 90vh;
+    overflow-y: auto;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 1rem;
-}
-
-.scrollable {
-    overflow-y: auto;
-}
-
-.viewport-height-90 {
-    max-height: 90vh;
-}
-
-.position-top {
     top: 0;
 }
 

--- a/test/functional/test_site/expected/markbind/css/page-nav.css
+++ b/test/functional/test_site/expected/markbind/css/page-nav.css
@@ -1,10 +1,10 @@
 /* Page navigation */
 
 #page-nav {
-    border-left: solid 1px lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/test/functional/test_site/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site/expected/markbind/css/site-nav.css
@@ -2,12 +2,10 @@
 
 #site-nav {
     background: white;
-    border-right: 1px solid lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[Layout Nav]</li>
           </ul>

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -26,7 +26,7 @@
   <div id="app">
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2"><a href="/test_site_algolia_plugin/index.html" class="site-nav__a current">Home <span aria-hidden="true" class="glyphicon glyphicon-home"></span></a></li>
           </ul>

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -115,23 +115,24 @@ footer {
 
 /* Side Navigation menus */
 
-.site-nav-spacer {
-    /* This class is to ensure adequate spacing of contents from the top and
-    sides of the site nav */
+.border-left-grey {
+    border-left: 1px solid lightgrey;
+}
+
+.border-right-grey {
+    border-right: 1px solid lightgrey;
+}
+
+.nav-inner {
+    /* This class is used in both site and page navigation menus,
+       specifically for the sticky container to ensure adequate
+       spacing between itself and the boundaries of the menus
+     */
+    max-height: 90vh;
+    overflow-y: auto;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 1rem;
-}
-
-.scrollable {
-    overflow-y: auto;
-}
-
-.viewport-height-90 {
-    max-height: 90vh;
-}
-
-.position-top {
     top: 0;
 }
 

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/page-nav.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/page-nav.css
@@ -1,10 +1,10 @@
 /* Page navigation */
 
 #page-nav {
-    border-left: solid 1px lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
@@ -2,12 +2,10 @@
 
 #site-nav {
     background: white;
-    border-right: 1px solid lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/test/functional/test_site_convert/expected/Home.html
+++ b/test/functional/test_site_convert/expected/Home.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/Page-1.html
+++ b/test/functional/test_site_convert/expected/Page-1.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/_Footer.html
+++ b/test/functional/test_site_convert/expected/_Footer.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/test/functional/test_site_convert/expected/_Sidebar.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/about.html
+++ b/test/functional/test_site_convert/expected/about.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/index.html
+++ b/test/functional/test_site_convert/expected/index.html
@@ -37,7 +37,7 @@
     </header>
     <div id="flex-body">
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
-        <div class="position-sticky position-top site-nav-spacer viewport-height-90 scrollable slim-scroll">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="px-0 site-nav-list">
             <li class="mt-2">[[Home]]</li>
             <li class="mt-2">[[Page-1]]</li>

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -115,23 +115,24 @@ footer {
 
 /* Side Navigation menus */
 
-.site-nav-spacer {
-    /* This class is to ensure adequate spacing of contents from the top and
-    sides of the site nav */
+.border-left-grey {
+    border-left: 1px solid lightgrey;
+}
+
+.border-right-grey {
+    border-right: 1px solid lightgrey;
+}
+
+.nav-inner {
+    /* This class is used in both site and page navigation menus,
+       specifically for the sticky container to ensure adequate
+       spacing between itself and the boundaries of the menus
+     */
+    max-height: 90vh;
+    overflow-y: auto;
     padding-left: 20px;
     padding-right: 20px;
     padding-top: 1rem;
-}
-
-.scrollable {
-    overflow-y: auto;
-}
-
-.viewport-height-90 {
-    max-height: 90vh;
-}
-
-.position-top {
     top: 0;
 }
 

--- a/test/functional/test_site_convert/expected/markbind/css/page-nav.css
+++ b/test/functional/test_site_convert/expected/markbind/css/page-nav.css
@@ -1,10 +1,10 @@
 /* Page navigation */
 
 #page-nav {
-    border-left: solid 1px lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;

--- a/test/functional/test_site_convert/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_convert/expected/markbind/css/site-nav.css
@@ -2,12 +2,10 @@
 
 #site-nav {
     background: white;
-    border-right: 1px solid lightgrey;
     display: block;
     flex: 0 0 auto;
     max-width: 300px;
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
     transition: 0.4s;
     width: 300px;
     -webkit-transition: 0.4s;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves #851 

**What changes did you make? (Give an overview)**
- Refactor side navigation menu CSS classes in `markbind.css`
- Change the borders rendered on the page and site nav to be on the content div instead of the main div.


**Is there anything you'd like reviewers to focus on?**
- Commit messages
- Comment for `nav-inner` class

**Testing instructions:**
- Open Netlify preview and check both site and page nav is working as intended, with border lines equal to their content length.