### PR TITLE
Fix expected help message to show header

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,21 @@ function handleError(error) {
   process.exitCode = 1;
 }
 
+// We want to customize the help message to print MarkBind's header,
+// but commander.js does not provide an API directly for doing so.
+// Hence we override commander's outputHelp() completely.
+program.defaultOutputHelp = program.outputHelp;
+program.outputHelp = function (cb) {
+  printHeader();
+  this.defaultOutputHelp(cb);
+};
+
 program
   .allowUnknownOption()
   .usage(' <command>');
 
 program
+  .name('markbind')
   .version(CLI_VERSION);
 
 program
@@ -236,7 +246,6 @@ if (!program.args.length
   if (program.args.length) {
     logger.warn(`Command '${program.args[0]}' doesn't exist, run "markbind --help" to list commands.`);
   } else {
-    printHeader();
     program.help();
   }
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug Fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves #644 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Improves consistency of markbind's CLI interface.

**What changes did you make? (Give an overview)**

I added a function to handle help messages for use with commander. The function prints the banner and is used in commander's ```helpOption()``` method.

**Provide some example code that this change will affect:**
<!-- Paste the example code below: -->
```
function handleHelp(txt) {
  printHeader();
  logger.log('');
  return txt;
}
program
  .helpOption('-h, --help', handleHelp('output usage information'));
```

**Is there anything you'd like reviewers to focus on?**

Updating of the commander module to latest version, whether it was done properly.

**Testing instructions:**

From the main working directory, run ```node index.js -h```

**Proposed commit message: (wrap lines at 72 characters)**

Fixes CLI help command.

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
