### PR TITLE
Use path.join instead of string interpolation

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -920,7 +920,7 @@ class Site {
       }
       const filteredFiles = files.filter(file => _.includes(file, '.') && !_.includes(file, '.md'));
       const copyAll = Promise.all(filteredFiles.map(file =>
-        fs.copyAsync(`${siteLayoutPath}/${file}`, `${layoutsDestPath}/${file}`)));
+        fs.copyAsync(path.join(siteLayoutPath, file), path.join(layoutsDestPath, file))));
       return copyAll.then(() => Promise.resolve());
     });
   }


### PR DESCRIPTION
Assuming forward slashes may cause errors on windows systems

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Bug fix

**What is the rationale for this request?**
This line was causing a error in tests as `createDir` uses string splitting based on the `path.sep` native to the OS.

```
function createDir(pathArg) {
  const { dir, ext } = path.parse(pathArg);
  const dirNames = (ext === '')
    ? pathArg.split(path.sep)
    : dir.split(pathArg.sep);
```

**What changes did you make? (Give an overview)**
Changed a path concatenation to use `path.join` instead of string interpolation.

It was the only instance I could find in the entire project that was using string interpolation. 

**Provide some example code that this change will affect:**
Should not have any changes

**Is there anything you'd like reviewers to focus on?**
-

**Testing instructions:**
-

**Proposed commit message: (wrap lines at 72 characters)**
Assuming forward slashes may cause errors on windows systems. 
Let's use path.join to maintain cross platform compatibility.