### PR TITLE
Fix refactor to processDynamicResources

### DIFF
--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -211,11 +211,10 @@ class Parser {
 
     $('img, pic, thumbnail').each(function () {
       const elem = $(this);
-      const resourcePath = utils.ensurePosix(elem.attr('src'));
-      if (resourcePath === undefined || resourcePath === '') {
-        // Found empty img/pic resource in resourcePath
+      if (!elem.attr('src')) {
         return;
       }
+      const resourcePath = utils.ensurePosix(elem.attr('src'));
       if (utils.isAbsolutePath(resourcePath) || utils.isUrl(resourcePath)) {
         // Do not rewrite.
         return;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Apologies, missed this out while reviewing #1075.
See https://github.com/MarkBind/markbind/pull/1075#discussion_r389262255 for original code

CI passes on travis because `ensurePosix` only runs if `path.sep !== /` ( non-unix ).
Otherwise `undefined` is passed to it which causes tests to fail. This is one such case #1040 could be really useful

**What changes did you make? (Give an overview)**
Reintroduced a `undefined` check for the the element's `src` before passing it to `utils.ensurePosix` to prevent said error.

**Proposed commit message: (wrap lines at 72 characters)**
Fix refactor to processDynamicResources
