### PR TITLE
Fix plugin live reloading for relative file paths

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -152,22 +152,28 @@ During the `preRender` and `postRender` stages however, plugins may do custom pr
 source file types, as parsed from the raw Markdown, typically requiring rebuilding the site.
 
 Hence, to add custom source files to watch, you can implement the `getSources()` method.
-- `getSources(content, pluginContext, frontMatter)`: Returns an array of source file paths to watch. Called **before** a Markdown file's `preRender` function is called.
-  - `content`: The raw Markdown of the current Markdown file (`.md`, `.mbd`, etc.).
-  - `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
-  - `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
 
-Example usage of `getSources` from the PlantUML plugin:
+`getSources(content, pluginContext, frontMatter)`: Called _before_ a Markdown file's `preRender` function is called.
+- `content`: The raw Markdown of the current Markdown file (`.md`, `.mbd`, etc.).
+- `pluginContext`: User provided parameters for the plugin. This can be specified in the `site.json`.
+- `frontMatter`: The frontMatter of the page being processed, in case any frontMatter data is required.
+
+It should return an object, consisting of _at least one of the following fields_:
+- `tagMap`: An array consisting of `['tag name', 'source attribute name']` key value pairs.
+  - MarkBind will automatically search for matching tags with the source attributes, and watch them.
+  - For relative file paths, _if the tag is part of some included content_ ( eg. `<include />` tags ), it will be resolved against the included page. Otherwise, it is resolved against the page being processed.
+- `sources`: An array of source file paths to watch, where relative file paths are resolved only against the page being processed.
+- You can also directly return an array of source file paths to watch. ( ie. the `sources` field ) ___(deprecated)___
+
+Example usage of `getSources` from the PlantUML plugin, which allows insertion of PlantUML diagrams using `<puml src="..." >` tags.
+This allows files specified by the `src` attributes of `<puml>` tags to be watched:
 
 ```js
 {
   ...
-  getSources: (content) => {
-    // Add all src attributes in <puml> tags to watch list
-    const $ = cheerio.load(content, { xmlMode: true });
-
-    return $('puml').map((i, tag) => tag.attribs.src).get();
-  },
+  getSources: () => ({
+    tagMap: [['puml', 'src']],
+  })
 }
 ```
 

--- a/src/plugins/default/markbind-plugin-plantuml.js
+++ b/src/plugins/default/markbind-plugin-plantuml.js
@@ -110,10 +110,7 @@ module.exports = {
 
     return $.html();
   },
-  getSources: (content) => {
-    // Add all src attributes in <puml> tags to watch list
-    const $ = cheerio.load(content, { xmlMode: true });
-
-    return $('puml').map((i, tag) => tag.attribs.src).get();
-  },
+  getSources: () => ({
+    tagMap: [['puml', 'src']],
+  }),
 };

--- a/test/unit/Page.test.js
+++ b/test/unit/Page.test.js
@@ -1,3 +1,8 @@
+const path = require('path');
+const {
+  COLLECT_PLUGIN_SOURCES,
+  COLLECT_PLUGIN_TEST_PLUGIN,
+} = require('./utils/pageData');
 const Page = require('../../src/Page');
 
 test('Page#collectIncludedFiles collects included files from 1 dependency object', () => {
@@ -19,4 +24,27 @@ test('Page#collectIncludedFiles collects nothing', () => {
   page.collectIncludedFiles([]);
 
   expect(page.includedFiles).toEqual(new Set());
+});
+
+test('Page#collectPluginSources collects correct sources', () => {
+  const page = new Page({
+    sourcePath: path.resolve('/root/index.md'),
+    plugins: { testPlugin: COLLECT_PLUGIN_TEST_PLUGIN },
+    pluginsContext: { testPlugin: {} },
+  });
+  page.collectPluginSources(COLLECT_PLUGIN_SOURCES);
+
+  const EXPECTED_SOURCE_FILES = new Set([
+    // source files from { sources: [...] }
+    path.resolve('/root/paths/here/should/be/resolved/relative/to/processed/page.cpp'),
+    path.resolve('/except/absolute/sources.c'),
+    // source files found from provided { tagMap: [[tag, srcAttr], ...] }
+    path.resolve('/root/images/sample1.png'),
+    path.resolve('/root/subdir/images/sample2.png'),
+    path.resolve('/root/subdir2/sample3.png'),
+    path.resolve('/root/images/sample4.png'),
+    path.resolve('/absolute/paths/should/not/be/rewritten.png'),
+  ]);
+
+  expect(page.pluginSourceFiles).toEqual(EXPECTED_SOURCE_FILES);
 });

--- a/test/unit/utils/pageData.js
+++ b/test/unit/utils/pageData.js
@@ -1,0 +1,37 @@
+module.exports.COLLECT_PLUGIN_SOURCES = `
+<custom-tag-one src="images/sample1.png">
+  Lorem ipsum dolor sit amet, Ut enim ad minim veniam, 
+  <div data-included-from="/root/subdir/includedpage.md">
+    consectetur adipiscing elit, 
+    <div>
+      <custom-tag-two srcattr="images/sample2.png">
+        sed do eiusmod tempor incididunt ut labore
+        <div data-included-from="/root/subdir2/includedpage.md">
+          <custom-tag-two srcattr="sample3.png">
+            et dolore
+          </custom-tag-two>
+          <custom-tag-two incorrectattr="should/not/be/returned.png">
+             magna aliqua.
+          </custom-tag-two>
+        </div>
+      </custom-tag-two>
+    </div>
+  </div>
+  quis nostrud exercitation ut
+  <custom-tag-two srcattr="images/sample4.png">Lorem ipsum</custom-tag-two>
+  <!-- urls should not be included -->
+  <custom-tag-one src="https://www.google.com">ullamco laboris nisi </custom-tag-one>
+  <custom-tag-one src="/absolute/paths/should/not/be/rewritten.png">
+    aliquip ex ea commodo consequat.
+  </custom-tag-one>
+</custom-tag-one>`;
+
+module.exports.COLLECT_PLUGIN_TEST_PLUGIN = {
+  getSources: () => ({
+    tagMap: [['custom-tag-one', 'src'], ['custom-tag-two', 'srcattr']],
+    sources: [
+      'paths/here/should/be/resolved/relative/to/processed/page.cpp',
+      '/except/absolute/sources.c',
+    ],
+  }),
+};


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] Bug fix
• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #913 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
As mentioned in #913, relative file paths for sources defined by plugins are not correctly resolved
against the page being processed. If the source is also part of an included file, then it should be resolved against the included file.

Urls are also added to the page's `pluginSourceFiles`, which has no effect, but is incorrect

**What changes did you make? (Give an overview)**
Let's fix this and simplify the api for defining sources.

`getSources` now returns
```
{
  tagMap: [ ['tag name', 'src attribute name' ], ['tag name', 'src attribute name' ], ... ]
  sources: as before, which is an array of absolute / relative file paths to watch
}
```

From a plugin author's perspective, resolving said sources against the page being processed
/ the included file is tricky. This moves all such logic to `Page.js`, exposing a simpler api.

The old return syntax is deprecated, but still supported as well.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
getSources: () => ({
  tagMap: [['puml', 'src']],
}),
```

**Testing instructions:**
Simply use `npm run test` to run the new unit tests,

For manual testing of live reloading, the test_site has some
sample pumls at the bottom.

**Proposed commit message: (wrap lines at 72 characters)**
Fix plugin live reloading for relative file paths

Relative file paths provided by plugins are not resolved against the
processed page or included file.

This results in live reloading failing for pages not in the root
directory.

Let's fix this, and also rewrite plugin source collection, allowing
plugins to simply define tags and corresponding source attributes
to watch.

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
