### PR TITLE
README.md: add link to Developer Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@
 **The MarkBind website for the current MarkBind release is at https://markbind.org/**.
 
 The website for the latest master branch (not yet released to the public) is at https://markbind-master.netlify.com.
+
+The Developer Guide can be found at https://markbind.org/devdocs/devGuide/index.html


### PR DESCRIPTION
• [X] Documentation update
Fixes #845 
Add the link to the Developer Guide in README.