### PR TITLE
Change number emoji to use unicode characters

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-emoji-fixed.js
+++ b/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-emoji-fixed.js
@@ -2,12 +2,16 @@
 const emojiData = require('markdown-it-emoji/lib/data/full.json');
 // Extend emoji here
 
-// Add number key cap emoji
-const unicodes = '0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣'.split(' ');
-const letters = 'zero one two three four five six seven eight nine'.split(' ');
-
-letters.forEach((letter, index) => {
-  emojiData[letter] = unicodes[index];
-});
+// Add keycap number emoji
+emojiData['zero'] = '0️⃣';
+emojiData['one'] = '1️⃣';
+emojiData['two'] = '2️⃣';
+emojiData['three'] = '3️⃣';
+emojiData['four'] = '4️⃣';
+emojiData['five'] = '5️⃣';
+emojiData['six'] = '6️⃣';
+emojiData['seven'] = '7️⃣';
+emojiData['eight'] = '8️⃣';
+emojiData['nine'] = '9️⃣';
 
 module.exports = emojiData;

--- a/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-emoji-fixed.js
+++ b/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-emoji-fixed.js
@@ -1,15 +1,13 @@
 // fix emoji numbers
 const emojiData = require('markdown-it-emoji/lib/data/full.json');
 // Extend emoji here
-emojiData['zero'] = emojiData['0'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0030-20e3.png">';
-emojiData['one'] = emojiData['1'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0031-20e3.png">';
-emojiData['two'] = emojiData['2'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0032-20e3.png">';
-emojiData['three'] = emojiData['3'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0033-20e3.png">';
-emojiData['four'] = emojiData['4'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0034-20e3.png">';
-emojiData['five'] = emojiData['5'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0035-20e3.png">';
-emojiData['six'] = emojiData['6'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0036-20e3.png">';
-emojiData['seven'] = emojiData['7'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0037-20e3.png">';
-emojiData['eight'] = emojiData['8'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0038-20e3.png">';
-emojiData['nine'] = emojiData['9'] = '<img style="height: 1em;width: 1em;margin: 0 .05em 0 .1em;vertical-align: -0.1em;" src="https://assets-cdn.github.com/images/icons/emoji/unicode/0039-20e3.png">';
+
+// Add number key cap emoji
+const unicodes = '0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣'.split(' ');
+const letters = 'zero one two three four five six seven eight nine'.split(' ');
+
+letters.forEach((letter, index) => {
+  emojiData[letter] = unicodes[index];
+});
 
 module.exports = emojiData;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #992 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
The links we use for number emoji (e.g. 1️⃣ ) from the Github CDN are no longer working, as they have changed to use unicode characters.

**What changes did you make? (Give an overview)**
Change the number emoji used in markdown-it-emoji to use unicode characters.

**Proposed commit message: (wrap lines at 72 characters)**


Number emojis in Markbind use the emoji images from Github's CDN.
Github has migrated to use unicode characters for their emojis, causing
our number emojis to break.

Let's update our number emojis to use the unicode characters as well.

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
