### PR TITLE
Standardize multiple references to the same footnote

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it/markdown-it-footnotes.js
+++ b/src/lib/markbind/src/lib/markdown-it/markdown-it-footnotes.js
@@ -27,10 +27,6 @@
         function render_footnote_caption(tokens, idx/* , options, env, slf */) {
           let n = Number(tokens[idx].meta.id + 1).toString();
 
-          if (tokens[idx].meta.subId > 0) {
-            n += `:${tokens[idx].meta.subId}`;
-          }
-
           return `[${n}]`;
         }
 

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -149,6 +149,9 @@
               <trigger for="pop:footnote1"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote1" id="footnoteref1">[1]</a></sup></trigger> and another.
               <trigger for="pop:footnote2"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote2" id="footnoteref2">[2]</a></sup></trigger>
             </p>
+            <p>Here is a repeated footnote to
+              <trigger for="pop:footnote1"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote1" id="footnoteref1:1">[1]</a></sup></trigger>
+            </p>
             <p><strong>Inline footnotes:</strong> Here is an inline note.
               <trigger for="pop:footnote3"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote3" id="footnoteref3">[3]</a></sup></trigger>
             </p>

--- a/test/functional/test_site/testFootnotes.md
+++ b/test/functional/test_site/testFootnotes.md
@@ -1,6 +1,8 @@
 **Normal footnotes:**
 Here is a footnote reference,[^1] and another.[^longnote]
 
+Here is a repeated footnote to [^1]
+
 [^1]: Here is the footnote. Footnotes will appear at the bottom of the page.
 
 [^longnote]: Here's one with multiple blocks.


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [x] Enhancement to an existing feature
• [] Other, please explain:

Resolves #971 
<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

**What is the rationale for this request?**

Since we do not offer backreferences like the original markdown-it-footnote plugin due to complications with closed panels, there is no benefit to have multiple references to the same footnote look different.

**What changes did you make? (Give an overview)**

Deleted logic to make multiple references to the same footnote have unique captions.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```md
Here is a footnote reference,[^1].

Here is a repeated footnote to [^1]

[^1]: Here is the footnote. Footnotes will appear at the bottom of the page.

```

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**


**Proposed commit message: (wrap lines at 72 characters)**
```
Multiple references to the same footnote (e.g. footnote 1) now look like
1
1:1
1:2
...etc

Let's standardize them so they all just show `1` instead.
```
<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
