### PR TITLE
[For Testing] Add pageNav to Using Plugins Page (#1062)

### DIFF
--- a/docs/userGuide/usingPlugins.md
+++ b/docs/userGuide/usingPlugins.md
@@ -3,6 +3,7 @@
 <frontmatter>
   title: "User Guide: {{ title }}"
   layout: userGuide
+  pageNav: "default"
 </frontmatter>
 
 # Using Plugins


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

Testing if issue #1077 already exists in #991 and pre-#1034. In order to narrow down the cause of bug.

This branch contains all commits until #991, and commit `92c90a3` cherry picked (in order to include the addition of the page nav in usingPlugins.md). 

Noting the netifly preview of this PR shows that bug exists since #991. 
https://deploy-preview-1094--markbind-master.netlify.com/userguide/usingplugins

This is the netifly preview corresponding to #1034 
https://deploy-preview-1034--markbind-master.netlify.com/userguide/usingplugins