### PR TITLE
Implement box markdown header attributes parsing

### DIFF
--- a/docs/userGuide/syntax/boxes.mbdf
+++ b/docs/userGuide/syntax/boxes.mbdf
@@ -33,9 +33,9 @@
 <box type="info" dismissible>
     dismissible info
 </box>
-<box type="success" header="Tip box header">
+<box type="success" header="#### Header :rocket:" icon-size="2x">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    <box type="warning" header="Tip box header" dismissible>
+    <box type="warning" header="You can use **markdown** here! :pizza:" dismissible>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </box>
 </box>
@@ -70,9 +70,9 @@
 <box type="info" dismissible>
     dismissible info
 </box>
-<box type="success" header="Tip box header">
+<box type="success" header="#### Header :rocket:" icon-size="2x">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    <box type="warning" header="Tip box header" dismissible>
+    <box type="warning" header="You can use **markdown** here! :pizza:" dismissible>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </box>
 </box>
@@ -259,8 +259,8 @@ border-left-color | `String` | `null` | Overrides border-color for the left bord
 color | `String` | `null` | Color of the text.
 dismissible | `Boolean` | `false` | Adds a button to close the box to the top right corner.
 icon | `String` | `null` | Inline MarkDown text of the icon displayed on the left.
-icon-size | `String` | `null` | Resizes the icon. Supports integer-scaling of the icon dimensions e.g. `2x`, `3x`, `4x`, etc.  
-header <hr style="margin-top:0.2rem; margin-bottom:0" /> <small>heading <br> (deprecated)</small> | `String` | `null` | Plain text of the header on the top right corner.
+icon-size | `String` | `null` | Resizes the icon. Supports integer-scaling of the icon dimensions e.g. `2x`, `3x`, `4x`, etc.
+header <hr style="margin-top:0.2rem; margin-bottom:0" /> <small>heading <br> (deprecated)</small> | `String` | `null` | Markdown text of the box header.
 type | `String` | `'none'` | Supports: `info`, `warning`, `success`, `important`, `wrong`, `tip`, `definition`, or empty for default.
 light | `Boolean` | `false` | Uses a light color scheme for the box.
 seamless | `Boolean` | `false` | Uses a seamless style for the box. If `light` is specified, this style will not be activated.

--- a/src/lib/markbind/src/parsers/componentParser.js
+++ b/src/lib/markbind/src/parsers/componentParser.js
@@ -179,6 +179,12 @@ function _parseTabAttributes(element) {
 
 function _parseBoxAttributes(element) {
   _parseAttributeWithoutOverride(element, 'icon', true, '_icon');
+  _parseAttributeWithoutOverride(element, 'header', false, '_header');
+
+  // TODO deprecate heading attribute for box
+  _parseAttributeWithoutOverride(element, 'heading', false, '_header');
+
+  // TODO warn when light and seamless attributes are both present
 }
 
 /*

--- a/test/functional/test_site_templates/test_default/expected/index.html
+++ b/test/functional/test_site_templates/test_default/expected/index.html
@@ -155,16 +155,15 @@
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </box>
-        <box type="tip" heading="Tip box heading">
-          tip
+        <box type="tip"><template slot="_header"><p>Tip box heading</p></template> tip
         </box>
-        <box type="success" heading="Tip box heading">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <box type="success"><template slot="_header"><p>Tip box heading</p></template> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+          nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
         </box>
-        <box type="important" dismissible="" heading="Tip box heading">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-          in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <box type="important" dismissible=""><template slot="_header"><p>Tip box heading</p></template> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+          nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
         </box>
         <br>
         <h1 id="heading-3">Heading 3<a class="fa fa-anchor" href="#heading-3"></a></h1>

--- a/test/unit/parsers/componentParser.test.js
+++ b/test/unit/parsers/componentParser.test.js
@@ -83,6 +83,10 @@ test('parseComponent parses tab & tab-group attributes and inserts into dom as s
 test('parseComponent parses box attributes and inserts into dom as slots correctly', () => {
   parseAndVerifyTemplate(testData.PARSE_BOX_ICON,
                          testData.PARSE_BOX_ICON_EXPECTED);
+  parseAndVerifyTemplate(testData.PARSE_BOX_HEADER,
+                         testData.PARSE_BOX_HEADER_EXPECTED);
+  parseAndVerifyTemplate(testData.PARSE_BOX_HEADING,
+                         testData.PARSE_BOX_HEADING_EXPECTED);
 });
 
 test('postParseComponent assigns the correct header id to panels', () => {

--- a/test/unit/utils/componentParserData.js
+++ b/test/unit/utils/componentParserData.js
@@ -251,4 +251,32 @@ module.exports.PARSE_BOX_ICON_EXPECTED = `
 </box>
 `;
 
+module.exports.PARSE_BOX_HEADER = `
+<box header="#### Lorem ipsum dolor sit amet :rocket:">
+  Header attribute should be inserted as internal _header slot and deleted.
+</box>
+`;
+
+module.exports.PARSE_BOX_HEADER_EXPECTED = `
+<box><template slot="_header"><h4>Lorem ipsum dolor sit amet 🚀</h4>
+</template>
+  Header attribute should be inserted as internal _header slot and deleted.
+</box>
+`;
+
+// todo remove this test once 'heading' attribute is fully deprecated for boxes
+
+module.exports.PARSE_BOX_HEADING = `
+<box heading="#### Lorem ipsum dolor sit amet :rocket:">
+  Heading attribute should be inserted as internal _header slot and deleted.
+</box>
+`;
+
+module.exports.PARSE_BOX_HEADING_EXPECTED = `
+<box><template slot="_header"><h4>Lorem ipsum dolor sit amet 🚀</h4>
+</template>
+  Heading attribute should be inserted as internal _header slot and deleted.
+</box>
+`;
+
 /* eslint-enable max-len */


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves #962 

Requires https://github.com/MarkBind/vue-strap/pull/118
Follow up to #999 

**What is the rationale for this request?**
To add markdown parsing for box headings 

**What changes did you make? (Give an overview)**
- Added non-inline markdown parsing for box headers using `componentParser`
- Add new unit tests
- Update an existing test template

**Provide some example code that this change will affect:**

Markdown parsing for headers in `componentParser`:
```js
_parseAttributeWithoutOverride(element, 'header', false, '_header');

// TODO deprecate heading attribute for box
_parseAttributeWithoutOverride(element, 'heading', false, '_header');
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
- `npm run test` should pass
- https://github.com/MarkBind/vue-strap/pull/118 for manual UI testing

**Proposed commit message: (wrap lines at 72 characters)**
Implement box markdown header attributes parsing
