### PR TITLE
Modify user guide templates to have one click netlify deploy

### DIFF
--- a/docs/userGuide/templates.md
+++ b/docs/userGuide/templates.md
@@ -16,7 +16,7 @@ markbind init --template minimal
 
 ## Supported Templates
 
-Name    | Template key | Description
-----    | -------      | ------
-Default | `default`    | Default template if `--template` is unspecified. Filled with Markbind features to guide you to author better content.
-Minimal | `minimal`    | Minimalistic template that gets you started quickly
+Name    | Template key | Description | Quick Deploy
+----    | -------      | ----------- | ------------
+Default | `default`    | Default template if `--template` is unspecified. Filled with Markbind features to guide you to author better content. | <a href="https://app.netlify.com/start/deploy?repository=https://github.com/MarkBind/init-typical-netlify"><img src="https://www.netlify.com/img/deploy/button.svg" /></a>
+Minimal | `minimal` | Minimalistic template that gets you started quickly | <a href="https://app.netlify.com/start/deploy?repository=https://github.com/MarkBind/init-minimal-netlify"><img src="https://www.netlify.com/img/deploy/button.svg" /></a>


### PR DESCRIPTION
Resolves #479.

Apart from adding one click deploy in staticgen.com, this PR also provide this capability in the user guide:

![image](https://user-images.githubusercontent.com/4986717/69694269-228df180-1113-11ea-84a8-2ebcb47de811.png)
