### PR TITLE
Add temp styles to panel to reduce FOUC

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -198,28 +198,31 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
-/* Hide the contents of unexpanded panels*/
-
+/* Hide the contents of unexpanded panels */
+/* stylelint-disable */
 panel:not([expanded]) {
+    /* stylelint-enable */
     visibility: hidden;
     height: 50px;
     display: block;
 }
 
+/* stylelint-disable */
 panel:not([expanded])::before {
+    /* stylelint-enable */
     content: attr(header);
     visibility: visible;
     position: relative;
-    display:block;
+    display: block;
 
     /* Below values are copied from the final rendered styles */
 
     margin-top: 5px;
-    padding: .75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0,0,0,.03);
-    border: 1px solid rgba(0,0,0,.125);
-    border-radius: .25rem;
+    background-color: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
 }
 
 /* Footnote anchor */

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -284,6 +284,11 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+
+/* increasing specificity */
+#flex-body panel:not([expanded]) panel {
+    display: none;
+}
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -266,7 +266,8 @@ panel[type=info]:not([expanded])::before {
     border-color: var(--info);
 }
 
-panel[type=light]:not([expanded])::before {
+panel[type=light]:not([expanded])::before,
+panel:not([type]):not([expanded])::before {
     color: black;
     background-color: var(--light);
 }

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -201,28 +201,83 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable */
 panel:not([expanded]) {
-    /* stylelint-enable */
     visibility: hidden;
-    height: 50px;
     display: block;
 }
 
-/* stylelint-disable */
-panel:not([expanded])::before {
-    /* stylelint-enable */
-    content: attr(header);
+panel:not([expanded]):not([minimized])::before {
+    content: "Loading...";
+    color: white;
     visibility: visible;
     position: relative;
-    display: block;
-
-    /* Below values are copied from the final rendered styles */
-
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0, 0, 0, 0.03);
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    border-radius: 0.25rem;
+    line-height: 1.5;
+    height: 52.85px;
+    display: block;
+}
+
+panel[minimized]::before {
+    content: "";
+    color: white;
+    visibility: visible;
+    position: relative;
+    height: 37.5px;
+    margin-top: 0;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: 0;
+    display: inline-block;
+}
+
+panel[type=seamless]:not([expanded])::before {
+    color: black;
+    background-color: transparent;
+    border: 0;
+}
+
+panel[type=primary]:not([expanded])::before {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+panel[type=secondary]:not([expanded])::before {
+    background-color: var(--secondary);
+    border-color: var(--secondary);
+}
+
+panel[type=success]:not([expanded])::before {
+    background-color: var(--success);
+    border-color: var(--success);
+}
+
+panel[type=warning]:not([expanded])::before {
+    background-color: var(--warning);
+    border-color: var(--warning);
+}
+
+panel[type=danger]:not([expanded])::before {
+    background-color: var(--danger);
+    border-color: var(--danger);
+}
+
+panel[type=info]:not([expanded])::before {
+    background-color: var(--info);
+    border-color: var(--info);
+}
+
+panel[type=light]:not([expanded])::before {
+    color: black;
+    background-color: var(--light);
+}
+
+panel[type=dark]:not([expanded])::before {
+    background-color: var(--dark);
+    border-color: var(--dark);
+}
+
+panel[minimized]:not([expanded])::before {
+    background-color: var(--light);
 }
 
 /* Footnote anchor */

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -199,22 +199,27 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
-/* stylelint-disable */
-panel:not([expanded]) {
+panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
+    height: 53px;
+}
+
+panel[minimized] {
+    visibility: hidden;
+    display: inline-block;
+    height: 38px;
 }
 
 panel:not([expanded]):not([minimized])::before {
     content: "Loading...";
     color: white;
     visibility: visible;
-    position: relative;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
     line-height: 1.5;
-    height: 52.85px;
+    height: 53px;
     display: block;
 }
 
@@ -222,12 +227,10 @@ panel[minimized]::before {
     content: "";
     color: white;
     visibility: visible;
-    position: relative;
-    height: 37.5px;
-    margin-top: 0;
+    height: 38px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
     display: inline-block;
+    border: #0b2e13;
 }
 
 panel[type=seamless]:not([expanded])::before {

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -199,6 +199,7 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
+/* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
@@ -283,6 +284,7 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+/* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */
 

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -198,6 +198,30 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
+/* Hide the contents of unexpanded panels*/
+
+panel:not([expanded]) {
+    visibility: hidden;
+    height: 50px;
+    display: block;
+}
+
+panel:not([expanded])::before {
+    content: attr(header);
+    visibility: visible;
+    position: relative;
+    display:block;
+
+    /* Below values are copied from the final rendered styles */
+
+    margin-top: 5px;
+    padding: .75rem 1.25rem;
+    margin-bottom: 0;
+    background-color: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.125);
+    border-radius: .25rem;
+}
+
 /* Footnote anchor */
 
 li.footnote-item:target {

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -201,43 +201,43 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
-    visibility: hidden;
     display: block;
     height: 53px;
+    visibility: hidden;
 }
 
 panel[minimized] {
-    visibility: hidden;
     display: inline-block;
     height: 38px;
+    visibility: hidden;
 }
 
 panel:not([expanded]):not([minimized])::before {
-    content: "Loading...";
     color: white;
-    visibility: visible;
+    content: "Loading...";
+    display: block;
+    height: 53px;
+    line-height: 1.5;
+    margin-bottom: 0;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
-    line-height: 1.5;
-    height: 53px;
-    display: block;
+    visibility: visible;
 }
 
 panel[minimized]::before {
-    content: "";
+    border: #0b2e13;
     color: white;
-    visibility: visible;
+    content: "";
+    display: inline-block;
     height: 38px;
     padding: 0.75rem 1.25rem;
-    display: inline-block;
-    border: #0b2e13;
+    visibility: visible;
 }
 
 panel[type=seamless]:not([expanded])::before {
-    color: black;
     background-color: transparent;
     border: 0;
+    color: black;
 }
 
 panel[type=primary]:not([expanded])::before {
@@ -272,8 +272,8 @@ panel[type=info]:not([expanded])::before {
 
 panel[type=light]:not([expanded])::before,
 panel:not([type]):not([expanded])::before {
-    color: black;
     background-color: var(--light);
+    color: black;
 }
 
 panel[type=dark]:not([expanded])::before {
@@ -289,6 +289,7 @@ panel[minimized]:not([expanded])::before {
 #flex-body panel:not([expanded]) panel {
     display: none;
 }
+
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -198,28 +198,31 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
-/* Hide the contents of unexpanded panels*/
-
+/* Hide the contents of unexpanded panels */
+/* stylelint-disable */
 panel:not([expanded]) {
+    /* stylelint-enable */
     visibility: hidden;
     height: 50px;
     display: block;
 }
 
+/* stylelint-disable */
 panel:not([expanded])::before {
+    /* stylelint-enable */
     content: attr(header);
     visibility: visible;
     position: relative;
-    display:block;
+    display: block;
 
     /* Below values are copied from the final rendered styles */
 
     margin-top: 5px;
-    padding: .75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0,0,0,.03);
-    border: 1px solid rgba(0,0,0,.125);
-    border-radius: .25rem;
+    background-color: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -284,6 +284,11 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+
+/* increasing specificity */
+#flex-body panel:not([expanded]) panel {
+    display: none;
+}
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -266,7 +266,8 @@ panel[type=info]:not([expanded])::before {
     border-color: var(--info);
 }
 
-panel[type=light]:not([expanded])::before {
+panel[type=light]:not([expanded])::before,
+panel:not([type]):not([expanded])::before {
     color: black;
     background-color: var(--light);
 }

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -201,28 +201,83 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable */
 panel:not([expanded]) {
-    /* stylelint-enable */
     visibility: hidden;
-    height: 50px;
     display: block;
 }
 
-/* stylelint-disable */
-panel:not([expanded])::before {
-    /* stylelint-enable */
-    content: attr(header);
+panel:not([expanded]):not([minimized])::before {
+    content: "Loading...";
+    color: white;
     visibility: visible;
     position: relative;
-    display: block;
-
-    /* Below values are copied from the final rendered styles */
-
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0, 0, 0, 0.03);
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    border-radius: 0.25rem;
+    line-height: 1.5;
+    height: 52.85px;
+    display: block;
+}
+
+panel[minimized]::before {
+    content: "";
+    color: white;
+    visibility: visible;
+    position: relative;
+    height: 37.5px;
+    margin-top: 0;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: 0;
+    display: inline-block;
+}
+
+panel[type=seamless]:not([expanded])::before {
+    color: black;
+    background-color: transparent;
+    border: 0;
+}
+
+panel[type=primary]:not([expanded])::before {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+panel[type=secondary]:not([expanded])::before {
+    background-color: var(--secondary);
+    border-color: var(--secondary);
+}
+
+panel[type=success]:not([expanded])::before {
+    background-color: var(--success);
+    border-color: var(--success);
+}
+
+panel[type=warning]:not([expanded])::before {
+    background-color: var(--warning);
+    border-color: var(--warning);
+}
+
+panel[type=danger]:not([expanded])::before {
+    background-color: var(--danger);
+    border-color: var(--danger);
+}
+
+panel[type=info]:not([expanded])::before {
+    background-color: var(--info);
+    border-color: var(--info);
+}
+
+panel[type=light]:not([expanded])::before {
+    color: black;
+    background-color: var(--light);
+}
+
+panel[type=dark]:not([expanded])::before {
+    background-color: var(--dark);
+    border-color: var(--dark);
+}
+
+panel[minimized]:not([expanded])::before {
+    background-color: var(--light);
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -199,22 +199,27 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
-/* stylelint-disable */
-panel:not([expanded]) {
+panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
+    height: 53px;
+}
+
+panel[minimized] {
+    visibility: hidden;
+    display: inline-block;
+    height: 38px;
 }
 
 panel:not([expanded]):not([minimized])::before {
     content: "Loading...";
     color: white;
     visibility: visible;
-    position: relative;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
     line-height: 1.5;
-    height: 52.85px;
+    height: 53px;
     display: block;
 }
 
@@ -222,12 +227,10 @@ panel[minimized]::before {
     content: "";
     color: white;
     visibility: visible;
-    position: relative;
-    height: 37.5px;
-    margin-top: 0;
+    height: 38px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
     display: inline-block;
+    border: #0b2e13;
 }
 
 panel[type=seamless]:not([expanded])::before {

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -199,6 +199,7 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
+/* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
@@ -283,6 +284,7 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+/* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */
 

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -198,6 +198,30 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
+/* Hide the contents of unexpanded panels*/
+
+panel:not([expanded]) {
+    visibility: hidden;
+    height: 50px;
+    display: block;
+}
+
+panel:not([expanded])::before {
+    content: attr(header);
+    visibility: visible;
+    position: relative;
+    display:block;
+
+    /* Below values are copied from the final rendered styles */
+
+    margin-top: 5px;
+    padding: .75rem 1.25rem;
+    margin-bottom: 0;
+    background-color: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.125);
+    border-radius: .25rem;
+}
+
 /* Footnote anchor */
 
 li.footnote-item:target {

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -201,43 +201,43 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
-    visibility: hidden;
     display: block;
     height: 53px;
+    visibility: hidden;
 }
 
 panel[minimized] {
-    visibility: hidden;
     display: inline-block;
     height: 38px;
+    visibility: hidden;
 }
 
 panel:not([expanded]):not([minimized])::before {
-    content: "Loading...";
     color: white;
-    visibility: visible;
+    content: "Loading...";
+    display: block;
+    height: 53px;
+    line-height: 1.5;
+    margin-bottom: 0;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
-    line-height: 1.5;
-    height: 53px;
-    display: block;
+    visibility: visible;
 }
 
 panel[minimized]::before {
-    content: "";
+    border: #0b2e13;
     color: white;
-    visibility: visible;
+    content: "";
+    display: inline-block;
     height: 38px;
     padding: 0.75rem 1.25rem;
-    display: inline-block;
-    border: #0b2e13;
+    visibility: visible;
 }
 
 panel[type=seamless]:not([expanded])::before {
-    color: black;
     background-color: transparent;
     border: 0;
+    color: black;
 }
 
 panel[type=primary]:not([expanded])::before {
@@ -272,8 +272,8 @@ panel[type=info]:not([expanded])::before {
 
 panel[type=light]:not([expanded])::before,
 panel:not([type]):not([expanded])::before {
-    color: black;
     background-color: var(--light);
+    color: black;
 }
 
 panel[type=dark]:not([expanded])::before {
@@ -289,6 +289,7 @@ panel[minimized]:not([expanded])::before {
 #flex-body panel:not([expanded]) panel {
     display: none;
 }
+
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -198,28 +198,31 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
-/* Hide the contents of unexpanded panels*/
-
+/* Hide the contents of unexpanded panels */
+/* stylelint-disable */
 panel:not([expanded]) {
+    /* stylelint-enable */
     visibility: hidden;
     height: 50px;
     display: block;
 }
 
+/* stylelint-disable */
 panel:not([expanded])::before {
+    /* stylelint-enable */
     content: attr(header);
     visibility: visible;
     position: relative;
-    display:block;
+    display: block;
 
     /* Below values are copied from the final rendered styles */
 
     margin-top: 5px;
-    padding: .75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0,0,0,.03);
-    border: 1px solid rgba(0,0,0,.125);
-    border-radius: .25rem;
+    background-color: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -284,6 +284,11 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+
+/* increasing specificity */
+#flex-body panel:not([expanded]) panel {
+    display: none;
+}
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -266,7 +266,8 @@ panel[type=info]:not([expanded])::before {
     border-color: var(--info);
 }
 
-panel[type=light]:not([expanded])::before {
+panel[type=light]:not([expanded])::before,
+panel:not([type]):not([expanded])::before {
     color: black;
     background-color: var(--light);
 }

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -201,28 +201,83 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable */
 panel:not([expanded]) {
-    /* stylelint-enable */
     visibility: hidden;
-    height: 50px;
     display: block;
 }
 
-/* stylelint-disable */
-panel:not([expanded])::before {
-    /* stylelint-enable */
-    content: attr(header);
+panel:not([expanded]):not([minimized])::before {
+    content: "Loading...";
+    color: white;
     visibility: visible;
     position: relative;
-    display: block;
-
-    /* Below values are copied from the final rendered styles */
-
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0, 0, 0, 0.03);
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    border-radius: 0.25rem;
+    line-height: 1.5;
+    height: 52.85px;
+    display: block;
+}
+
+panel[minimized]::before {
+    content: "";
+    color: white;
+    visibility: visible;
+    position: relative;
+    height: 37.5px;
+    margin-top: 0;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: 0;
+    display: inline-block;
+}
+
+panel[type=seamless]:not([expanded])::before {
+    color: black;
+    background-color: transparent;
+    border: 0;
+}
+
+panel[type=primary]:not([expanded])::before {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+panel[type=secondary]:not([expanded])::before {
+    background-color: var(--secondary);
+    border-color: var(--secondary);
+}
+
+panel[type=success]:not([expanded])::before {
+    background-color: var(--success);
+    border-color: var(--success);
+}
+
+panel[type=warning]:not([expanded])::before {
+    background-color: var(--warning);
+    border-color: var(--warning);
+}
+
+panel[type=danger]:not([expanded])::before {
+    background-color: var(--danger);
+    border-color: var(--danger);
+}
+
+panel[type=info]:not([expanded])::before {
+    background-color: var(--info);
+    border-color: var(--info);
+}
+
+panel[type=light]:not([expanded])::before {
+    color: black;
+    background-color: var(--light);
+}
+
+panel[type=dark]:not([expanded])::before {
+    background-color: var(--dark);
+    border-color: var(--dark);
+}
+
+panel[minimized]:not([expanded])::before {
+    background-color: var(--light);
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -199,22 +199,27 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
-/* stylelint-disable */
-panel:not([expanded]) {
+panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
+    height: 53px;
+}
+
+panel[minimized] {
+    visibility: hidden;
+    display: inline-block;
+    height: 38px;
 }
 
 panel:not([expanded]):not([minimized])::before {
     content: "Loading...";
     color: white;
     visibility: visible;
-    position: relative;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
     line-height: 1.5;
-    height: 52.85px;
+    height: 53px;
     display: block;
 }
 
@@ -222,12 +227,10 @@ panel[minimized]::before {
     content: "";
     color: white;
     visibility: visible;
-    position: relative;
-    height: 37.5px;
-    margin-top: 0;
+    height: 38px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
     display: inline-block;
+    border: #0b2e13;
 }
 
 panel[type=seamless]:not([expanded])::before {

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -199,6 +199,7 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
+/* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
@@ -283,6 +284,7 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+/* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */
 

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -198,6 +198,30 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
+/* Hide the contents of unexpanded panels*/
+
+panel:not([expanded]) {
+    visibility: hidden;
+    height: 50px;
+    display: block;
+}
+
+panel:not([expanded])::before {
+    content: attr(header);
+    visibility: visible;
+    position: relative;
+    display:block;
+
+    /* Below values are copied from the final rendered styles */
+
+    margin-top: 5px;
+    padding: .75rem 1.25rem;
+    margin-bottom: 0;
+    background-color: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.125);
+    border-radius: .25rem;
+}
+
 /* Footnote anchor */
 
 li.footnote-item:target {

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -201,43 +201,43 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
-    visibility: hidden;
     display: block;
     height: 53px;
+    visibility: hidden;
 }
 
 panel[minimized] {
-    visibility: hidden;
     display: inline-block;
     height: 38px;
+    visibility: hidden;
 }
 
 panel:not([expanded]):not([minimized])::before {
-    content: "Loading...";
     color: white;
-    visibility: visible;
+    content: "Loading...";
+    display: block;
+    height: 53px;
+    line-height: 1.5;
+    margin-bottom: 0;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
-    line-height: 1.5;
-    height: 53px;
-    display: block;
+    visibility: visible;
 }
 
 panel[minimized]::before {
-    content: "";
+    border: #0b2e13;
     color: white;
-    visibility: visible;
+    content: "";
+    display: inline-block;
     height: 38px;
     padding: 0.75rem 1.25rem;
-    display: inline-block;
-    border: #0b2e13;
+    visibility: visible;
 }
 
 panel[type=seamless]:not([expanded])::before {
-    color: black;
     background-color: transparent;
     border: 0;
+    color: black;
 }
 
 panel[type=primary]:not([expanded])::before {
@@ -272,8 +272,8 @@ panel[type=info]:not([expanded])::before {
 
 panel[type=light]:not([expanded])::before,
 panel:not([type]):not([expanded])::before {
-    color: black;
     background-color: var(--light);
+    color: black;
 }
 
 panel[type=dark]:not([expanded])::before {
@@ -289,6 +289,7 @@ panel[minimized]:not([expanded])::before {
 #flex-body panel:not([expanded]) panel {
     display: none;
 }
+
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -198,28 +198,31 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
-/* Hide the contents of unexpanded panels*/
-
+/* Hide the contents of unexpanded panels */
+/* stylelint-disable */
 panel:not([expanded]) {
+    /* stylelint-enable */
     visibility: hidden;
     height: 50px;
     display: block;
 }
 
+/* stylelint-disable */
 panel:not([expanded])::before {
+    /* stylelint-enable */
     content: attr(header);
     visibility: visible;
     position: relative;
-    display:block;
+    display: block;
 
     /* Below values are copied from the final rendered styles */
 
     margin-top: 5px;
-    padding: .75rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0,0,0,.03);
-    border: 1px solid rgba(0,0,0,.125);
-    border-radius: .25rem;
+    background-color: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -284,6 +284,11 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+
+/* increasing specificity */
+#flex-body panel:not([expanded]) panel {
+    display: none;
+}
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -266,7 +266,8 @@ panel[type=info]:not([expanded])::before {
     border-color: var(--info);
 }
 
-panel[type=light]:not([expanded])::before {
+panel[type=light]:not([expanded])::before,
+panel:not([type]):not([expanded])::before {
     color: black;
     background-color: var(--light);
 }

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -201,28 +201,83 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable */
 panel:not([expanded]) {
-    /* stylelint-enable */
     visibility: hidden;
-    height: 50px;
     display: block;
 }
 
-/* stylelint-disable */
-panel:not([expanded])::before {
-    /* stylelint-enable */
-    content: attr(header);
+panel:not([expanded]):not([minimized])::before {
+    content: "Loading...";
+    color: white;
     visibility: visible;
     position: relative;
-    display: block;
-
-    /* Below values are copied from the final rendered styles */
-
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
-    background-color: rgba(0, 0, 0, 0.03);
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    border-radius: 0.25rem;
+    line-height: 1.5;
+    height: 52.85px;
+    display: block;
+}
+
+panel[minimized]::before {
+    content: "";
+    color: white;
+    visibility: visible;
+    position: relative;
+    height: 37.5px;
+    margin-top: 0;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: 0;
+    display: inline-block;
+}
+
+panel[type=seamless]:not([expanded])::before {
+    color: black;
+    background-color: transparent;
+    border: 0;
+}
+
+panel[type=primary]:not([expanded])::before {
+    background-color: var(--primary);
+    border-color: var(--primary);
+}
+
+panel[type=secondary]:not([expanded])::before {
+    background-color: var(--secondary);
+    border-color: var(--secondary);
+}
+
+panel[type=success]:not([expanded])::before {
+    background-color: var(--success);
+    border-color: var(--success);
+}
+
+panel[type=warning]:not([expanded])::before {
+    background-color: var(--warning);
+    border-color: var(--warning);
+}
+
+panel[type=danger]:not([expanded])::before {
+    background-color: var(--danger);
+    border-color: var(--danger);
+}
+
+panel[type=info]:not([expanded])::before {
+    background-color: var(--info);
+    border-color: var(--info);
+}
+
+panel[type=light]:not([expanded])::before {
+    color: black;
+    background-color: var(--light);
+}
+
+panel[type=dark]:not([expanded])::before {
+    background-color: var(--dark);
+    border-color: var(--dark);
+}
+
+panel[minimized]:not([expanded])::before {
+    background-color: var(--light);
 }
 
 /* Footnote anchor */

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -199,22 +199,27 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
-/* stylelint-disable */
-panel:not([expanded]) {
+panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
+    height: 53px;
+}
+
+panel[minimized] {
+    visibility: hidden;
+    display: inline-block;
+    height: 38px;
 }
 
 panel:not([expanded]):not([minimized])::before {
     content: "Loading...";
     color: white;
     visibility: visible;
-    position: relative;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
     margin-bottom: 0;
     line-height: 1.5;
-    height: 52.85px;
+    height: 53px;
     display: block;
 }
 
@@ -222,12 +227,10 @@ panel[minimized]::before {
     content: "";
     color: white;
     visibility: visible;
-    position: relative;
-    height: 37.5px;
-    margin-top: 0;
+    height: 38px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
     display: inline-block;
+    border: #0b2e13;
 }
 
 panel[type=seamless]:not([expanded])::before {

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -199,6 +199,7 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 }
 
 /* Hide the contents of unexpanded panels */
+/* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
     visibility: hidden;
     display: block;
@@ -283,6 +284,7 @@ panel[type=dark]:not([expanded])::before {
 panel[minimized]:not([expanded])::before {
     background-color: var(--light);
 }
+/* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */
 

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -198,6 +198,30 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
     display: none;
 }
 
+/* Hide the contents of unexpanded panels*/
+
+panel:not([expanded]) {
+    visibility: hidden;
+    height: 50px;
+    display: block;
+}
+
+panel:not([expanded])::before {
+    content: attr(header);
+    visibility: visible;
+    position: relative;
+    display:block;
+
+    /* Below values are copied from the final rendered styles */
+
+    margin-top: 5px;
+    padding: .75rem 1.25rem;
+    margin-bottom: 0;
+    background-color: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.125);
+    border-radius: .25rem;
+}
+
 /* Footnote anchor */
 
 li.footnote-item:target {

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -201,43 +201,43 @@ so we apply temporary styles to fix the layout until Vue correctly updates the D
 /* Hide the contents of unexpanded panels */
 /* stylelint-disable selector-type-no-unknown */
 panel:not([expanded]):not([minimized]) {
-    visibility: hidden;
     display: block;
     height: 53px;
+    visibility: hidden;
 }
 
 panel[minimized] {
-    visibility: hidden;
     display: inline-block;
     height: 38px;
+    visibility: hidden;
 }
 
 panel:not([expanded]):not([minimized])::before {
-    content: "Loading...";
     color: white;
-    visibility: visible;
+    content: "Loading...";
+    display: block;
+    height: 53px;
+    line-height: 1.5;
+    margin-bottom: 0;
     margin-top: 5px;
     padding: 0.75rem 1.25rem;
-    margin-bottom: 0;
-    line-height: 1.5;
-    height: 53px;
-    display: block;
+    visibility: visible;
 }
 
 panel[minimized]::before {
-    content: "";
+    border: #0b2e13;
     color: white;
-    visibility: visible;
+    content: "";
+    display: inline-block;
     height: 38px;
     padding: 0.75rem 1.25rem;
-    display: inline-block;
-    border: #0b2e13;
+    visibility: visible;
 }
 
 panel[type=seamless]:not([expanded])::before {
-    color: black;
     background-color: transparent;
     border: 0;
+    color: black;
 }
 
 panel[type=primary]:not([expanded])::before {
@@ -272,8 +272,8 @@ panel[type=info]:not([expanded])::before {
 
 panel[type=light]:not([expanded])::before,
 panel:not([type]):not([expanded])::before {
-    color: black;
     background-color: var(--light);
+    color: black;
 }
 
 panel[type=dark]:not([expanded])::before {
@@ -289,6 +289,7 @@ panel[minimized]:not([expanded])::before {
 #flex-body panel:not([expanded]) panel {
     display: none;
 }
+
 /* stylelint-enable selector-type-no-unknown */
 
 /* Footnote anchor */


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes #921 

**What is the rationale for this request?**

Unexpanded panels show their content temporarily until Vue loads
completely.

Let's add some temp styles to panel tags that reduce this FOUC.

**Provide some example code that this change will affect:**

**Is there anything you'd like reviewers to focus on?**

View the preview site, see if there is a flash of the unexpanded panel on page load.
