### PR TITLE
Allow stylelint to ignore test sites

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+**/*.min.css
+test/functional/**/*.css

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,2 @@
 **/*.min.css
-test/functional/**/*.css
+test/functional/**/expected/**/*.css

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "scripts": {
     "autolint": "npm run lintfix && npm run csslintfix",
-    "csslint": "./node_modules/.bin/stylelint **/*.css !**/*.min.css",
-    "csslintfix": "./node_modules/.bin/stylelint **/*.css !**/*.min.css --fix",
+    "csslint": "./node_modules/.bin/stylelint **/*.css",
+    "csslintfix": "./node_modules/.bin/stylelint **/*.css --fix",
     "jest": "jest",
     "lint": "./node_modules/.bin/eslint .",
     "lintfix": "./node_modules/.bin/eslint . --fix",


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain:

This PR allows stylelint to ignore CSS files in the generated test sites. Refer to https://github.com/MarkBind/markbind/pull/1000#discussion_r371920889 for more details.

**What is the rationale for this request?**
As @marvinchin explained -
> Not linting generated files seem to make sense to me because some of these generated files might be minified, dependent on external assets etc. and would not satisfy our linting rules (it wouldn’t make sense to lint node_modules for similar reasons!). We should only be applying linting rules to the source files that we are working on.

**What changes did you make? (Give an overview)**
Add an ignore file for stylelint to exclude CSS files in `test/functional/**`. 

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```
**/*.min.css
test/functional/**/*.css
```

**Is there anything you'd like reviewers to focus on?**
–

**Testing instructions:**
Check that files that end with `min.css` and CSS files in `test/functional/**` are not linted by stylelint. 

**Proposed commit message: (wrap lines at 72 characters)**
Allow stylelint to ignore test sites
