### PR TITLE
Configure nunjucks to always escape variables

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -3,8 +3,6 @@ const fm = require('fastmatter');
 const fs = require('fs-extra-promise');
 const htmlBeautify = require('js-beautify').html;
 const nunjucks = require('nunjucks');
-
-nunjucks.configure({ autoescape: true });
 const path = require('path');
 const pathIsInside = require('path-is-inside');
 const Promise = require('bluebird');
@@ -51,6 +49,7 @@ const TEMP_DROPDOWN_PLACEHOLDER_CLASS = 'temp-dropdown-placeholder';
 
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
+nunjucks.configure({ autoescape: true });
 
 function Page(pageConfig) {
   this.asset = pageConfig.asset;

--- a/src/Page.js
+++ b/src/Page.js
@@ -3,6 +3,8 @@ const fm = require('fastmatter');
 const fs = require('fs-extra-promise');
 const htmlBeautify = require('js-beautify').html;
 const nunjucks = require('nunjucks');
+
+nunjucks.configure({ autoescape: true });
 const path = require('path');
 const pathIsInside = require('path-is-inside');
 const Promise = require('bluebird');

--- a/src/Site.js
+++ b/src/Site.js
@@ -4,6 +4,8 @@ const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
 const nunjucks = require('nunjucks');
+
+nunjucks.configure({ autoescape: true });
 const path = require('path');
 const Promise = require('bluebird');
 const ProgressBar = require('progress');

--- a/src/Site.js
+++ b/src/Site.js
@@ -4,8 +4,6 @@ const fs = require('fs-extra-promise');
 const ghpages = require('gh-pages');
 const ignore = require('ignore');
 const nunjucks = require('nunjucks');
-
-nunjucks.configure({ autoescape: true });
 const path = require('path');
 const Promise = require('bluebird');
 const ProgressBar = require('progress');
@@ -64,6 +62,8 @@ const LAYOUT_SITE_FOLDER_NAME = 'layouts';
 const USER_VARIABLES_PATH = '_markbind/variables.md';
 const WIKI_SITE_NAV_PATH = '_Sidebar.md';
 const WIKI_FOOTER_PATH = '_Footer.md';
+
+nunjucks.configure({ autoescape: true });
 
 function getBootswatchThemePath(theme) {
   return path.join(__dirname, '..', 'node_modules', 'bootswatch', 'dist', theme, 'bootstrap.min.css');

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -2,8 +2,6 @@ const cheerio = require('cheerio');
 const fs = require('fs');
 const htmlparser = require('htmlparser2');
 const nunjucks = require('nunjucks');
-
-nunjucks.configure({ autoescape: true });
 const path = require('path');
 const pathIsInside = require('path-is-inside');
 const Promise = require('bluebird');
@@ -23,6 +21,7 @@ const utils = require('./utils');
 
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
+nunjucks.configure({ autoescape: true });
 
 const ATTRIB_INCLUDE_PATH = 'include-path';
 const ATTRIB_CWF = 'cwf';

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -2,6 +2,8 @@ const cheerio = require('cheerio');
 const fs = require('fs');
 const htmlparser = require('htmlparser2');
 const nunjucks = require('nunjucks');
+
+nunjucks.configure({ autoescape: true });
 const path = require('path');
 const pathIsInside = require('path-is-inside');
 const Promise = require('bluebird');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes #907 

**What is the rationale for this request?**

Make nunjucks autoescape all variables.

**What changes did you make? (Give an overview)**

Configure nunjucks, setting `autoescape` to `true.

https://mozilla.github.io/nunjucks/getting-started.html

**Provide some example code that this change will affect:**

If the following is in a nunjucks variable `v`,
```html
<span id="x"><br/></span>,
```
It does not need to be escaped with `{{ v | safe }}` anymore.
