### PR TITLE
Restructure generated site data for searchbar ui

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -344,17 +344,6 @@ class Page {
   }
 
   /**
-   * Concatenates keywords in this.keywords to heading text in this.headings
-   */
-  concatenateHeadingsAndKeywords() {
-    Object.keys(this.keywords)
-      .forEach((headingId) => {
-        const keywordString = this.keywords[headingId].join(', ');
-        this.headings[headingId] += ` | ${keywordString}`;
-      });
-  }
-
-  /**
    * Records the dynamic or static included files into this.includedFiles
    * @param dependencies array of maps of the external dependency and where it is included
    */

--- a/src/Site.js
+++ b/src/Site.js
@@ -846,7 +846,6 @@ class Site {
     this.pages.forEach((page) => {
       if (generateForAllPages || filePaths.some(filePath => page.includedFiles.has(filePath))) {
         page.collectHeadingsAndKeywords();
-        page.concatenateHeadingsAndKeywords();
       }
     });
     this.writeSiteData();
@@ -914,7 +913,11 @@ class Site {
       const siteData = {
         enableSearch: this.siteConfig.enableSearch,
         pages: this.pages.filter(page => page.searchable)
-          .map(page => ({ headings: page.headings, ...page.frontMatter })),
+          .map(page => ({
+            ...page.frontMatter,
+            headings: page.headings,
+            headingKeywords: page.keywords,
+          })),
       };
 
       fs.outputJsonAsync(siteDataPath, siteData)

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -2,52 +2,16 @@
   "enableSearch": true,
   "pages": [
     {
-      "headings": {},
       "title": "Open Bugs",
       "header": "header.md",
       "src": "bugs/index.md",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "panel-with-heading": "Panel with heading | panel keyword",
-        "panel-without-heading-with-keyword": "Panel without heading with keyword",
-        "panel-with-heading-with-keyword": "Panel with heading with keyword",
-        "panel-without-src-header": "Panel without src header",
-        "panel-with-normal-src-header": "Panel with normal src header",
-        "panel-with-src-from-a-page-segment-header": "Panel with src from a page segment header",
-        "boilerplate-referencing": "Boilerplate referencing",
-        "referencing-specified-path-in-boilerplate": "Referencing specified path in boilerplate",
-        "outer-nested-panel": "Outer nested panel",
-        "outer-nested-panel-without-src": "Outer nested panel without src",
-        "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
-        "panel-with-src-from-another-markbind-site-header-2": "Panel with src from another Markbind site header",
-        "unexpanded-panel-header": "Unexpanded panel header",
-        "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading | panel keyword",
-        "panel-normal-source-content-headings": "Panel normal source content headings",
-        "panel-source-segment-content-headings": "Panel source segment content headings",
-        "boilerplate-test-for-panel-heading": "boilerplate test for panel heading",
-        "heading-in-panel-boilerplate": "heading in panel boilerplate",
-        "nested-panel": "Nested Panel",
-        "normal-panel-content-heading": "Normal panel content heading",
-        "inner-panel-header-without-src": "Inner panel header without src",
-        "feature-list": "Feature list",
-        "heading-with-multiple-keywords": "Heading with multiple keywords | keyword 1, keyword 2",
-        "heading-with-keyword-in-panel": "Heading with keyword in panel | panel keyword",
-        "keyword-should-be-tagged-to-the-panel-heading-not-this-heading": "Keyword should be tagged to the panel heading, not this heading | panel keyword",
-        "heading-with-included-keyword": "Heading with included keyword | included keyword",
-        "included-heading": "Included Heading | Keyword with included heading",
-        "heading-with-nested-keyword": "Heading with nested keyword | nested keyword",
-        "heading-with-hidden-keyword": "Heading with hidden keyword | invisible keyword",
-        "establishing-requirements": "Establishing Requirements",
-        "brainstorming": "Brainstorming",
-        "user-surveys": "User surveys",
-        "focus-groups": "Focus groups",
-        "markbind-plugin-pre-render": "Markbind Plugin Pre-render",
-        "level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed": "Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed"
-      },
       "title": "Hello World",
       "header": "header.md",
       "footer": "footer.md",
@@ -67,79 +31,159 @@
         "-tag-site-override-specific*"
       ],
       "src": "index.md",
-      "layout": "default"
+      "layout": "default",
+      "headings": {
+        "panel-with-heading": "Panel with heading",
+        "panel-without-heading-with-keyword": "Panel without heading with keyword",
+        "panel-with-heading-with-keyword": "Panel with heading with keyword",
+        "panel-without-src-header": "Panel without src header",
+        "panel-with-normal-src-header": "Panel with normal src header",
+        "panel-with-src-from-a-page-segment-header": "Panel with src from a page segment header",
+        "boilerplate-referencing": "Boilerplate referencing",
+        "referencing-specified-path-in-boilerplate": "Referencing specified path in boilerplate",
+        "outer-nested-panel": "Outer nested panel",
+        "outer-nested-panel-without-src": "Outer nested panel without src",
+        "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
+        "panel-with-src-from-another-markbind-site-header-2": "Panel with src from another Markbind site header",
+        "unexpanded-panel-header": "Unexpanded panel header",
+        "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading",
+        "panel-normal-source-content-headings": "Panel normal source content headings",
+        "panel-source-segment-content-headings": "Panel source segment content headings",
+        "boilerplate-test-for-panel-heading": "boilerplate test for panel heading",
+        "heading-in-panel-boilerplate": "heading in panel boilerplate",
+        "nested-panel": "Nested Panel",
+        "normal-panel-content-heading": "Normal panel content heading",
+        "inner-panel-header-without-src": "Inner panel header without src",
+        "feature-list": "Feature list",
+        "heading-with-multiple-keywords": "Heading with multiple keywords",
+        "heading-with-keyword-in-panel": "Heading with keyword in panel",
+        "keyword-should-be-tagged-to-the-panel-heading-not-this-heading": "Keyword should be tagged to the panel heading, not this heading",
+        "heading-with-included-keyword": "Heading with included keyword",
+        "included-heading": "Included Heading",
+        "heading-with-nested-keyword": "Heading with nested keyword",
+        "heading-with-hidden-keyword": "Heading with hidden keyword",
+        "establishing-requirements": "Establishing Requirements",
+        "brainstorming": "Brainstorming",
+        "user-surveys": "User surveys",
+        "focus-groups": "Focus groups",
+        "markbind-plugin-pre-render": "Markbind Plugin Pre-render",
+        "level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed": "Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed"
+      },
+      "headingKeywords": {
+        "heading-with-keyword-in-panel": [
+          "panel keyword"
+        ],
+        "panel-with-heading": [
+          "panel keyword"
+        ],
+        "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": [
+          "panel keyword"
+        ],
+        "heading-with-multiple-keywords": [
+          "keyword 1",
+          "keyword 2"
+        ],
+        "keyword-should-be-tagged-to-the-panel-heading-not-this-heading": [
+          "panel keyword"
+        ],
+        "heading-with-included-keyword": [
+          "included keyword"
+        ],
+        "included-heading": [
+          "Keyword with included heading"
+        ],
+        "heading-with-nested-keyword": [
+          "nested keyword"
+        ],
+        "heading-with-hidden-keyword": [
+          "invisible keyword"
+        ]
+      }
     },
     {
-      "headings": {
-        "feature-list": "Feature list"
-      },
       "src": "sub_site/index.md",
       "title": "",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {
+        "feature-list": "Feature list"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "some-heading": "Some heading"
-      },
       "src": "test_md_fragment.md",
       "title": "",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {
+        "some-heading": "Some heading"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "layout": "testAfterSetup",
       "src": "testAfterSetup.md",
       "title": "Hello World",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testEmptyFrontmatter.md",
       "title": "Hello World",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testExternalScripts.md",
       "title": "Hello World",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "title": "Hello World",
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
       "src": "testLayouts.md",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "title": "Hello World",
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
       "src": "testLayoutsOverride.md",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testAntiFOUCStyles.md",
       "title": "Hello World",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
+      "title": "Anchor Generation Test",
+      "src": "testAnchorGeneration.md",
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "should-have-anchor-7": "should have anchor",
         "should-have-anchor-20": "should have anchor",
@@ -162,56 +206,57 @@
         "should-have-anchor-16": "should have anchor",
         "should-have-anchor-17": "should have anchor"
       },
-      "title": "Anchor Generation Test",
-      "src": "testAnchorGeneration.md",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "569-stray-space-after-tooltip": "569: Stray space after tooltip"
-      },
       "src": "testTooltipSpacing.mbd",
       "title": "Tooltip Spacing Test",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {
+        "569-stray-space-after-tooltip": "569: Stray space after tooltip"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testThumbnails.md",
       "title": "Thumbnails Test",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testPlantUML.md",
       "title": "PlantUML Test",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "trying-to-access-a-page-variable": "Trying to access a page variable:",
-        "trying-to-access-an-imported-variable-via-namespace": "Trying to access an imported variable via namespace:"
-      },
       "src": "testImportVariables.md",
       "title": "Imported Variables Test",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {
+        "trying-to-access-a-page-variable": "Trying to access a page variable:",
+        "trying-to-access-an-imported-variable-via-namespace": "Trying to access an imported variable via namespace:"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "testPanelsWithImportedVariables.md",
       "title": "Panels with Imported Variables Test",
       "layout": "default",
       "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override"
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site_algolia_plugin/expected/siteData.json
+++ b/test/functional/test_site_algolia_plugin/expected/siteData.json
@@ -2,12 +2,13 @@
   "enableSearch": true,
   "pages": [
     {
-      "headings": {},
       "title": "Hello World",
       "footer": "footer.md",
       "siteNav": "site-nav.md",
       "src": "index.md",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site_convert/expected/siteData.json
+++ b/test/functional/test_site_convert/expected/siteData.json
@@ -2,78 +2,88 @@
   "enableSearch": true,
   "pages": [
     {
-      "headings": {},
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "Home.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
+      "src": "Page-1.md",
+      "title": "",
+      "layout": "default",
       "headings": {
         "page-1": "Page 1"
       },
-      "src": "Page-1.md",
-      "title": "",
-      "layout": "default"
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "_Footer.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "src": "_Sidebar.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
+      "src": "about.md",
+      "title": "",
+      "layout": "default",
       "headings": {
         "about": "About"
       },
-      "src": "about.md",
-      "title": "",
-      "layout": "default"
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "topic-1": "Topic 1"
-      },
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic1.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {
+        "topic-1": "Topic 1"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic2.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic3a.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic3b.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site_expressive_layout/expected/siteData.json
+++ b/test/functional/test_site_expressive_layout/expected/siteData.json
@@ -2,13 +2,14 @@
   "enableSearch": true,
   "pages": [
     {
-      "headings": {
-        "welcome-to-markbind": "Welcome to Markbind"
-      },
       "footer": "footer.md",
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default"
+      "layout": "default",
+      "headings": {
+        "welcome-to-markbind": "Welcome to Markbind"
+      },
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site_templates/test_default/expected/siteData.json
+++ b/test/functional/test_site_templates/test_default/expected/siteData.json
@@ -2,6 +2,13 @@
   "enableSearch": true,
   "pages": [
     {
+      "header": "header.md",
+      "pageNav": 2,
+      "pageNavTitle": "Chapters of This Page",
+      "siteNav": "site-nav.md",
+      "src": "index.md",
+      "title": "Landing Page",
+      "layout": "default",
       "headings": {
         "heading-1": "Heading 1",
         "sub-heading-1-1": "Sub Heading 1.1",
@@ -9,47 +16,45 @@
         "heading-2": "Heading 2",
         "heading-3": "Heading 3"
       },
-      "header": "header.md",
-      "pageNav": 2,
-      "pageNavTitle": "Chapters of This Page",
-      "siteNav": "site-nav.md",
-      "src": "index.md",
-      "title": "Landing Page",
-      "layout": "default"
+      "headingKeywords": {}
     },
     {
-      "headings": {
-        "topic-1": "Topic 1"
-      },
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic1.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {
+        "topic-1": "Topic 1"
+      },
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic2.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic3a.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     },
     {
-      "headings": {},
       "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic3b.md",
       "title": "",
-      "layout": "default"
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
     }
   ]
 }

--- a/test/functional/test_site_templates/test_minimal/expected/siteData.json
+++ b/test/functional/test_site_templates/test_minimal/expected/siteData.json
@@ -2,13 +2,14 @@
   "enableSearch": true,
   "pages": [
     {
-      "headings": {
-        "welcome-to-markbind": "Welcome to Markbind"
-      },
       "footer": "footer.md",
       "src": "index.md",
       "title": "Hello World",
-      "layout": "default"
+      "layout": "default",
+      "headings": {
+        "welcome-to-markbind": "Welcome to Markbind"
+      },
+      "headingKeywords": {}
     }
   ]
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves MarkBind/markbind#994
Requires https://github.com/MarkBind/vue-strap/pull/126 ( searchbar ui for vue-strap )

**What is the rationale for this request?**
Generated site data for the searchbar needs to be restructured to sift out the keywords from the heading deterministically.

**What changes did you make? (Give an overview)**
Generated site data:
- `headings` now store only the `id:'heading text...'` pair instead of `id:'heading text... | concatenated keywords ...'`
- keywords for headings are now stored in the `headingKeywords` field
- Removed `concatenateHeadingsAndKeywords` which is no longer needed

**Provide some example code that this change will affect:**

New site data:
```js
const siteData = {
    enableSearch: this.siteConfig.enableSearch,
    pages: this.pages.filter(page => page.searchable)
      .map(page => ({
        ...page.frontMatter,
        headings: page.headings,
        headingKeywords: page.keywords,
      })),
  };
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
`npm run test` should pass

**Proposed commit message: (wrap lines at 72 characters)**

Restructure generated site data for searchbar ui

Keywords tied to a heading are appended to the heading with a prepending
'|' character.
This is so that the '|' character would serve as a visual separator
between the heading and the keyword.

However, it is thus not possible to extract a keyword from its heading
deterministically, as a heading can also include the '|' character.

Let's move the keywords to its own field, allowing the searchbar to
extract a heading's keyword from it.

