### PR TITLE
Refactor constants to a separate file

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ const fsUtil = require('./src/util/fsUtil');
 const logger = require('./src/util/logger');
 const Site = require('./src/Site');
 
-const ACCEPTED_COMMANDS = ['init', 'build', 'serve', 'deploy'];
-const ACCEPTED_COMMANDS_ALIAS = ['i', 'b', 's', 'd'];
+const { ACCEPTED_COMMANDS, ACCEPTED_COMMANDS_ALIAS } = require('./src/constants');
 const CLI_VERSION = require('./package.json').version;
 
 process.title = 'MarkBind';

--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ const fsUtil = require('./src/util/fsUtil');
 const logger = require('./src/util/logger');
 const Site = require('./src/Site');
 
-const { ACCEPTED_COMMANDS, ACCEPTED_COMMANDS_ALIAS } = require('./src/constants');
+const {
+  ACCEPTED_COMMANDS,
+  ACCEPTED_COMMANDS_ALIAS,
+} = require('./src/constants');
 const CLI_VERSION = require('./package.json').version;
 
 process.title = 'MarkBind';

--- a/src/Page.js
+++ b/src/Page.js
@@ -19,33 +19,30 @@ const md = require('./lib/markbind/src/lib/markdown-it');
 
 const CLI_VERSION = require('../package.json').version;
 
-const FOOTERS_FOLDER_PATH = '_markbind/footers';
-const HEAD_FOLDER_PATH = '_markbind/head';
-const HEADERS_FOLDER_PATH = '_markbind/headers';
-const LAYOUT_DEFAULT_NAME = 'default';
-const LAYOUT_FOLDER_PATH = '_markbind/layouts';
-const LAYOUT_FOOTER = 'footer.md';
-const LAYOUT_HEAD = 'head.md';
-const LAYOUT_HEADER = 'header.md';
-const LAYOUT_NAVIGATION = 'navigation.md';
-const NAVIGATION_FOLDER_PATH = '_markbind/navigation';
-
-const CONTENT_WRAPPER_ID = 'content-wrapper';
-const FRONT_MATTER_FENCE = '---';
-const PAGE_NAV_ID = 'page-nav';
-const PAGE_NAV_TITLE_CLASS = 'page-nav-title';
-const SITE_NAV_ID = 'site-nav';
-const SITE_NAV_LIST_CLASS = 'site-nav-list';
-const TITLE_PREFIX_SEPARATOR = ' - ';
-
-const DROPDOWN_BUTTON_ICON_HTML = '<i class="dropdown-btn-icon">\n'
-  + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
-  + '</i>';
-const DROPDOWN_EXPAND_KEYWORD = ':expanded:';
-
-const TEMP_NAVBAR_CLASS = 'temp-navbar';
-const TEMP_DROPDOWN_CLASS = 'temp-dropdown';
-const TEMP_DROPDOWN_PLACEHOLDER_CLASS = 'temp-dropdown-placeholder';
+const {
+  FOOTERS_FOLDER_PATH,
+  HEAD_FOLDER_PATH,
+  HEADERS_FOLDER_PATH,
+  LAYOUT_DEFAULT_NAME,
+  LAYOUT_FOLDER_PATH,
+  LAYOUT_FOOTER,
+  LAYOUT_HEAD,
+  LAYOUT_HEADER,
+  LAYOUT_NAVIGATION,
+  NAVIGATION_FOLDER_PATH,
+  CONTENT_WRAPPER_ID,
+  FRONT_MATTER_FENCE,
+  PAGE_NAV_ID,
+  PAGE_NAV_TITLE_CLASS,
+  SITE_NAV_ID,
+  SITE_NAV_LIST_CLASS,
+  TITLE_PREFIX_SEPARATOR,
+  DROPDOWN_BUTTON_ICON_HTML,
+  DROPDOWN_EXPAND_KEYWORD,
+  TEMP_NAVBAR_CLASS,
+  TEMP_DROPDOWN_CLASS,
+  TEMP_DROPDOWN_PLACEHOLDER_CLASS,
+} = require('./constants');
 
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities

--- a/src/Site.js
+++ b/src/Site.js
@@ -34,29 +34,31 @@ const Template = require('./template/template');
 
 const CLI_VERSION = require('../package.json').version;
 
-const CONFIG_FOLDER_NAME = '_markbind';
-const HEADING_INDEXING_LEVEL_DEFAULT = 3;
-const SITE_ASSET_FOLDER_NAME = 'asset';
-const TEMP_FOLDER_NAME = '.temp';
-const TEMPLATE_SITE_ASSET_FOLDER_NAME = 'markbind';
-
-const ABOUT_MARKDOWN_FILE = 'about.md';
-const BUILT_IN_PLUGIN_FOLDER_NAME = 'plugins';
-const BUILT_IN_DEFAULT_PLUGIN_FOLDER_NAME = 'plugins/default';
-const FAVICON_DEFAULT_PATH = 'favicon.ico';
-const FOOTER_PATH = '_markbind/footers/footer.md';
-const INDEX_MARKDOWN_FILE = 'index.md';
-const MARKBIND_PLUGIN_PREFIX = 'markbind-plugin-';
-const PAGE_TEMPLATE_NAME = 'page.ejs';
-const PROJECT_PLUGIN_FOLDER_NAME = '_markbind/plugins';
-const SITE_CONFIG_NAME = 'site.json';
-const SITE_DATA_NAME = 'siteData.json';
-const LAYOUT_DEFAULT_NAME = 'default';
-const LAYOUT_FOLDER_PATH = '_markbind/layouts';
-const LAYOUT_SITE_FOLDER_NAME = 'layouts';
-const USER_VARIABLES_PATH = '_markbind/variables.md';
-const WIKI_SITE_NAV_PATH = '_Sidebar.md';
-const WIKI_FOOTER_PATH = '_Footer.md';
+const {
+  CONFIG_FOLDER_NAME,
+  HEADING_INDEXING_LEVEL_DEFAULT,
+  SITE_ASSET_FOLDER_NAME,
+  TEMP_FOLDER_NAME,
+  TEMPLATE_SITE_ASSET_FOLDER_NAME,
+  ABOUT_MARKDOWN_FILE,
+  BUILT_IN_PLUGIN_FOLDER_NAME,
+  BUILT_IN_DEFAULT_PLUGIN_FOLDER_NAME,
+  FAVICON_DEFAULT_PATH,
+  FOOTER_PATH,
+  INDEX_MARKDOWN_FILE,
+  MARKBIND_PLUGIN_PREFIX,
+  MARKBIND_WEBSITE_URL,
+  PAGE_TEMPLATE_NAME,
+  PROJECT_PLUGIN_FOLDER_NAME,
+  SITE_CONFIG_NAME,
+  SITE_DATA_NAME,
+  LAYOUT_DEFAULT_NAME,
+  LAYOUT_FOLDER_PATH,
+  LAYOUT_SITE_FOLDER_NAME,
+  USER_VARIABLES_PATH,
+  WIKI_SITE_NAV_PATH,
+  WIKI_FOOTER_PATH,
+} = require('./constants');
 
 function getBootswatchThemePath(theme) {
   return path.join(__dirname, '..', 'node_modules', 'bootswatch', 'dist', theme, 'bootstrap.min.css');
@@ -97,7 +99,6 @@ const TOP_NAV_DEFAULT = '<header><navbar placement="top" type="inverse">\n'
   + '  </li>\n'
   + '</navbar></header>';
 
-const MARKBIND_WEBSITE_URL = 'https://markbind.org/';
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${CLI_VERSION}</a>`;
 
 function Site(rootPath, outputPath, onePagePath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
@@ -616,7 +617,7 @@ Site.prototype._buildMultipleAssets = function (filePaths) {
  * @param filePaths a single path or an array of paths corresponding to the assets to build
  */
 Site.prototype.buildAsset
- = delay(Site.prototype._buildMultipleAssets, 1000);
+  = delay(Site.prototype._buildMultipleAssets, 1000);
 
 Site.prototype._removeMultipleAssets = function (filePaths) {
   const filePathArray = Array.isArray(filePaths) ? filePaths : [filePaths];
@@ -634,7 +635,7 @@ Site.prototype._removeMultipleAssets = function (filePaths) {
  * @param filePaths a single path or an array of paths corresponding to the assets to remove
  */
 Site.prototype.removeAsset
- = delay(Site.prototype._removeMultipleAssets, 1000);
+  = delay(Site.prototype._removeMultipleAssets, 1000);
 
 Site.prototype.buildAssets = function () {
   logger.info('Building assets...');

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,29 +56,16 @@ module.exports = {
   WIKI_FOOTER_PATH: '_Footer.md',
   MARKBIND_WEBSITE_URL: 'https://markbind.org/',
 
-  // src/lib/parser.js
-  ATTRIB_INCLUDE_PATH: 'include-path',
-  ATTRIB_CWF: 'cwf',
-
-  BOILERPLATE_FOLDER_NAME: '_markbind/boilerplates',
-  /* Imported global variables will be assigned a namespace.
-   * A prefix is appended to reduce clashes with other variables in the page.
-   */
-  IMPORTED_VARIABLE_PREFIX: '$__MARKBIND__',
-
-  // src/lib/utils.js
-  markdownFileExts: ['md', 'mbd', 'mbdf'],
-
-  // plugins/algolia.js
+  // src/plugins/algolia.js
   ALGOLIA_CSS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
   ALGOLIA_JS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js',
   ALGOLIA_INPUT_SELECTOR: '#algolia-search-input',
 
-  // plugins/default/markbind-plugin-anchors.js
+  // src/plugins/default/markbind-plugin-anchors.js
   ANCHOR_HTML: '<a class="fa fa-anchor" href="#"></a>',
   HEADER_TAGS: 'h1, h2, h3, h4, h5, h6',
 
-  // plugins/default/markbind-plugin-plantuml.js
+  // src/plugins/default/markbind-plugin-plantuml.js
   ERR_PROCESSING: 'Error processing',
   ERR_READING: 'Error reading',
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,90 @@
+module.exports = {
+  // index.js
+  ACCEPTED_COMMANDS: ['init', 'build', 'serve', 'deploy'],
+  ACCEPTED_COMMANDS_ALIAS: ['i', 'b', 's', 'd'],
+
+  // src/Page.js
+  FOOTERS_FOLDER_PATH: '_markbind/footers',
+  HEAD_FOLDER_PATH: '_markbind/head',
+  HEADERS_FOLDER_PATH: '_markbind/headers',
+  LAYOUT_DEFAULT_NAME: 'default',
+  LAYOUT_FOLDER_PATH: '_markbind/layouts',
+  LAYOUT_FOOTER: 'footer.md',
+  LAYOUT_HEAD: 'head.md',
+  LAYOUT_HEADER: 'header.md',
+  LAYOUT_NAVIGATION: 'navigation.md',
+  NAVIGATION_FOLDER_PATH: '_markbind/navigation',
+
+  CONTENT_WRAPPER_ID: 'content-wrapper',
+  FRONT_MATTER_FENCE: '---',
+  PAGE_NAV_ID: 'page-nav',
+  PAGE_NAV_TITLE_CLASS: 'page-nav-title',
+  SITE_NAV_ID: 'site-nav',
+  SITE_NAV_LIST_CLASS: 'site-nav-list',
+  TITLE_PREFIX_SEPARATOR: ' - ',
+
+  DROPDOWN_BUTTON_ICON_HTML: '<i class="dropdown-btn-icon">\n'
+  + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
+  + '</i>',
+  DROPDOWN_EXPAND_KEYWORD: ':expanded:',
+
+  TEMP_NAVBAR_CLASS: 'temp-navbar',
+  TEMP_DROPDOWN_CLASS: 'temp-dropdown',
+  TEMP_DROPDOWN_PLACEHOLDER_CLASS: 'temp-dropdown-placeholder',
+
+  // src/Site.js
+  CONFIG_FOLDER_NAME: '_markbind',
+  HEADING_INDEXING_LEVEL_DEFAULT: 3,
+  SITE_ASSET_FOLDER_NAME: 'asset',
+  TEMP_FOLDER_NAME: '.temp',
+  TEMPLATE_SITE_ASSET_FOLDER_NAME: 'markbind',
+
+  ABOUT_MARKDOWN_FILE: 'about.md',
+  BUILT_IN_PLUGIN_FOLDER_NAME: 'plugins',
+  BUILT_IN_DEFAULT_PLUGIN_FOLDER_NAME: 'plugins/default',
+  FAVICON_DEFAULT_PATH: 'favicon.ico',
+  FOOTER_PATH: '_markbind/footers/footer.md',
+  INDEX_MARKDOWN_FILE: 'index.md',
+  MARKBIND_PLUGIN_PREFIX: 'markbind-plugin-',
+  PAGE_TEMPLATE_NAME: 'page.ejs',
+  PROJECT_PLUGIN_FOLDER_NAME: '_markbind/plugins',
+  SITE_CONFIG_NAME: 'site.json',
+  SITE_DATA_NAME: 'siteData.json',
+  LAYOUT_SITE_FOLDER_NAME: 'layouts',
+  USER_VARIABLES_PATH: '_markbind/variables.md',
+  WIKI_SITE_NAV_PATH: '_Sidebar.md',
+  WIKI_FOOTER_PATH: '_Footer.md',
+  MARKBIND_WEBSITE_URL: 'https://markbind.org/',
+
+  // src/lib/parser.js
+  ATTRIB_INCLUDE_PATH: 'include-path',
+  ATTRIB_CWF: 'cwf',
+
+  BOILERPLATE_FOLDER_NAME: '_markbind/boilerplates',
+  /* Imported global variables will be assigned a namespace.
+   * A prefix is appended to reduce clashes with other variables in the page.
+   */
+  IMPORTED_VARIABLE_PREFIX: '$__MARKBIND__',
+
+  // src/lib/utils.js
+  markdownFileExts: ['md', 'mbd', 'mbdf'],
+
+  // plugins/algolia.js
+  ALGOLIA_CSS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
+  ALGOLIA_JS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js',
+  ALGOLIA_INPUT_SELECTOR: '#algolia-search-input',
+
+  // plugins/default/markbind-plugin-anchors.js
+  ANCHOR_HTML: '<a class="fa fa-anchor" href="#"></a>',
+  HEADER_TAGS: 'h1, h2, h3, h4, h5, h6',
+
+  // plugins/default/markbind-plugin-plantuml.js
+  ERR_PROCESSING: 'Error processing',
+  ERR_READING: 'Error reading',
+
+  // src/template/template.js
+  requiredFiles: ['index.md', 'site.json', '_markbind/'],
+
+  // src/util/fsUtil.js
+  sourceFileExtNames: ['.html', '.md', '.mbd', '.mbdf', '.puml'],
+};

--- a/src/lib/markbind/src/constants.js
+++ b/src/lib/markbind/src/constants.js
@@ -1,5 +1,5 @@
 module.exports = {
-  // src/lib/parser.js
+  // src/lib/markbind/src/parser.js
   ATTRIB_INCLUDE_PATH: 'include-path',
   ATTRIB_CWF: 'cwf',
 
@@ -10,6 +10,6 @@ module.exports = {
    */
   IMPORTED_VARIABLE_PREFIX: '$__MARKBIND__',
 
-  // src/lib/utils.js
+  // src/lib/markbind/src/utils.js
   markdownFileExts: ['md', 'mbd', 'mbdf'],
 };

--- a/src/lib/markbind/src/constants.js
+++ b/src/lib/markbind/src/constants.js
@@ -1,0 +1,15 @@
+module.exports = {
+  // src/lib/parser.js
+  ATTRIB_INCLUDE_PATH: 'include-path',
+  ATTRIB_CWF: 'cwf',
+
+  BOILERPLATE_FOLDER_NAME: '_markbind/boilerplates',
+
+  /* Imported global variables will be assigned a namespace.
+   * A prefix is appended to reduce clashes with other variables in the page.
+   */
+  IMPORTED_VARIABLE_PREFIX: '$__MARKBIND__',
+
+  // src/lib/utils.js
+  markdownFileExts: ['md', 'mbd', 'mbdf'],
+};

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -22,15 +22,13 @@ const utils = require('./utils');
 cheerio.prototype.options.xmlMode = true; // Enable xml mode for self-closing tag
 cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
 
-const ATTRIB_INCLUDE_PATH = 'include-path';
-const ATTRIB_CWF = 'cwf';
+const {
+  ATTRIB_INCLUDE_PATH,
+  ATTRIB_CWF,
+  BOILERPLATE_FOLDER_NAME,
+  IMPORTED_VARIABLE_PREFIX,
+} = require('../../../constants');
 
-const BOILERPLATE_FOLDER_NAME = '_markbind/boilerplates';
-
-/* Imported global variables will be assigned a namespace.
- * A prefix is appended to reduce clashes with other variables in the page.
- */
-const IMPORTED_VARIABLE_PREFIX = '$__MARKBIND__';
 const VARIABLE_LOOKUP = new Map();
 const FILE_ALIASES = new Map();
 const PROCESSED_INNER_VARIABLES = new Set();

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -27,7 +27,7 @@ const {
   ATTRIB_CWF,
   BOILERPLATE_FOLDER_NAME,
   IMPORTED_VARIABLE_PREFIX,
-} = require('../../../constants');
+} = require('./constants');
 
 const VARIABLE_LOOKUP = new Map();
 const FILE_ALIASES = new Map();

--- a/src/lib/markbind/src/utils.js
+++ b/src/lib/markbind/src/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const markdownFileExts = ['md', 'mbd', 'mbdf'];
+const { markdownFileExts } = require('../../../constants');
 
 module.exports = {
   getCurrentDirectoryBase() {

--- a/src/lib/markbind/src/utils.js
+++ b/src/lib/markbind/src/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { markdownFileExts } = require('../../../constants');
+const { markdownFileExts } = require('./constants');
 
 module.exports = {
   getCurrentDirectoryBase() {

--- a/src/plugins/algolia.js
+++ b/src/plugins/algolia.js
@@ -1,8 +1,10 @@
 const cheerio = module.parent.require('cheerio');
 
-const ALGOLIA_CSS_URL = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css';
-const ALGOLIA_JS_URL = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
-const ALGOLIA_INPUT_SELECTOR = '#algolia-search-input';
+const {
+  ALGOLIA_CSS_URL,
+  ALGOLIA_JS_URL,
+  ALGOLIA_INPUT_SELECTOR,
+} = require('../constants');
 
 function buildAlgoliaInitScript(pluginContext) {
   return `<script>

--- a/src/plugins/default/markbind-plugin-anchors.js
+++ b/src/plugins/default/markbind-plugin-anchors.js
@@ -1,8 +1,11 @@
 const cheerio = module.parent.require('cheerio');
 const md = require('./../../lib/markbind/src/lib/markdown-it');
 
-const ANCHOR_HTML = '<a class="fa fa-anchor" href="#"></a>';
-const HEADER_TAGS = 'h1, h2, h3, h4, h5, h6';
+const {
+  ANCHOR_HTML,
+  HEADER_TAGS,
+} = require('../../constants');
+
 /**
  * Adds anchor links to headers
  */

--- a/src/plugins/default/markbind-plugin-plantuml.js
+++ b/src/plugins/default/markbind-plugin-plantuml.js
@@ -11,8 +11,10 @@ const logger = require('../../util/logger');
 
 const JAR_PATH = path.resolve(__dirname, 'plantuml.jar');
 
-const ERR_PROCESSING = 'Error processing';
-const ERR_READING = 'Error reading';
+const {
+  ERR_PROCESSING,
+  ERR_READING,
+} = require('../../constants');
 
 // Tracks diagrams that have already been processed
 const processedDiagrams = new Set();

--- a/src/template/template.js
+++ b/src/template/template.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs-extra-promise');
 const fsUtils = require('../util/fsUtil');
 
-const requiredFiles = ['index.md', 'site.json', '_markbind/'];
+const { requiredFiles } = require('../constants');
 
 function Template(rootPath, templatePath) {
   this.rootPath = rootPath;

--- a/src/util/cliUtil.js
+++ b/src/util/cliUtil.js
@@ -2,7 +2,7 @@ const findUp = require('find-up');
 const fs = require('fs-extra-promise');
 const path = require('path');
 
-const SITE_CONFIG_NAME = 'site.json';
+const { SITE_CONFIG_NAME } = require('../constants');
 
 module.exports = {
   findRootFolder: (userSpecifiedRoot, siteConfigPath = SITE_CONFIG_NAME) => {

--- a/src/util/fsUtil.js
+++ b/src/util/fsUtil.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra-promise');
 
-const sourceFileExtNames = ['.html', '.md', '.mbd', '.mbdf', '.puml'];
+const { sourceFileExtNames } = require('../constants');
 
 module.exports = {
   isSourceFile(filePath) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

• [x] Other: Refactoring constants into a separate file.

Fixes #597 

**What is the rationale for this request?**
Currently, there are multiple occurrences of the same constant across multiple files e.g. `LAYOUT_FOLDER_PATH`. This PR addresses this issue by keeping all constants in a single file.

**What changes did you make?**
Moved all constants in functional code to a new file - `src/constants.js`.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
module.exports = {
  // index.js
  ACCEPTED_COMMANDS: ['init', 'build', 'serve', 'deploy'],
  ACCEPTED_COMMANDS_ALIAS: ['i', 'b', 's', 'd'],

  // src/Page.js
  FOOTERS_FOLDER_PATH: '_markbind/footers',
  HEAD_FOLDER_PATH: '_markbind/head',
  ...
  ...
}
```

**Proposed commit message: (wrap lines at 72 characters)**
Refactor constants to a separate file
