### PR TITLE
Remove undefined anchors

### DIFF
--- a/asset/js/setup.js
+++ b/asset/js/setup.js
@@ -21,10 +21,12 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
-    jQuery(heading).on('mouseleave',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    if (heading.id) {
+      jQuery(heading).on('mouseenter',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+      jQuery(heading).on('mouseleave',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    }
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {

--- a/src/plugins/default/markbind-plugin-anchors.js
+++ b/src/plugins/default/markbind-plugin-anchors.js
@@ -10,7 +10,9 @@ module.exports = {
   postRender: (content) => {
     const $ = cheerio.load(content, { xmlMode: false });
     $(HEADER_TAGS).each((i, heading) => {
-      $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
+      if ($(heading).attr('id')) {
+        $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
+      }
     });
     $('panel[header]').each((i, panel) => {
       const panelHeading = cheerio.load(md.render(panel.attribs.header), { xmlMode: false });

--- a/test/functional/test_site/expected/markbind/js/setup.js
+++ b/test/functional/test_site/expected/markbind/js/setup.js
@@ -21,10 +21,12 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
-    jQuery(heading).on('mouseleave',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    if (heading.id) {
+      jQuery(heading).on('mouseenter',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+      jQuery(heading).on('mouseleave',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    }
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {

--- a/test/functional/test_site_algolia_plugin/expected/markbind/js/setup.js
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/js/setup.js
@@ -21,10 +21,12 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
-    jQuery(heading).on('mouseleave',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    if (heading.id) {
+      jQuery(heading).on('mouseenter',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+      jQuery(heading).on('mouseleave',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    }
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {

--- a/test/functional/test_site_convert/expected/markbind/js/setup.js
+++ b/test/functional/test_site_convert/expected/markbind/js/setup.js
@@ -21,10 +21,12 @@ function flattenModals() {
 
 function setupAnchors() {
   jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    jQuery(heading).on('mouseenter',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
-    jQuery(heading).on('mouseleave',
-                       () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    if (heading.id) {
+      jQuery(heading).on('mouseenter',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'visible'));
+      jQuery(heading).on('mouseleave',
+                         () => jQuery(heading).find('.fa.fa-anchor').css('visibility', 'hidden'));
+    }
   });
   jQuery('.fa-anchor').each((index, anchor) => {
     jQuery(anchor).on('click', function () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #463 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The anchor plugin currently generates anchors for all headings. However, manually authored headings (e.g. `<h3>Non-markdown heading</h3>`) do not have IDs automatically generated for them. This results in the anchors for manual headings not having a valid `href` to jump to.

**What changes did you make? (Give an overview)**
- Change anchor generation to only headings with an ID 
- Change attaching event listeners to anchors with an ID

**Is there anything you'd like reviewers to focus on?**
- Commit message

**Testing instructions:**
1. Open Netlify Preview
2. The first "MarkBind" heading should not have any anchors hidden nor any `mouseenter` / `mouseleave` event listeners.
3. Other headings with ids should have valid anchors generated.
