### PR TITLE
Add '_site' to the ignored folders in site.json

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -1,5 +1,5 @@
 mark {
-    background-color: rgba(255, 231, 2, 0.15);
+    background-color: #FFFF00;
     border-radius: 5px;
     padding-top: 0;
     padding-bottom: 0;

--- a/src/Site.js
+++ b/src/Site.js
@@ -52,6 +52,7 @@ const {
   SITE_ASSET_FOLDER_NAME,
   SITE_CONFIG_NAME,
   SITE_DATA_NAME,
+  SITE_FOLDER_NAME,
   TEMP_FOLDER_NAME,
   TEMPLATE_SITE_ASSET_FOLDER_NAME,
   USER_VARIABLES_PATH,
@@ -427,7 +428,7 @@ class Site {
       globPages.concat(walkSync(this.rootPath, {
         directories: false,
         globs: [addressableGlob.glob],
-        ignore: [CONFIG_FOLDER_NAME],
+        ignore: [CONFIG_FOLDER_NAME, SITE_FOLDER_NAME],
       }).map(globPath => ({
         src: globPath,
         searchable: addressableGlob.searchable,

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,7 @@ module.exports = {
   CONFIG_FOLDER_NAME: '_markbind',
   HEADING_INDEXING_LEVEL_DEFAULT: 3,
   SITE_ASSET_FOLDER_NAME: 'asset',
+  SITE_FOLDER_NAME: '_site',
   TEMP_FOLDER_NAME: '.temp',
   TEMPLATE_SITE_ASSET_FOLDER_NAME: 'markbind',
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature


<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #587 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

As per #587 , the default site.json generated during markbind init can be improved by ignoring `_site`

**What changes did you make? (Give an overview)**
Updated the default site.json that is generated by the markbind init command as follows:
1. Added `_site` to the ignore array so that these files will be ignored while copying over to the generated site's directory.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
const globPaths = addressableGlobs.reduce((globPages, addressableGlob) =>	      
  globPages.concat(walkSync(this.rootPath, {
    directories: false,
    globs: [addressableGlob.glob],
    ignore: [CONFIG_FOLDER_NAME, SITE_FOLDER_NAME],
}).map(globPath => ({
  src: globPath,
  searchable: addressableGlob.searchable,
  layout: addressableGlob.layout,
  frontmatter: addressableGlob.frontmatter,
}))), []);	

```

**Is there anything you'd like reviewers to focus on?**

N.A.

**Testing instructions:**

Run the test suite / build markbind locally and test
