### PR TITLE
Allow using 'none' footer attribute in frontmatter

### DIFF
--- a/docs/userGuide/syntax/footers.mbdf
+++ b/docs/userGuide/syntax/footers.mbdf
@@ -24,6 +24,7 @@ In the page that you want to include the footer:
 Notes:
 - Any inline footers will be removed by MarkBind to ensure compatibility with footer files.
 - If a [Layout]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#page-layouts) is specified, the footer file specified in the `<frontmatter>` will override the footer within the Layout.
+- If you wish to use a Layout but exclude its footer file, specify `footer: none` in the `<frontmatter>` of the page.
 - [MarkBind Components]({{ baseUrl }}/userGuide/usingComponents.html) and [`<include>` tags]({{ baseUrl }}/userGuide/reusingContents.html#the-include-tag) are not supported in footers.
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/headers.mbdf
+++ b/docs/userGuide/syntax/headers.mbdf
@@ -26,6 +26,7 @@ In the page that you want to include the header:
 Notes:
 - Any inline headers will be removed by MarkBind to ensure compatibility with header files.
 - If a [Layout]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#page-layouts) is specified, the header file specified in the `<frontmatter>` will override the header within the Layout.
+- If you wish to use a Layout but exclude its header file, specify `header: none` in the `<frontmatter>` of the page.
 - [MarkBind Components]({{ baseUrl }}/userGuide/usingComponents.html) and [`<include>` tags]({{ baseUrl }}/userGuide/reusingContents.html#the-include-tag) are not supported in headers.
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/pageHead.mbdf
+++ b/docs/userGuide/syntax/pageHead.mbdf
@@ -78,3 +78,5 @@ To specify that you want to insert `myCustomLinks.md` into the `<head>` of `myPa
  </frontmatter>
 ```
 </span>
+
+If you wish to use a [Layout]({{ baseUrl }}/userGuide/tweakingThePageStructure.html#page-layouts) but exclude its head file, specify `head: none` in the `<frontmatter>` of the page.

--- a/docs/userGuide/syntax/siteNavigationMenus.mbdf
+++ b/docs/userGuide/syntax/siteNavigationMenus.mbdf
@@ -89,6 +89,8 @@ A siteNav has a fixed width of 300 pixels for its contents. A siteNavs is [_resp
 
 There is no limit to the number of nesting levels or the number of items in the menu, but note that any content exceeding a height of 1000 pixels will be cut off.
 
+If you wish to use a Layout but exclude its navigation file, specify `siteNav: none` in the `<frontmatter>` of the page.
+
 
 <span id="short" class="d-none">
 

--- a/src/Page.js
+++ b/src/Page.js
@@ -500,7 +500,7 @@ class Page {
     if (footer === FRONT_MATTER_NONE_ATTR) {
       return pageData;
     }
-    
+
     let footerFile;
     if (footer) {
       footerFile = path.join(FOOTERS_FOLDER_PATH, footer);

--- a/src/Page.js
+++ b/src/Page.js
@@ -37,6 +37,7 @@ const {
   NAVIGATION_FOLDER_PATH,
   CONTENT_WRAPPER_ID,
   FRONT_MATTER_FENCE,
+  FRONT_MATTER_NONE_ATTR,
   PAGE_NAV_ID,
   PAGE_NAV_TITLE_CLASS,
   SITE_NAV_ID,
@@ -496,6 +497,10 @@ class Page {
    */
   insertFooterFile(pageData) {
     const { footer } = this.frontMatter;
+    if (footer === FRONT_MATTER_NONE_ATTR) {
+      return pageData;
+    }
+    
     let footerFile;
     if (footer) {
       footerFile = path.join(FOOTERS_FOLDER_PATH, footer);

--- a/src/Page.js
+++ b/src/Page.js
@@ -683,6 +683,8 @@ class Page {
   collectHeadFiles(baseUrl, hostBaseUrl) {
     const { head } = this.frontMatter;
     if (head === FRONT_MATTER_NONE_ATTR) {
+      this.headFileTopContent = '';
+      this.headFileBottomContent = '';
       return;
     }
 

--- a/src/Page.js
+++ b/src/Page.js
@@ -471,6 +471,10 @@ class Page {
    */
   insertHeaderFile(pageData) {
     const { header } = this.frontMatter;
+    if (header === FRONT_MATTER_NONE_ATTR) {
+      return pageData;
+    }
+
     let headerFile;
     if (header) {
       headerFile = path.join(HEADERS_FOLDER_PATH, header);
@@ -528,6 +532,10 @@ class Page {
    */
   insertSiteNav(pageData) {
     const { siteNav } = this.frontMatter;
+    if (siteNav === FRONT_MATTER_NONE_ATTR) {
+      return pageData;
+    }
+
     let siteNavFile;
     if (siteNav) {
       siteNavFile = path.join(NAVIGATION_FOLDER_PATH, siteNav);
@@ -674,6 +682,10 @@ class Page {
 
   collectHeadFiles(baseUrl, hostBaseUrl) {
     const { head } = this.frontMatter;
+    if (head === FRONT_MATTER_NONE_ATTR) {
+      return;
+    }
+
     let headFiles;
     const collectedTopContent = [];
     const collectedBottomContent = [];

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ module.exports = {
 
   CONTENT_WRAPPER_ID: 'content-wrapper',
   FRONT_MATTER_FENCE: '---',
+  FRONT_MATTER_NONE_ATTR: 'none',
   PAGE_NAV_ID: 'page-nav',
   PAGE_NAV_TITLE_CLASS: 'page-nav-title',
   SITE_NAV_ID: 'site-nav',


### PR DESCRIPTION


**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

- [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #638 

**What is the rationale for this request?**

Enables users to exclude the footer that is derived/inherited from the layout specified in the `<frontmatter>`.

**What changes did you make? (Give an overview)**
Added a check for when the `footer` attribute is `none` while inserting the footer file into a `Page`.

**Testing instructions:**
* Specify a layout in a page's `<frontmatter>`
* Add `footer: none` to `<frontmatter>`
* Build and serve site

Expected output: Footer of the derived layout is omitted

**Proposed commit message: (wrap lines at 72 characters)**
Allow using 'none' footer attribute in frontmatter

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
