### PR TITLE
Simplify baseUrl resolving process

### DIFF
--- a/src/lib/markbind/package.json
+++ b/src/lib/markbind/package.json
@@ -16,6 +16,7 @@
     "@sindresorhus/slugify": "^0.9.1",
     "bluebird": "^3.7.2",
     "cheerio": "^0.22.0",
+    "ensure-posix-path": "^1.1.1",
     "fastmatter": "^2.1.1",
     "highlight.js": "^9.14.2",
     "htmlparser2": "^3.10.1",

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -5,6 +5,7 @@ const nunjucks = require('nunjucks');
 const path = require('path');
 const Promise = require('bluebird');
 const slugify = require('@sindresorhus/slugify');
+const ensurePosix = require('ensure-posix-path');
 const componentParser = require('./parsers/componentParser');
 const componentPreprocessor = require('./preprocessors/componentPreprocessor');
 const nunjuckUtils = require('./utils/nunjuckUtils');
@@ -139,8 +140,8 @@ class Parser {
       return utils.createErrorNode(node, e);
     }
     const fileContent = this._fileCache[filePath]; // cache the file contents to save some I/O
-    const { parent, relative } = urlUtils.calculateNewBaseUrls(asIfAt, config.rootPath, config.baseUrlMap);
-    const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
+    const parentSitePath = urlUtils.getParentSiteAbsolutePath(asIfAt, config.rootPath, config.baseUrlMap);
+    const userDefinedVariables = config.userDefinedVariablesMap[parentSitePath];
     // Extract included variables from the PARENT file
     const includeVariables = Parser.extractIncludeVariables(node, context.variables);
     // Extract page variables from the CHILD file
@@ -395,9 +396,8 @@ class Parser {
           reject(err);
           return;
         }
-        const { parent, relative }
-          = urlUtils.calculateNewBaseUrls(file, config.rootPath, config.baseUrlMap);
-        const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
+        const parentSitePath = urlUtils.getParentSiteAbsolutePath(file, config.rootPath, config.baseUrlMap);
+        const userDefinedVariables = config.userDefinedVariablesMap[parentSitePath];
         const pageVariables = this.extractPageVariables(file, data, userDefinedVariables, {});
         let fileContent = nunjuckUtils.renderEscaped(nunjucks, data, {
           ...pageVariables,
@@ -466,9 +466,8 @@ class Parser {
         decodeEntities: true,
       });
 
-      const { parent, relative } = urlUtils.calculateNewBaseUrls(actualFilePath,
-                                                                 config.rootPath, config.baseUrlMap);
-      const userDefinedVariables = config.userDefinedVariablesMap[path.resolve(parent, relative)];
+      const parentSitePath = urlUtils.getParentSiteAbsolutePath(file, config.rootPath, config.baseUrlMap);
+      const userDefinedVariables = config.userDefinedVariablesMap[parentSitePath];
       const { additionalVariables } = config;
       const pageVariables = this.extractPageVariables(actualFilePath, pageData, userDefinedVariables, {});
 
@@ -555,30 +554,17 @@ class Parser {
   }
 
   resolveBaseUrl(pageData, config) {
-    const { baseUrlMap, rootPath, isDynamic } = config;
+    const { baseUrlMap, rootPath } = config;
     this.baseUrlMap = baseUrlMap;
     this.rootPath = rootPath;
-    this.isDynamic = isDynamic || false;
-    if (this.isDynamic) {
-      this.dynamicSource = config.dynamicSource;
-    }
+
     return new Promise((resolve, reject) => {
       const handler = new htmlparser.DomHandler((error, dom) => {
         if (error) {
           reject(error);
           return;
         }
-        const nodes = dom.map((d) => {
-          const node = d;
-          const childrenBase = {};
-          if (this.isDynamic) {
-            // Change CWF for each top level element
-            if (node.attribs) {
-              node.attribs[ATTRIB_CWF] = this.dynamicSource;
-            }
-          }
-          return this._rebaseReference(node, childrenBase);
-        });
+        const nodes = dom.map(d => this._rebaseReference(d));
         cheerio.prototype.options.xmlMode = false;
         resolve(cheerio.html(nodes));
         cheerio.prototype.options.xmlMode = true;
@@ -591,53 +577,51 @@ class Parser {
     });
   }
 
-  _rebaseReference(node, foundBase) {
+  /**
+   * Pre-renders the baseUrl of the provided node and its children according to
+   * the site they belong to, such that the final call to render baseUrl correctly
+   * resolves baseUrl according to the said site.
+   */
+  _rebaseReference(node) {
     if (_.isArray(node)) {
-      return node.map(el => this._rebaseReference(el, foundBase));
+      return node.map(el => this._rebaseReference(el));
     }
     if (Parser.isText(node)) {
       return node;
     }
-    // Rebase children element
-    const childrenBase = {};
-    node.children.forEach((el) => {
-      this._rebaseReference(el, childrenBase);
-    });
-    // rebase current element
-    if (node.attribs[ATTRIB_INCLUDE_PATH]) {
-      const filePath = node.attribs[ATTRIB_INCLUDE_PATH];
-      let newBaseUrl = urlUtils.calculateNewBaseUrls(filePath, this.rootPath, this.baseUrlMap);
-      if (newBaseUrl) {
-        const { relative, parent } = newBaseUrl;
-        // eslint-disable-next-line no-param-reassign
-        foundBase[parent] = relative;
-      }
-      // override with parent's base
-      const combinedBases = { ...childrenBase, ...foundBase };
-      const bases = Object.keys(combinedBases);
-      if (bases.length !== 0) {
-        // need to rebase
-        newBaseUrl = combinedBases[bases[0]];
-        if (node.children) {
-          // ATTRIB_CWF is where the element was preprocessed
-          const currentBase = urlUtils.calculateNewBaseUrls(node.attribs[ATTRIB_CWF],
-                                                            this.rootPath, this.baseUrlMap);
-          if (currentBase && currentBase.relative !== newBaseUrl) {
-            cheerio.prototype.options.xmlMode = false;
-            const rendered = nunjuckUtils.renderEscaped(nunjucks, cheerio.html(node.children), {
-              // This is to prevent the nunjuck call from converting {{hostBaseUrl}} to an empty string
-              // and let the hostBaseUrl value be injected later.
-              hostBaseUrl: '{{hostBaseUrl}}',
-              baseUrl: `{{hostBaseUrl}}/${newBaseUrl}`,
-            }, { path: filePath });
-            node.children = cheerio.parseHTML(rendered, true);
-            cheerio.prototype.options.xmlMode = true;
-          }
-        }
-      }
-      delete node.attribs[ATTRIB_INCLUDE_PATH];
-    }
+
+    // Rebase children elements
+    node.children.forEach(el => this._rebaseReference(el));
+
+    const includeSourceFile = node.attribs[ATTRIB_CWF];
+    const includedSourceFile = node.attribs[ATTRIB_INCLUDE_PATH];
     delete node.attribs[ATTRIB_CWF];
+    delete node.attribs[ATTRIB_INCLUDE_PATH];
+
+    // Skip rebasing for non-includes
+    if (!includedSourceFile || !node.children) {
+      return node;
+    }
+
+    // The site at which the file with the include element was pre-processed
+    const currentBase = urlUtils.getParentSiteAbsolutePath(includeSourceFile, this.rootPath, this.baseUrlMap);
+    // The site of the included file
+    const newBase = urlUtils.getParentSiteAbsoluteAndRelativePaths(includedSourceFile, this.rootPath,
+                                                                   this.baseUrlMap);
+
+    // Only re-render if include src and content are from different sites
+    if (currentBase !== newBase.absolute) {
+      cheerio.prototype.options.xmlMode = false;
+      const rendered = nunjuckUtils.renderEscaped(nunjucks, cheerio.html(node.children), {
+        // This is to prevent the nunjuck call from converting {{hostBaseUrl}} to an empty string
+        // and let the hostBaseUrl value be injected later.
+        hostBaseUrl: '{{hostBaseUrl}}',
+        baseUrl: `{{hostBaseUrl}}/${ensurePosix(newBase.relative)}`,
+      }, { path: includedSourceFile });
+      node.children = cheerio.parseHTML(rendered, true);
+      cheerio.prototype.options.xmlMode = true;
+    }
+
     return node;
   }
 

--- a/src/lib/markbind/src/preprocessors/componentPreprocessor.js
+++ b/src/lib/markbind/src/preprocessors/componentPreprocessor.js
@@ -182,28 +182,6 @@ function _preProcessPanel(node, context, config, parser) {
  * Includes
  */
 
-
-function _rebaseReferenceForStaticIncludes(pageData, element, config) {
-  if (!config) return pageData;
-
-  if (!pageData.includes('{{baseUrl}}')) return pageData;
-
-  const filePath = element.attribs[ATTRIB_INCLUDE_PATH];
-  const fileBase = urlUtils.calculateNewBaseUrls(filePath, config.rootPath, config.baseUrlMap);
-
-  if (!fileBase.relative) return pageData;
-
-  const currentPath = element.attribs[ATTRIB_CWF];
-  const currentBase = urlUtils.calculateNewBaseUrls(currentPath, config.rootPath, config.baseUrlMap);
-
-  if (currentBase.relative === fileBase.relative) return pageData;
-
-  const newBase = fileBase.relative;
-  const newBaseUrl = `{{hostBaseUrl}}/${newBase}`;
-
-  return nunjuckUtils.renderEscaped(nunjucks, pageData, { baseUrl: newBaseUrl }, { path: filePath });
-}
-
 function _deleteIncludeAttributes(node) {
   const element = node;
 
@@ -334,7 +312,6 @@ function _preprocessInclude(node, context, config, parser) {
   if (isIncludeSrcMd) {
     actualContent = isInline ? actualContent : `\n\n${actualContent}\n`;
   }
-  actualContent = _rebaseReferenceForStaticIncludes(actualContent, element, config);
 
   // Flag with a data-included-from flag with the source filePath for calculating
   // the file path of dynamic resources ( images, anchors, plugin sources, etc. ) later

--- a/src/lib/markbind/src/utils/urls.js
+++ b/src/lib/markbind/src/utils/urls.js
@@ -8,48 +8,59 @@ const {
   BOILERPLATE_FOLDER_NAME,
 } = require('../constants');
 
+
 /**
+ * Calculates the absolute path of of the immediate parent site of the specified filePath.
  * @param filePath The absolute file path to look up that is nested inside the root directory
  * @param root The base directory from which to terminate the look up
  * @param lookUp The set of urls representing the sites' base directories
- * @return An object containing
- *         1. The parent site's path of that the immediate parent site of the specified filePath,
- *            or the root site's path if there is none
- *         2. The relative path from (1) to the immediate parent site of the specified filePath
+ * @return String The immediate parent site's absolute path.
  * @throws If a non-absolute path or path outside the root is given
  */
-function calculateNewBaseUrls(filePath, root, lookUp) {
+function getParentSiteAbsolutePath(filePath, root, lookUp) {
   if (!path.isAbsolute(filePath)) {
-    throw new Error(`Non-absolute path given to calculateNewBaseUrls: '${filePath}'`);
+    throw new Error(`Non-absolute path given to getParentSiteAbsolutePath: '${filePath}'`);
   }
   if (!pathIsInside(filePath, root)) {
     throw new Error(`Path given '${filePath}' is not in root '${root}'`);
   }
 
-  function calculate(file, result) {
+  function calculate(file) {
     if (file === root) {
-      return { relative: '', parent: root };
+      return file;
     }
 
     const parent = path.dirname(file);
-    if (lookUp.has(parent)) {
-      return result
-        ? { relative: path.relative(parent, result), parent }
-        : calculate(parent, parent);
-    }
-
-    return calculate(parent, result);
+    return lookUp.has(parent)
+      ? parent
+      : calculate(parent);
   }
 
-  return calculate(filePath, undefined);
+  return calculate(filePath);
 }
 
+/**
+ * Calculates the absolute and relative path of of the immediate parent site of the specified filePath.
+ */
+function getParentSiteAbsoluteAndRelativePaths(filePath, root, lookUp) {
+  const absolute = getParentSiteAbsolutePath(filePath, root, lookUp);
+  return {
+    absolute,
+    relative: path.relative(root, absolute),
+  };
+}
+
+/**
+ * Calculates a boilerplate's source file path at the immediate parent site of
+ * the supplied file path.
+ */
 function calculateBoilerplateFilePath(pathInBoilerplates, asIfAt, config) {
-  const { parent, relative } = calculateNewBaseUrls(asIfAt, config.rootPath, config.baseUrlMap);
-  return path.resolve(parent, relative, BOILERPLATE_FOLDER_NAME, pathInBoilerplates);
+  return path.resolve(getParentSiteAbsolutePath(asIfAt, config.rootPath, config.baseUrlMap),
+                      BOILERPLATE_FOLDER_NAME, pathInBoilerplates);
 }
 
 module.exports = {
+  getParentSiteAbsolutePath,
+  getParentSiteAbsoluteAndRelativePaths,
   calculateBoilerplateFilePath,
-  calculateNewBaseUrls,
 };

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -287,7 +287,6 @@
             <p>Requirements gathering, requirements elicitation, requirements analysis, requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity of understanding what a software product should
               do.</p>
           </div>
-
           <p><strong>Boilerplate include</strong></p>
           <div name="Boilerplate Referencing">
             <p>
@@ -373,6 +372,35 @@ specification that specifies how the product will address the requirements. </sp
             <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
             <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
           </div>
+          <p><strong>Include nested sub-site directly</strong></p>
+          <box>
+            <div>
+              <p><strong>baseUrl in a nested sub-site should correctly evaluate to the nested sub-site</strong></p>
+              <p>The base url in the nested_sub_site is /test_site/sub_site/nested_sub_site.</p>
+              <div>
+                <p><strong>baseUrl in a nested sub-site page's include should correctly evaluate to the nested sub-site</strong></p>
+                <p>The base url in the nested_sub_site page's include is /test_site/sub_site/nested_sub_site.</p>
+              </div>
+            </div>
+          </box>
+          <p><strong>Include nested sub-site from sub-site</strong></p>
+          <box>
+            <div>
+              <p><strong>baseUrl in a sub site should correctly evaluate</strong></p>
+              <p>The base url in sub_site is /test_site/sub_site.</p>
+              <p><strong>Subsite including nested subsite:</strong></p>
+              <box>
+                <div>
+                  <p><strong>baseUrl in a nested sub-site should correctly evaluate to the nested sub-site</strong></p>
+                  <p>The base url in the nested_sub_site is /test_site/sub_site/nested_sub_site.</p>
+                  <div>
+                    <p><strong>baseUrl in a nested sub-site page's include should correctly evaluate to the nested sub-site</strong></p>
+                    <p>The base url in the nested_sub_site page's include is /test_site/sub_site/nested_sub_site.</p>
+                  </div>
+                </div>
+              </box>
+            </div>
+          </box>
           <p><strong>Trimmed include</strong></p>
           <p><strong><span>Fragment with leading spaces and newline</span></strong></p>
           <p><strong>Trimmed include fragment</strong></p>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -114,6 +114,15 @@
       "headingKeywords": {}
     },
     {
+      "src": "sub_site/nested_sub_site/index.md",
+      "title": "",
+      "layout": "default",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
+    },
+    {
       "src": "test_md_fragment.md",
       "title": "",
       "layout": "default",

--- a/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
+++ b/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta name="default-head-top">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="generator" content="MarkBind 2.12.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title></title>
+  <link rel="stylesheet" href="../../markbind/css/bootstrap.min.css">
+  <link rel="stylesheet" href="../../markbind/css/bootstrap-vue.min.css">
+  <link rel="stylesheet" href="../../markbind/fontawesome/css/all.min.css">
+  <link rel="stylesheet" href="../../markbind/glyphicons/css/bootstrap-glyphicons.min.css">
+  <link rel="stylesheet" href="../../markbind/css/octicons.css">
+  <link rel="stylesheet" href="../../markbind/css/github.min.css">
+  <link rel="stylesheet" href="../../markbind/css/markbind.css">
+  <link rel="stylesheet" href="STYLESHEET_LINK">
+  <link rel="stylesheet" href="../../markbind/layouts/default/styles.css">
+  <meta name="default-head-bottom">
+  <link rel="icon" href="/test_site/favicon.png">
+</head>
+
+<body>
+  <div id="app">
+    <div id="flex-body">
+      <div id="content-wrapper">
+        <p><strong>baseUrl in a nested sub-site should correctly evaluate to the nested sub-site</strong></p>
+        <p>The base url in the nested_sub_site is /test_site/sub_site/nested_sub_site.</p>
+        <div>
+          <p><strong>baseUrl in a nested sub-site page's include should correctly evaluate to the nested sub-site</strong></p>
+          <p>The base url in the nested_sub_site page's include is /test_site/sub_site/nested_sub_site.</p>
+        </div>
+      </div>
+    </div>
+    <footer>
+      <div class="text-center">
+        Default footer
+      </div>
+    </footer>
+  </div>
+</body>
+<script src="../../markbind/js/vue.min.js"></script>
+<script src="../../markbind/js/vue-strap.min.js"></script>
+<script src="../../markbind/js/bootstrap-utility.min.js"></script>
+<script src="../../markbind/js/polyfill.min.js"></script>
+<script src="../../markbind/js/bootstrap-vue.min.js"></script>
+<script>
+  const baseUrl = '/test_site'
+  const enableSearch = true
+</script>
+<script src="../../markbind/js/setup.js"></script>
+<script src="SCRIPT_LINK"></script>
+<script>
+  alert("hello")
+</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=TRACKING-ID"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+
+  gtag('config', 'TRACKING-ID');
+</script>
+<script src="../../markbind/layouts/default/scripts.js"></script>
+
+</html>

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -153,6 +153,18 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 <include src="sub_site/testReuse.md#imageTest" />
 
+**Include nested sub-site directly**
+
+<box>
+<include src="sub_site/nested_sub_site/index.md" />
+</box>
+
+**Include nested sub-site from sub-site**
+
+<box>
+<include src="sub_site/testSubsiteAndNestedSubsiteBaseUrl.md" />
+</box>
+
 **Trimmed include** 
 
 **<include src="testTrimInclude.md" trim inline />**

--- a/test/functional/test_site/sub_site/nested_sub_site/contents/testNestedSubsiteBaseUrl.md
+++ b/test/functional/test_site/sub_site/nested_sub_site/contents/testNestedSubsiteBaseUrl.md
@@ -1,0 +1,3 @@
+**baseUrl in a nested sub-site page's include should correctly evaluate to the nested sub-site**
+
+The base url in the nested_sub_site page's include is {{ baseUrl }}.

--- a/test/functional/test_site/sub_site/nested_sub_site/index.md
+++ b/test/functional/test_site/sub_site/nested_sub_site/index.md
@@ -1,0 +1,5 @@
+**baseUrl in a nested sub-site should correctly evaluate to the nested sub-site**
+
+The base url in the nested_sub_site is {{ baseUrl }}.
+
+<include src="contents/testNestedSubsiteBaseUrl.md" />

--- a/test/functional/test_site/sub_site/nested_sub_site/site.json
+++ b/test/functional/test_site/sub_site/nested_sub_site/site.json
@@ -1,0 +1,30 @@
+{
+  "baseUrl": "",
+  "titlePrefix": "",
+  "ignore": [
+    "_markbind/layouts/*",
+    "_markbind/logs/*",
+    "_site/*",
+    "site.json",
+    "*.md",
+    "*.mbd",
+    "*.mbdf",
+    "*.njk",
+    ".git/*"
+  ],
+  "pages": [
+    {
+      "src": "index.md",
+      "title": "Landing Page"
+    },
+    {
+      "glob": "**/index.md"
+    },
+    {
+      "glob": "**/*.+(md|mbd)"
+    }
+  ],
+  "deploy": {
+    "message": "Site Update."
+  }
+}

--- a/test/functional/test_site/sub_site/testSubsiteAndNestedSubsiteBaseUrl.md
+++ b/test/functional/test_site/sub_site/testSubsiteAndNestedSubsiteBaseUrl.md
@@ -1,0 +1,9 @@
+**baseUrl in a sub site should correctly evaluate**
+
+The base url in sub_site is {{ baseUrl }}.
+
+**Subsite including nested subsite:**
+
+<box>
+<include src="nested_sub_site/index.md" />
+</box>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: Code maintainability / readability

Resolves #1083 

**What is the rationale for this request?**
To remove unnecessary complexity in the baseUrl resolving process and refactor some methods to simplify things.

**What changes did you make? (Give an overview)**
- Added a simpler version of `calculateNewBaseUrls` that directly returns the immediate parent site path instead of `{ parent, relative }`, as is the use case for `calculateNewBaseUrls` in many cases.
- Removed some unnecessary complexity ( `foundBase`, see below ) and refactored `_rebaseReference` to use guard clauses instead of nested ifs.
- Removed `_rebaseReferenceForStaticIncludes`, which is made redundant by `_rebaseReference`.

**Is there anything you'd like reviewers to focus on?**
What is the purpose of `foundBase` in `_rebaseReference`, if any?
The old `_rebaseReference` code calculated the new relative url from `combinedBases[bases[0]]`, where `combinedBases` was the result of `{ ...childrenBase, ...parentBase }`.

The purpose of this seems unclear, and also indeterministic. ( no issues were presented thus far as adding a `console.log` to `combinedBases` reveals that `combinedBases` is always of length `1` at most )

For example, suppose we have
```
<include src="file from main site" />
<include src="file from a sub (x2) site" />
```
that are siblings of one another. After we process the first `include`, `foundBase[root] = ''` would be present.
After processing the second `include` from a doubly nested sub site, we would have `foundBase[subsite1] = 'subsite1 to 2 relative path'`.
Since `Object.keys()` maintains the insertion order, we would wrongly retrieve the relative path of `''` for the second include, causing `{{baseUrl}}` to be resolved wrongly.

Another irregularity was the need for `childrenBase` in `combinedBases`.
When we find the relative base url of the included file, the only concern when resolving said url is `what site/subsite does the included file belong in?`.
It can also cause the same insertion order problem if we repeat the above example, but shift the second include as the child of the first include.

ie.
```
<include src="file from main site"> // in this case the relative url for the parent include is resolved wrongly
  <include src="file from a sub (x2) site" /> // that was a result of the parent include.
</include
```

**Testing instructions:**
`npm run test`, and 2103 site diff should have no diffs.

**Proposed commit message: (wrap lines at 72 characters)**
Simplify baseUrl resolving process

BaseUrls for static includes are rendered once during pre-processing
and another time during resolveBaseUrls.
The rebaseReference subroutine used during resolveBaseUrls also has
some unnecessary complexity.
In addition, in calculateNewBaseUrls, the relative baseUrl for doubly
nested subsites are not resolved correctly.

Let’s remove the rendering during pre-processing, unifying where baseUrl
is resolved for statically included content.
Let’s also refactor the rebaseReference method, simplifying its logic.
At the same time, we can standardise usages of the calculateNewBaseUrls
method to calculateImmediateParentSitePath, and fix the relative baseUrl
returned for doubly nested subsites.