### PR TITLE
Fix broken link in User Guide

### DIFF
--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -78,7 +78,7 @@ MarkBind Command Line Interface (CLI) can be run in the following ways:
   Root directory. Default is the current directory.<br>
   {{ icon_example }} `./myWebsite`
 * `-c`, `--convert`<br>
-  Convert an existing GitHub wiki or `docs` folder into a MarkBind website. See [Converting an existing Github project]({{ baseUrl }}/userGuide/markBindInTheProjectWorkflow.html#converting-an-existing-github-project) for more information.
+  Convert an existing GitHub wiki or `docs` folder into a MarkBind website. See [Converting an existing Github project]({{ baseUrl }}/userGuide/markBindInTheProjectWorkflow.html#converting-existing-project-documentation-wiki) for more information.
 
 {{ icon_examples }}
 * `markbind init` : Initializes the site in the current working directory.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X ] Documentation update
• [X ] Bug fix

Fixes #843 
**What is the rationale for this request?**
To fix a broken link in the user guide.

**What changes did you make? (Give an overview)**
I replaced a link in `userGuide/cliCommands.md`.

**Provide some example code that this change will affect:**
N.A. 
**Is there anything you'd like reviewers to focus on?**
N.A.

**Testing instructions:**
Manually verify the correctness of the new link using a locally generated copy of the site.

**Proposed commit message: (wrap lines at 72 characters)**
```
User Guide: Fix broken link to section on converting an existing wiki

There is a broken link in the explanation of the `init` command,
under the References section of the user guide.

Let's replace this link with the correct link, so information is
communicated effectively to users.
```
