### PR TITLE
Fix heading indexing for pure html headings

### DIFF
--- a/docs/userGuide/makingTheSiteSearchable.md
+++ b/docs/userGuide/makingTheSiteSearchable.md
@@ -18,7 +18,7 @@
 **MarkBind comes with with an in-built _site search_ facility**. You can add a [Search Bar](usingComponents.html#search-bar) component to your pages %%(e.g., into the top navigation bar)%% to allow readers to search your website for keywords.
 </span>
 
-**All headings of levels 1-3 are captured in the search index** by default. You can change this setting using the [`headingIndexLevel` property of the `site.json`](siteConfiguration.html#headingindexinglevel).
+**All markdown and html headings of levels 1-3 are captured in the search index** by default. You can change this setting using the [`headingIndexLevel` property of the `site.json`](siteConfiguration.html#headingindexinglevel).
 
 <box type="info">
 

--- a/docs/userGuide/syntax/indexing.mbdf
+++ b/docs/userGuide/syntax/indexing.mbdf
@@ -1,6 +1,6 @@
 ## Including or Excluding Headings
 
-**You can specify headings which are to be included or excluded from the index built by MarkBind's built-in search feature** using the `.always-index` or `.no-index` attributes.
+**You can specify headings which are to be included or excluded from the index built by MarkBind's built-in search feature** using the `.always-index` or `.no-index` classes.
 
 If you wish to index a specific heading outside the specified `headingIndexLevel`, you may add the `.always-index` attribute to the heading. Similarly, if you wish for a specific heading inside the specified `headingIndexLevel` not to be indexed, you may add the `.no-index` attribute to the heading.
 
@@ -12,5 +12,12 @@ If you wish to index a specific heading outside the specified `headingIndexLevel
 ###### Heading outside heading index level that will be indexed {.always-index}
 
 # Heading inside heading index level that will not be indexed {.no-index}
+```
+
+Equivalently,
+```html
+<h6 class="always-index"> Heading outside heading index level that will be indexed </h6>
+
+<h1 class="no-index"> Heading inside heading index level that will not be indexed </h1>
 ```
 </div>

--- a/src/plugins/default/markbind-plugin-anchors.js
+++ b/src/plugins/default/markbind-plugin-anchors.js
@@ -1,4 +1,5 @@
 const cheerio = module.parent.require('cheerio');
+const slugify = require('@sindresorhus/slugify');
 const md = require('./../../lib/markbind/src/lib/markdown-it');
 
 const {
@@ -13,9 +14,13 @@ module.exports = {
   postRender: (content) => {
     const $ = cheerio.load(content, { xmlMode: false });
     $(HEADER_TAGS).each((i, heading) => {
-      if ($(heading).attr('id')) {
-        $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
+      // Give pure html <h1..6> tags an id with the same slugify function used in markdown-it-anchor
+      if (!$(heading).attr('id')) {
+        const slugifiedHeading = slugify($(heading).text(), { decamelize: false });
+        $(heading).attr('id', slugifiedHeading);
       }
+
+      $(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
     });
     $('panel[header]').each((i, panel) => {
       const panelHeading = cheerio.load(md.render(panel.attribs.header), { xmlMode: false });

--- a/test/functional/test_site_templates/test_default/expected/index.html
+++ b/test/functional/test_site_templates/test_default/expected/index.html
@@ -64,7 +64,7 @@
         <br>
         <div class="jumbotron jumbotron-fluid bg-primary text-white">
           <div class="container">
-            <h1 class="display-4">Landing Page Title</h1>
+            <h1 class="display-4" id="landing-page-title">Landing Page Title<a class="fa fa-anchor" href="#landing-page-title"></a></h1>
             <p class="lead">A tagline can go here</p>
           </div>
         </div>
@@ -201,6 +201,7 @@
         <div class="border-left-grey nav-inner position-sticky slim-scroll">
           <a class="navbar-brand page-nav-title" href="#">Chapters of This Page</a>
           <nav class="nav nav-pills flex-column my-0 small no-flex-wrap">
+            <a class="nav-link py-1" href="#landing-page-title">Landing Page Title&#x200E;</a>
             <a class="nav-link py-1" href="#heading-1">Heading 1&#x200E;</a>
             <nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">
               <a class="nav-link py-1" href="#sub-heading-1-1">Sub Heading 1.1&#x200E;</a>

--- a/test/functional/test_site_templates/test_default/expected/siteData.json
+++ b/test/functional/test_site_templates/test_default/expected/siteData.json
@@ -3,7 +3,7 @@
   "pages": [
     {
       "headings": {
-        "undefined": "Landing Page Title",
+        "landing-page-title": "Landing Page Title",
         "heading-1": "Heading 1",
         "sub-heading-1-1": "Sub Heading 1.1",
         "sub-heading-1-2": "Sub Heading 1.2",


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Currently, headings specified in markdown format ( `#`, `##`, ... ) are correctly indexed and given an
id, enabling them to be searched.

Headings specified with pure html `h1 ... h6` are not.
Let's fix this, since pure html headings can be useful in nested doms / panel `slot` headers.

**What changes did you make? (Give an overview)**
- Add id for pure html heading tags, using the same slugify used in markdown-it-anchor
- Update relavant test files

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
markbind-plugin-anchors.js

// Give pure html <h1..6> tags an id with the same slugify function used in markdown-it-anchor
if (!$(heading).attr('id')) {
  const slugifiedHeading = slugify($(heading).text(), { decamelize: false });
  $(heading).attr('id', slugifiedHeading);
}

$(heading).append(ANCHOR_HTML.replace('#', `#${$(heading).attr('id')}`));
```

**Is there anything you'd like reviewers to focus on?**
Would like some confirmation with #967.
( could add on the fix to this pr if its fine, since both pertain to heading indexing )

**Testing instructions:**
Add any `<h123456>` of your choice to any site. ( there's a `<h1>Landing Page Title</h1>` in `src\template\default\index.md` )

The heading should show up in the search bar, if it obeys all other search rules as well:
- maximum heading indexing level
- headings in default unexpanded panels and modals not indexed
- `always-index` / `no-index`

`<h123..>` tags used as slot headers for panels should also now be indexed correctly when the panel has the `expanded` attribute

**Proposed commit message: (wrap lines at 72 characters)**
Fix heading indexing for pure html headings
<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
