### PR TITLE
Add relative date feature

### DIFF
--- a/docs/userGuide/fullSyntaxReference.md
+++ b/docs/userGuide/fullSyntaxReference.md
@@ -21,6 +21,7 @@
   emoji : ['Emoji', ['basic', 'reader-facing']],
   icons : ['Icons', ['basic', 'reader-facing']],
   embeds : ['Embeds', ['basic', 'reader-facing']],
+  dates : ['Dates', ['basic', 'reader-facing']],
 
   frontmatter : ['Front Matter', ['other']],
   includes : ['Includes', ['other']],

--- a/docs/userGuide/syntax/dates.mbdf
+++ b/docs/userGuide/syntax/dates.mbdf
@@ -1,0 +1,107 @@
+## Dates
+
+{% macro njcode(raw) %}<code>{<a/>{ {{ raw }} }}</code>{% endmacro %}
+{% macro njblock(raw) %}<code>{<a/>% {{ raw }} %}</code>{% endmacro %}
+
+**Markbind supports date formatting and simple calculations** as a Nunjucks [filter](https://mozilla.github.io/nunjucks/templating.html#filters).
+
+**Syntax:** {{ njcode('baseDate | date(format, daysToAdd)') }}
+
+<span id="main-example">
+
+20 days after 1st Jan 2020:
+
+{{ njcode('"2020-01-01" | date("ddd, Do MMM, YYYY", 20) ') }} :glyphicon-arrow-right: {{ "2020-01-01" | date("ddd, Do MMM, YYYY", 20) }}
+</span>
+
+<box type="info">
+
+The baseDate follows the format: `YYYY-MM-DD`
+
+The default output format is `"ddd D MMM"` e.g. Fri 6 Mar
+</box>
+
+### Using variables
+
+{{ njblock('set base1 = "2020-01-01"') }} {% set base1 = "2020-01-01" %} <br/>
+{{ njblock('set format1 = "DD MM YYYY"') }} {% set format1 = "DD MM YYYY" %} <br/>
+{{ njblock('set format2 = "ddd Do MMM (DD/MM/YYYY)"') }} {% set format2 = "ddd Do MMM (DD/MM/YYYY)" %}
+
+{{ njcode('base1 | date') }} :glyphicon-arrow-right: {{ base1 | date }}<br/>
+
+#### Custom formatting
+{{ njcode('base1 | date(format1)') }} :glyphicon-arrow-right: {{ base1 | date(format1) }}<br/>
+
+#### Adding days
+{{ njcode('base1 | date(format2, 0)') }} :glyphicon-arrow-right: {{ base1 | date(format2, 0) }}<br/>
+{{ njcode('base1 | date(format2, 10)') }} :glyphicon-arrow-right: {{ base1 | date(format2, 10) }}<br/>
+
+#### Page variables
+Dates can be supplied using [page variables](../reusingContents.html#variables) for convenience.
+
+Inside `variables.md` or referencing page:
+```
+<variable name="date_pagevar">2020-03-06</variable>
+```
+<variable name="date_pagevar">2020-03-06</variable>
+
+{{ njcode('date_pagevar | date(format2)') }} :glyphicon-arrow-right: {{ date_pagevar | date(format2) }} <br/>
+
+
+
+### Advanced Formatting
+
+The output date can be formatted to suit your needs by specifying a format string as an argument to the date filter.
+
+Default format: `"ddd D MMM"` e.g. Fri 6 Mar
+
+<panel header="**Brief reference**">
+
+Token | Output
+- | -
+D | 1
+Do | 1st
+DD | 01
+M | 1
+MM | 01
+MMM | Jan
+MMMM | January
+YY | 19
+YYYY | 2019
+</panel>
+
+Full formatting reference available [here](https://momentjs.com/docs/#/displaying/format/).
+
+{{ icon_example }}
+<span id="examples" class="d-none">
+<include boilerplate src="outputBox.md">
+<span id="code">
+
+<box><span>
+{{ njblock('set base1 = "2019-08-12"') }}<br/>
+{{ njblock('set format1 = "DD MM YYYY"') }}<br/>
+{{ njblock('set format2 = "ddd Do MM"') }}<br/>
+{{ njcode('base1 | date') }} `<!-- Mon 12 Aug -->`<br/>
+{{ njcode('base1 | date(format1)') }} `<!-- 12 08 2019 -->`<br/>
+{{ njcode('base1 | date(format1, 10)') }} `<!-- 22 08 2019 -->`<br/>
+{{ njcode('base1 | date(format2, 10)') }} `<!-- Thu 22/08 -->`<br/>
+</span></box>
+
+</span>
+<span id="output">
+Mon 12 Aug<br/>
+12 08 2019<br/>
+22 08 2019<br/>
+Thu 22/08
+</span>
+</include>
+
+<span id="short" class="d-none">
+
+<box><span>
+{{ njcode('"2019-08-12" | date("DD.MM.YYYY", 10)') }} `<!-- 22.08.2019 -->`<br/>
+</span></box>
+
+{{ "2019-08-12" | date("DD.MM.YYYY", 10) }}
+</span>
+</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,7 +2955,7 @@
       "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.4.1.tgz",
       "integrity": "sha512-W3aa3QJEc8BS2MmdVpQiYLKHj3ijpto1gMDlsgCRSKfIUe6MwkcpODGPQ3vZfb0XvCeCqlu9CBQTN7oQri2TZQ==",
       "requires": {
-        "moment": "^2.11.2"
+        "moment": "2.24.0"
       }
     },
     "filename-reserved-regex": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "markdown-it-table-of-contents": "^0.4.4",
     "markdown-it-task-lists": "^1.4.1",
     "markdown-it-video": "^0.6.3",
+    "moment": "^2.24.0",
     "nunjucks": "^3.2.0",
     "path-is-inside": "^1.0.2",
     "progress": "^2.0.3",

--- a/src/Site.js
+++ b/src/Site.js
@@ -2,13 +2,12 @@ const cheerio = require('cheerio');
 const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
-const nunjucks = require('nunjucks');
 const path = require('path');
 const Promise = require('bluebird');
 const ProgressBar = require('progress');
 const walkSync = require('walk-sync');
 const MarkBind = require('./lib/markbind/src/parser');
-const nunjuckUtils = require('./lib/markbind/src/utils/nunjuckUtils');
+const njUtil = require('./lib/markbind/src/utils/nunjuckUtils');
 const injectHtmlParser2SpecialTags = require('./lib/markbind/src/patches/htmlparser2');
 const injectMarkdownItSpecialTags = require(
   './lib/markbind/src/lib/markdown-it/markdown-it-escape-special-tags');
@@ -121,8 +120,7 @@ class Site {
 
     // Page template path
     this.pageTemplatePath = path.join(__dirname, PAGE_TEMPLATE_NAME);
-    const env = nunjucks.configure({ autoescape: false });
-    this.pageTemplate = nunjucks.compile(fs.readFileSync(this.pageTemplatePath, 'utf8'), env);
+    this.pageTemplate = njUtil.compile(fs.readFileSync(this.pageTemplatePath, 'utf8'));
     this.pages = [];
 
     // Other properties
@@ -532,7 +530,7 @@ class Site {
             const varData = JSON.parse(jsonData);
             Object.entries(varData).forEach(([varName, varValue]) => {
               // Process the content of the variable with nunjucks, in case it refers to other variables.
-              const variableValue = nunjuckUtils.renderEscaped(nunjucks, varValue, userDefinedVariables);
+              const variableValue = njUtil.renderRaw(varValue, userDefinedVariables, {}, false);
 
               userDefinedVariables[varName] = variableValue;
             });
@@ -541,7 +539,7 @@ class Site {
           }
         } else {
           // Process the content of the variable with nunjucks, in case it refers to other variables.
-          const html = nunjuckUtils.renderEscaped(nunjucks, $(this).html(), userDefinedVariables);
+          const html = njUtil.renderRaw($(this).html(), userDefinedVariables, {}, false);
           userDefinedVariables[name] = html;
         }
       });

--- a/src/lib/markbind/package.json
+++ b/src/lib/markbind/package.json
@@ -34,6 +34,7 @@
     "markdown-it-table-of-contents": "^0.4.4",
     "markdown-it-task-lists": "^1.4.1",
     "markdown-it-video": "^0.6.3",
+    "moment": "^2.24.0",
     "nunjucks": "^3.2.0",
     "path-is-inside": "^1.0.2"
   },

--- a/src/lib/markbind/src/lib/nunjucks-extensions/nunjucks-date.js
+++ b/src/lib/markbind/src/lib/nunjucks-extensions/nunjucks-date.js
@@ -1,0 +1,18 @@
+const Moment = require('moment');
+
+const DEFAULT_FORMAT = 'ddd D MMM'; // e.g. Thu 27 Aug
+
+/**
+ * Calculates the result of adding {days} days to the base date
+ * @param base
+ * @param days
+ */
+function calculateTarget(base, days) {
+  return Moment(base).add(days, 'days');
+}
+
+function filter(baseDate, format = DEFAULT_FORMAT, day = 0) {
+  return calculateTarget(baseDate, day).format(format);
+}
+
+module.exports = filter;

--- a/src/lib/markbind/src/preprocessors/componentPreprocessor.js
+++ b/src/lib/markbind/src/preprocessors/componentPreprocessor.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio');
-const nunjucks = require('nunjucks');
 const path = require('path');
 const url = require('url');
 
@@ -8,7 +7,7 @@ const CyclicReferenceError = require('../handlers/cyclicReferenceError.js');
 const md = require('../lib/markdown-it');
 const utils = require('../utils');
 const urlUtils = require('../utils/urls');
-const nunjuckUtils = require('../utils/nunjuckUtils');
+const njUtil = require('../utils/nunjuckUtils');
 
 const _ = {};
 _.has = require('lodash/has');
@@ -286,7 +285,7 @@ function _preprocessInclude(node, context, config, parser) {
   parser.extractInnerVariablesIfNotProcessed(content, childContext, config, filePath);
 
   const innerVariables = parser.getImportedVariableMap(filePath);
-  const fileContent = nunjuckUtils.renderEscaped(nunjucks, content, {
+  const fileContent = njUtil.renderRaw(content, {
     ...userDefinedVariables, ...innerVariables,
   });
 

--- a/src/lib/markbind/src/utils/nunjuckUtils.js
+++ b/src/lib/markbind/src/utils/nunjuckUtils.js
@@ -1,3 +1,9 @@
+const nunjucks = require('nunjucks');
+const dateFilter = require('../lib/nunjucks-extensions/nunjucks-date');
+
+const commonEnv = nunjucks.configure().addFilter('date', dateFilter);
+const unescapedEnv = nunjucks.configure({ autoescape: false }).addFilter('date', dateFilter);
+
 const START_ESCAPE_STR = '{% raw %}';
 const END_ESCAPE_STR = '{% endraw %}';
 const REGEX = new RegExp('{% *raw *%}(.*?){% *endraw *%}', 'gs');
@@ -7,8 +13,15 @@ function preEscapeRawTags(pageData) {
 }
 
 module.exports = {
-  renderEscaped(nunjucks, pageData, variableMap = {}, options = {}) {
+  renderRaw(pageData, variableMap = {}, options = {}, autoescape = true) {
     const escapedPage = preEscapeRawTags(pageData);
-    return nunjucks.renderString(escapedPage, variableMap, options);
+    if (autoescape) return commonEnv.renderString(escapedPage, variableMap, options);
+    return unescapedEnv.renderString(escapedPage, variableMap, options);
+  },
+  renderString(pageData, variableMap = {}, options = {}, env = commonEnv) {
+    return env.renderString(pageData, variableMap, options);
+  },
+  compile(src, ...args) {
+    return nunjucks.compile(src, unescapedEnv, ...args);
   },
 };

--- a/test/functional/test_site/_markbind/variables.md
+++ b/test/functional/test_site/_markbind/variables.md
@@ -10,3 +10,5 @@
 <variable name="global_variable">Global Variable</variable>
 <variable name="page_global_variable_overriding_page_variable">Global Variable Overriding Page Variable</variable>
 <variable from="variable.json"></variable>
+<variable name="base2">2019-01-01</variable>
+<variable name="formatted_date">{{ base2 | date("ddd D MMM", 10) }}</variable>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -304,6 +304,17 @@
       "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
+    },
+    {
+      "src": "testDates.md",
+      "title": "Nunjucks date filter tests",
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {
+        "dates": "Dates"
+      },
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site/expected/testDates.html
+++ b/test/functional/test_site/expected/testDates.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta name="default-head-top">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="generator" content="MarkBind 2.13.1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nunjucks date filter tests</title>
+  <link rel="stylesheet" href="markbind/css/bootstrap.min.css">
+  <link rel="stylesheet" href="markbind/css/bootstrap-vue.min.css">
+  <link rel="stylesheet" href="markbind/fontawesome/css/all.min.css">
+  <link rel="stylesheet" href="markbind/glyphicons/css/bootstrap-glyphicons.min.css">
+  <link rel="stylesheet" href="markbind/css/octicons.css">
+  <link rel="stylesheet" href="markbind/css/github.min.css">
+  <link rel="stylesheet" href="markbind/css/markbind.css">
+  <link rel="stylesheet" href="STYLESHEET_LINK">
+  <link rel="stylesheet" href="markbind/layouts/default/styles.css">
+  <meta name="default-head-bottom">
+  <link rel="icon" href="/test_site/favicon.png">
+</head>
+
+<body>
+  <div id="app">
+    <div id="flex-body">
+      <div id="content-wrapper">
+        <h2 id="dates">Dates<a class="fa fa-anchor" href="#dates"></a></h2>
+        <div></div>
+        <p>Mon 12 Aug should be Mon 12 Aug</p>
+        <p>12 08 2019 should be 12 08 2019</p>
+        <p>22 08 2019 should be 22 08 2019</p>
+        <p>Thu 22/08 should be Thu 22/08</p>
+        <p>Tue 1 Jan should be Tue 1 Jan</p>
+        <p>01 01 2019 should be 01 01 2019</p>
+        <p>11 01 2019 should be 11 01 2019</p>
+        <p>Fri 11/01 should be Fri 11/01</p>
+        <p>Fri 11 Jan should be Fri 11 Jan</p>
+      </div>
+
+
+    </div>
+    <footer>
+      <div class="text-center">
+        Default footer
+      </div>
+    </footer>
+  </div>
+</body>
+<script src="markbind/js/vue.min.js"></script>
+<script src="markbind/js/vue-strap.min.js"></script>
+<script src="markbind/js/bootstrap-utility.min.js"></script>
+<script src="markbind/js/polyfill.min.js"></script>
+<script src="markbind/js/bootstrap-vue.min.js"></script>
+<script>
+  const baseUrl = '/test_site'
+  const enableSearch = true
+</script>
+<script src="markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
+<script>
+  alert("hello")
+</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=TRACKING-ID"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+
+  gtag('config', 'TRACKING-ID');
+</script>
+<script src="markbind/layouts/default/scripts.js"></script>
+
+</html>

--- a/test/functional/test_site/site.json
+++ b/test/functional/test_site/site.json
@@ -79,6 +79,10 @@
     {
       "src": "testPopoverTrigger.md",
       "title": "Popover initiated by trigger should honor trigger attribute"
+    },
+    {
+      "src": "testDates.md",
+      "title": "Nunjucks date filter tests"
     }
   ],
   "ignore": [

--- a/test/functional/test_site/testDates.md
+++ b/test/functional/test_site/testDates.md
@@ -1,0 +1,26 @@
+## Dates
+<variable name="base1">2019-08-12</variable>
+
+{% set format1 = "DD MM YYYY" %}
+
+{% set format2 = "ddd DD/MM" %} 
+
+
+{{ base1 | date }} should be Mon 12 Aug
+
+{{ base1 | date(format1) }} should be 12 08 2019
+
+{{ base1 | date(format1, 10) }} should be 22 08 2019
+
+{{ base1 | date(format2, 10) }} should be Thu 22/08
+
+
+{{ base2 | date }} should be Tue 1 Jan
+
+{{ base2 | date(format1) }} should be 01 01 2019
+
+{{ base2 | date(format1, 10) }} should be 11 01 2019
+
+{{ base2 | date(format2, 10) }} should be Fri 11/01
+
+{{ formatted_date }} should be Fri 11 Jan

--- a/test/unit/nunjuckUtils.test.js
+++ b/test/unit/nunjuckUtils.test.js
@@ -1,23 +1,22 @@
-const nunjucks = require('nunjucks');
-const nunjuckUtils = require('../../src/lib/markbind/src/utils/nunjuckUtils');
+const njUtil = require('../../src/lib/markbind/src/utils/nunjuckUtils');
 
 test('Escaping nunjucks raw tags', () => {
   const escapedString = 'This is a content with escaped data {%raw%} CONTENT {%endraw%}';
-  const escapedContent = nunjuckUtils.renderEscaped(nunjucks, escapedString);
+  const escapedContent = njUtil.renderRaw(escapedString);
 
   expect(escapedContent).toBe(escapedString);
 });
 
 test('Escaping nunjucks with new lines', () => {
   const escapedString = 'This is a content with escaped data\n {%raw%} \nCONTENT\n {%endraw%}';
-  const escapedContent = nunjuckUtils.renderEscaped(nunjucks, escapedString);
+  const escapedContent = njUtil.renderRaw(escapedString);
 
   expect(escapedContent).toBe(escapedString);
 });
 
 test('Escaping multiple nunjucks raw tags', () => {
   const escapedString = 'Multiple escapes: {%raw%} first {%endraw%} {%raw%} second {%endraw%}';
-  const escapedContent = nunjuckUtils.renderEscaped(nunjucks, escapedString);
+  const escapedContent = njUtil.renderRaw(escapedString);
 
   expect(escapedContent).toBe(escapedString);
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] New feature

Addresses #901 

**What is the rationale for this request?**
Adds the ability to insert relative dates

**What changes did you make? (Give an overview)**
~Add a new markdown-it plugin that looks for `@date Week#day@` tokens and replaces them with 
dates relative to a specified `base` date.~

Changed to a Nunjucks filter extension:
`{{ baseDate | date(format, dayOffset) }}`

**Provide some example code that this change will affect:**


**Is there anything you'd like reviewers to focus on?**
Is the proposed syntax suitable, or should we implement it as a tag e.g. `<date>`


**Testing instructions:**
[Netlify preview](https://deploy-preview-908--markbind-master.netlify.com/userguide/fullsyntaxreference#dates)

**Proposed commit message: (wrap lines at 72 characters)**
Add a new nunjucks filter to allow dynamic date calculation given
 a base date and day offset and customizable formatting of the output.