### PR TITLE
Add language indicator to code blocks

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;

--- a/docs/userGuide/syntax/code.mbdf
+++ b/docs/userGuide/syntax/code.mbdf
@@ -1,6 +1,6 @@
 ## Code
 
-MarkBind can provide syntax coloring for a code block (aka _Fenced Code Blocks_).
+MarkBind can provide syntax coloring for a code block (aka _Fenced Code Blocks_). The language of the code block is labelled as well.
 <span id="main-example">
 <include src="outputBox.md" boilerplate >
 <span id="code">

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;

--- a/test/functional/test_site/expected/requirements/UserStories._include_.html
+++ b/test/functional/test_site/expected/requirements/UserStories._include_.html
@@ -2,10 +2,13 @@
 <p>A commonly used format for writing user stories is:<br>
   <strong><code>As a</code></strong> <code>&lt;use type/role&gt;</code> <strong><code>I can</code></strong> <code>&lt;function&gt;</code> <strong><code>so that</code></strong> <code>&lt;benefit&gt;</code></p>
 <p>Here are some examples of user stories for the IVLE system:</p>
-<pre><code class="hljs bat">* As a student, I can download files uploaded by lecturers, so that I can get my own <span class="hljs-built_in">copy</span> of the files.
+<div class="code-block">
+  <pre><code class="hljs bat">* As a student, I can download files uploaded by lecturers, so that I can get my own <span class="hljs-built_in">copy</span> of the files.
 * As a lecturer, I can create discussion forums, so that students can discuss things online.
 * As a tutor, I can <span class="hljs-built_in">print</span> attendance sheets, so that I can take attendance during the class.
 </code></pre>
+  <div class="code-block-lang"><span>bat</span></div>
+</div>
 <p>The <code>&lt;benefit&gt;</code> can be omitted if it is obvious. E.g. As a tutor, I can print attendance sheets. User stories are mainly used for early estimation and scheduling purposes.</p>
 <p>According to
   <ref xp-website="">this

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;

--- a/test/functional/test_site_templates/test_default/expected/index.html
+++ b/test/functional/test_site_templates/test_default/expected/index.html
@@ -88,10 +88,13 @@
           </li>
         </ul>
         <p><strong>A <code>code</code> example:</strong></p>
-        <pre><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span>
+        <div class="code-block">
+          <pre><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span>
 </code></pre>
+          <div class="code-block-lang"><span>html</span></div>
+        </div>
         <h2 id="sub-heading-1-1">Sub Heading 1.1<a class="fa fa-anchor" href="#sub-heading-1-1"></a></h2>
         <p>A
           <tooltip effect="scale" content=":exclamation: some **important explanation**" placement="top" trigger="hover">tooltip</tooltip>, a

--- a/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;

--- a/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
@@ -24,6 +24,26 @@ pre > code.hljs {
     border-radius: 5px;
 }
 
+.code-block {
+    position: relative;
+}
+
+.code-block > .code-block-lang {
+    background-color: #b4b4b9;
+    border-radius: 0.25rem;
+    color: #f8f8ff;
+    display: inline-block;
+    font-size: 75%;
+    line-height: 1;
+    padding: 0.25em 0.4em;
+    position: absolute;
+    right: 0.3em;
+    text-align: center;
+    top: 0.4em;
+    vertical-align: baseline;
+    white-space: nowrap;
+}
+
 kbd {
     background-color: #fafbfc;
     border: 1px solid #c6cbd1;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #646 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Developer documentation sometimes includes code to do one thing in multiple languages (eg. API use in multiple languages). It can be helpful to indicate the language of a code block in the block itself.

**What changes did you make? (Give an overview)**
- In `lib\markdown-it\index.js`, I rewrote the rule for a markdown fenced code block, to add a div that will show the name of the language of that code block (if a language is specified). 
- Because I had to position the div relative to the code block, I had to wrap the code block as a parent div so that I can position the child div according to the parent. `markbind.css` 

Here is how it looks like

![image](https://user-images.githubusercontent.com/27397021/70899194-18378700-2031-11ea-91e3-3d2ea33bd7f7.png)

~~This is a WIP, I believe I am failing some tests ('Test test_site Failed').~~ And will be mentioned later, I'm open to a better solution. ~~Plus, I will remove a particular `console.log` asap.~~ ~~I have yet to update UserGuide.~~

I am not sure if I need to update User Guide, as a deployment of the Markbind docs will now show the output code blocks with the code language labels. So I'll remove [WIP], I'll put it back to WIP if there a outstanding changes to be made.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->

https://gist.github.com/nbriannl/755a2d05145a27e3dc7e5797c25f4a5f 
Include the markdown code from this gist and `markbind serve` to see the changes.

Or even simply view the netifly preview and view `/userguide/fullsyntaxreference`

**Is there anything you'd like reviewers to focus on?**

First time contributing, I am open if there is a more elegant solution to obtain the language of the code block. I can also consider looking into the direction #629 did, since it is regarding adding a copy button instead of a language to a code block. 

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

Add language indicator to code blocks

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
