### PR TITLE
Document header.md in page layouts

### DIFF
--- a/docs/userGuide/syntax/pageLayouts.mbdf
+++ b/docs/userGuide/syntax/pageLayouts.mbdf
@@ -3,6 +3,7 @@
 **A _layout_ is a set of page-tweaks that can be applied to a page (or group of pages) in one go.**
 
 A layout consists of the following files:
+1. A header (filename: `header.md`)
 1. A footer (filename: `footer.md`)
 1. Tweaks to the `<head>` (`head.md`)
 1. A site navigation menu (`navigation.md`)
@@ -20,6 +21,7 @@ To apply the layout, specify it as an attribute named `layout` in the `<frontmat
 ```
 <root>/_markbind/layouts/
                   └── chapterLayout/
+                        ├── header.md
                         ├── footer.md
                         ├── head.md
                         ├── navigation.md


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

Fixes #890 

**What is the rationale for this request?**
`header.md` is supported as a layout file, and is undocumented.

**What changes did you make? (Give an overview)**
Add documentation for `header.md`

**Provide some example code that this change will affect:**
n/a

**Is there anything you'd like reviewers to focus on?**
n/a

**Testing instructions:**
![image](https://user-images.githubusercontent.com/2277141/60161922-04059080-982b-11e9-9902-b825b9268531.png)


**Proposed commit message: (wrap lines at 72 characters)**
`header.md` is supported as a layout file, and is undocumented.

Let's add documentation for `header.md`
