### PR TITLE
Allow live reloading for plugin defined sources

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -143,6 +143,34 @@ This will add the following link and script elements to the page:
 - `<script src="SCRIPT_LINK"></script>`
 - `<script>alert("hello")</script>`
 
+#### Live reload
+
+By default, MarkBind treats `.html`, `.md`, `.mbd`, and `.mbdf` as source files, and will rebuild any
+pages changed when serving the page.
+
+During the `preRender` and `postRender` stages however, plugins may do custom processing using some other
+source file types, as parsed from the raw Markdown, typically requiring rebuilding the site.
+
+Hence, to add custom source files to watch, you can implement the `getSources()` method.
+- `getSources(content, pluginContext, frontMatter)`: Returns an array of source file paths to watch. Called **before** a Markdown file's `preRender` function is called.
+  - `content`: The raw Markdown of the current Markdown file (`.md`, `.mbd`, etc.).
+  - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
+  - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+
+Example usage of `getSources` from the PlantUML plugin:
+
+```js
+{
+  ...
+  getSources: (content) => {
+    // Add all src attributes in <puml> tags to watch list
+    const $ = cheerio.load(content, { xmlMode: true });
+
+    return $('puml').map((i, tag) => tag.attribs.src).get();
+  },
+}
+```
+
 ### Advanced: Default plugins
 
 MarkBind has a set of default plugins that it uses to carry out some of its features. These are enabled by default for every project and should be left alone.

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ program
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath)) {
+        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
           return site.rebuildSourceFiles(filePath);
         }
         return site.buildAsset(filePath);
@@ -131,7 +131,7 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath)) {
+        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);
         }
         return site.buildAsset(filePath);
@@ -143,7 +143,7 @@ program
     const removeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath)) {
+        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
           return site.rebuildSourceFiles(filePath);
         }
         return site.removeAsset(filePath);

--- a/src/Site.js
+++ b/src/Site.js
@@ -700,6 +700,15 @@ function findDefaultPlugins() {
 }
 
 /**
+ * Checks if a specified file path is a plugin source file
+ * @param filePath file path to check
+ * @returns {boolean} whether the file path matches a plugin source file path
+ */
+Site.prototype.isPluginSourceFile = function (filePath) {
+  return this.pages.some(page => page.pluginSourceFiles.has(filePath));
+};
+
+/**
  * Loads a plugin
  * @param plugin name of the plugin
  * @param isDefault whether the plugin is a default plugin
@@ -827,7 +836,12 @@ Site.prototype.regenerateAffectedPages = function (filePaths) {
   }
   this._setTimestampVariable();
   this.pages.forEach((page) => {
-    if (shouldRebuildAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
+    if (shouldRebuildAllPages || filePaths.some((filePath) => {
+      const isIncludedFile = page.includedFiles.has(filePath);
+      const isPluginSourceFile = page.pluginSourceFiles.has(filePath);
+
+      return isIncludedFile || isPluginSourceFile;
+    })) {
       // eslint-disable-next-line no-param-reassign
       page.userDefinedVariablesMap = this.userDefinedVariablesMap;
       processingFiles.push(page.generate(builtFiles)

--- a/src/constants.js
+++ b/src/constants.js
@@ -73,5 +73,5 @@ module.exports = {
   requiredFiles: ['index.md', 'site.json', '_markbind/'],
 
   // src/util/fsUtil.js
-  sourceFileExtNames: ['.html', '.md', '.mbd', '.mbdf', '.puml'],
+  sourceFileExtNames: ['.html', '.md', '.mbd', '.mbdf'],
 };

--- a/src/plugins/default/markbind-plugin-plantuml.js
+++ b/src/plugins/default/markbind-plugin-plantuml.js
@@ -85,12 +85,9 @@ function generateDiagram(src, cwf, config) {
       errorLog += errorMsg;
     });
 
-    childProcess.on('close', (code) => {
-      if (code !== 0) {
-        logger.error(`${ERR_PROCESSING} ${rawDiagramPath}`);
-        // This goes to the log file, but not shown on the console
-        logger.debug(errorLog);
-      }
+    childProcess.on('exit', () => {
+      // This goes to the log file, but not shown on the console
+      logger.debug(errorLog);
     });
   });
 
@@ -99,6 +96,8 @@ function generateDiagram(src, cwf, config) {
 
 module.exports = {
   preRender: (content, pluginContext, frontmatter, config) => {
+    // Clear <puml> tags processed before for live reload
+    processedDiagrams.clear();
     // Processes all <puml> tags
     const $ = cheerio.load(content, { xmlMode: true });
     $('puml').each((i, tag) => {
@@ -110,5 +109,11 @@ module.exports = {
     });
 
     return $.html();
+  },
+  getSources: (content) => {
+    // Add all src attributes in <puml> tags to watch list
+    const $ = cheerio.load(content, { xmlMode: true });
+
+    return $('puml').map((i, tag) => tag.attribs.src).get();
   },
 };

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -465,6 +465,34 @@ specification that specifies how the product will address the requirements. </sp
           <p>Node Modules Plugin Post-render</p>
         </div>
         <p><strong>Test search indexing</strong></p>
+        <p><strong>Test PlantUML live reload without include</strong>
+          <pic src="/test_site/diagrams/activity.png" alt="activity diagram"></pic>
+        </p>
+        <p><strong>Test PlantUML live reload with include</strong></p>
+        <div>
+          <p><strong>PlantUML Test</strong></p>
+          <p><strong>Sequence Diagram</strong>
+            <pic src="/test_site/diagrams/sequence.png"></pic>
+          </p>
+          <p><strong>Use Case Diagram</strong>
+            <pic src="/test_site/diagrams/usecase.png"></pic>
+          </p>
+          <p><strong>Class Diagram</strong>
+            <pic src="/test_site/diagrams/class.png"></pic>
+          </p>
+          <p><strong>Activity Diagram</strong>
+            <pic src="/test_site/diagrams/activity.png"></pic>
+          </p>
+          <p><strong>Component Diagram</strong>
+            <pic src="/test_site/diagrams/component.png"></pic>
+          </p>
+          <p><strong>State Diagram</strong>
+            <pic src="/test_site/diagrams/state.png"></pic>
+          </p>
+          <p><strong>Object Diagram</strong>
+            <pic src="/test_site/diagrams/object.png"></pic>
+          </p>
+        </div>
         <h2 class="no-index" id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed">Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed<a class="fa fa-anchor" href="#level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed"></a></h2>
         <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed<a class="fa fa-anchor" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed"></a></h6>
         <hr class="footnotes-sep">

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -276,6 +276,12 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 **Test search indexing**
 
+**Test PlantUML live reload without include**
+<puml src="diagrams/activity.puml" alt="activity diagram" />
+
+**Test PlantUML live reload with include**
+<include src="testPlantUML.md" />
+
 ## Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed {.no-index}
 
 ###### Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed {.always-index}


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] Enhancement to an existing feature

Resolves #913 
<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
To allow plugins to define their own source file types and corresponding
source files that will be watched and updated by the live preview appropriately.

**What changes did you make? (Give an overview)**
- Plugins can a new attribute in its exports: `getSources`
  - `getSources`: Allows plugins to return an array of source file paths to watch
- Similar to `Page.prototype.preRender`, `Page.prototype.getSources` runs `getSources` all plugins just before
`preRender`.
- Updated relavant test files

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
(Plant uml plugin file)
module.exports = {
  ...,
  getSources: (content) => {
    // Add all src attributes in <puml> tags to watch list
    const $ = cheerio.load(content, { xmlMode: true });

    return $('puml').map((i, tag) => tag.attribs.src).get();
  },
```

**Is there anything you'd like reviewers to focus on?**
Whether a callback style solution would be better ( a 5th parameter to `preRender / postRender` that contains callbacks plugins can use ), since in the long run one may find plugins requiring more and more functionality.

**Testing instructions:**
I added a `<puml>` tag, and an `<include>` tag ( including testPlantUML.md )
to the test site. Changing any of the source files ( e.g. `activity.puml` ) should
cause the affected pages to reload when serving the page.

**Proposed commit message: (wrap lines at 72 characters)**
Allow live reloading for plugin defined sources

This allows plugins to define a custom list of source files and file
types for the page to be watched, allowing live reload to rebuild
the affected page.

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
