### PR TITLE
bugfix: Fix hrefs for headings with angular brackets

### DIFF
--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -263,7 +263,13 @@ class Parser {
 
     if ((/^h[1-6]$/).test(node.name) && !node.attribs.id) {
       const textContent = utils.getTextContent(node);
-      const slugifiedHeading = slugify(textContent, { decamelize: false });
+      const slugifiedHeading = slugify(textContent, {
+        decamelize: false,
+        customReplacements: [
+          ['and lt', ''],
+          ['and gt', ''],
+        ],
+      });
 
       let headerId = slugifiedHeading;
       const { headerIdMap } = config;

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -263,13 +263,9 @@ class Parser {
 
     if ((/^h[1-6]$/).test(node.name) && !node.attribs.id) {
       const textContent = utils.getTextContent(node);
-      const slugifiedHeading = slugify(textContent, {
-        decamelize: false,
-        customReplacements: [
-          ['and lt', ''],
-          ['and gt', ''],
-        ],
-      });
+      let cleanedContent = textContent.replace(/&lt;/g, '');
+      cleanedContent = cleanedContent.replace(/&gt;/g, '');
+      const slugifiedHeading = slugify(cleanedContent, { decamelize: false });
 
       let headerId = slugifiedHeading;
       const { headerIdMap } = config;

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -263,8 +263,8 @@ class Parser {
 
     if ((/^h[1-6]$/).test(node.name) && !node.attribs.id) {
       const textContent = utils.getTextContent(node);
-      let cleanedContent = textContent.replace(/&lt;/g, '');
-      cleanedContent = cleanedContent.replace(/&gt;/g, '');
+      // remove the '&lt;' and '&gt;' symbols that markdown-it uses to escape '<' and '>'
+      const cleanedContent = textContent.replace(/&lt;|&gt;/g, '');
       const slugifiedHeading = slugify(cleanedContent, { decamelize: false });
 
       let headerId = slugifiedHeading;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #1076 

**What is the rationale for this request?**
Presence of angular brackets in headings creates undesirable href links.

**What changes did you make? (Give an overview)**
Removed occurrences of the strings `'and lt'` and `'and gt'` that are passed to `slugify`. 

**Provide some example code that this change will affect:**

~~customReplacements: [~~
      ~~['and lt', ''],~~
      ~~['and gt', ''],~~
    ~~],~~
~~});~~

New fix: 

```js
let cleanedContent = textContent.replace(/&lt;/g, '');
cleanedContent = cleanedContent.replace(/&gt;/g, '');
```

**Is there anything you'd like reviewers to focus on?**
n/a

**Proposed commit message: (wrap lines at 72 characters)**
```
The hrefs of headings with angular brackets are incorrect because
markdown-it escapes the characters to "&lt;" and "&gt;" and the
subsequent slugify operation converts it to "and-lt" or "and-gt".

Let's fix this by removing the occurrences of the strings 
"&lt;" and "&gt;" before the slugify operation
```