### PR TITLE
Allow stylelint to ignore generated sites

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,3 @@
 **/*.min.css
+**/_site/**/*.css
 test/functional/**/expected/**/*.css


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain:

This PR allows stylelint to ignore files in generated sites (`**/_site`). 

**What is the rationale for this request?**
Now that we're allowing non-compliant CSS files from external libraries in the build process (https://github.com/MarkBind/markbind/pull/1000#discussion_r371918466), we should allow stylelint to ignore files in the generated sites, similar to how we allowed stylelint to ignore the test sites (#1011). 

Currently, running stylelint **after** sites have been generated (for example, running `npm run test` twice) causes it to fail because it tries to lint the generated sites (which contain non-compliant CSS files) as well. 

**What changes did you make? (Give an overview)**
Add a rule for stylelint to ignore generated sites. 

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```
**/_site/**/*.css
```

**Is there anything you'd like reviewers to focus on?**
-

**Testing instructions:**
1. Modify any CSS file in a generated site to be non-stylelint-compliant
2. `npm run csslint` should pass

**Proposed commit message: (wrap lines at 72 characters)**
Allow stylelint to ignore generated sites
