### PR TITLE
Allow an array of globs for the globs option

### DIFF
--- a/docs/dg-site.json
+++ b/docs/dg-site.json
@@ -3,17 +3,11 @@
   "titlePrefix": "MarkBind",
   "pages": [
     {
-      "glob": "**/*.mbd"
-    },
-    {
-      "glob": "*.md"
+      "glob": ["**/*.mbd", "*.md", "devGuide/*.md"]
     },
     {
       "src": "index.md",
       "searchable": "no"
-    },
-    {
-      "glob": "devGuide/*.md"
     }
   ],
   "headingIndexingLevel": 6,

--- a/docs/site.json
+++ b/docs/site.json
@@ -4,32 +4,16 @@
   "titlePrefix": "MarkBind",
   "pages": [
     {
-      "glob": "**/*.mbd"
+      "glob": ["**/*.mbd", "*.md", "userGuide/*.md", "devGuide/*.md"]
     },
     {
-      "glob": "*.md"
-    },
-    {
-      "src": "index.md",
+      "src": [
+        "index.md",
+        "userGuide/fullSyntaxReference.md",
+        "userGuide/syntaxCheatSheet.md",
+        "userGuide/readerFacingFeatures.md"
+      ],
       "searchable": "no"
-    },
-    {
-      "glob": "userGuide/*.md"
-    },
-    {
-      "src": "userGuide/fullSyntaxReference.md",
-      "searchable": "no"
-    },
-    {
-      "src": "userGuide/syntaxCheatSheet.md",
-      "searchable": "no"
-    },
-    {
-      "src": "userGuide/readerFacingFeatures.md",
-      "searchable": "no"
-    },
-    {
-      "glob": "devGuide/*.md"
     }
   ],
   "plugins" : [

--- a/docs/ug-site.json
+++ b/docs/ug-site.json
@@ -3,28 +3,15 @@
   "titlePrefix": "MarkBind",
   "pages": [
     {
-      "glob": "**/*.mbd"
+      "glob": ["**/*.mbd", "*.md", "userGuide/*.md"]
     },
     {
-      "glob": "*.md"
-    },
-    {
-      "src": "index.md",
-      "searchable": "no"
-    },
-    {
-      "glob": "userGuide/*.md"
-    },
-    {
-      "src": "userGuide/fullSyntaxReference.md",
-      "searchable": "no"
-    },
-    {
-      "src": "userGuide/syntaxCheatSheet.md",
-      "searchable": "no"
-    },
-    {
-      "src": "userGuide/readerFacingFeatures.md",
+      "src": [
+        "index.md",
+        "userGuide/fullSyntaxReference.md",
+        "userGuide/syntaxCheatSheet.md",
+        "userGuide/readerFacingFeatures.md"
+      ],
       "searchable": "no"
     }
   ],

--- a/docs/userGuide/siteConfiguration.md
+++ b/docs/userGuide/siteConfiguration.md
@@ -98,8 +98,11 @@ _(Optional)_ **The theme for the generated site.** Uses the default Bootstrap th
 
 **An array of pages to be rendered.**
 
-* **`src`**/**`glob`**: `src` can be used to specify a file e.g., `docs/index.md`.<br>
-    Alternatively, `glob` can be used to define a file pattern in the [_glob syntax_](https://en.wikipedia.org/wiki/Glob_(programming)) e.g., `**/*.md`.
+* **`src/glob`**
+  * `src` can be used to specify a single file, or an array of files.<br>
+  {{ icon_examples }} `docs/index.md` or `[ 'docs/index.md', 'docs/userGuide.md' ]` { .my-1 }
+  * `glob` can be used alternatively to define a file pattern in the [_glob syntax_](https://en.wikipedia.org/wiki/Glob_(programming)), or an array of such file patterns.<br>
+  {{ icon_examples }} `**/*.md` or `[ '**/*.md', '**/*.mbdf' ]` { .my-2 }
 * **`title`**: The page `<title>` for the generated web page. Titles specified here take priority over titles specified in the [front matter](addingPages.html#front-matter) of individual pages.
 * **`layout`**: The [layout](tweakingThePageStructure.html#page-layouts) to be used by the page. Default: `default`.
 * **`searchable`**: Specifies that the page(s) should be excluded from searching. Default: `yes`.

--- a/src/Site.js
+++ b/src/Site.js
@@ -15,6 +15,7 @@ const injectMarkdownItSpecialTags = require(
 
 const _ = {};
 _.difference = require('lodash/difference');
+_.flatMap = require('lodash/flatMap');
 _.get = require('lodash/get');
 _.has = require('lodash/has');
 _.includes = require('lodash/includes');
@@ -442,36 +443,38 @@ class Site {
    */
   collectAddressablePages() {
     const { pages } = this.siteConfig;
-    const addressableGlobs = pages.filter(page => page.glob);
-    this.addressablePages = pages.filter(page => page.src);
+    const pagesFromSrc = _.flatMap(pages.filter(page => page.src), page => (Array.isArray(page.src)
+      ? page.src.map(pageSrc => ({ ...page, src: pageSrc }))
+      : [page]));
     const set = new Set();
-    const duplicatePages = this.addressablePages
+    const duplicatePages = pagesFromSrc
       .filter(page => set.size === set.add(page.src).size)
       .map(page => page.src);
     if (duplicatePages.length > 0) {
       return Promise.reject(
         new Error(`Duplicate page entries found in site config: ${_.uniq(duplicatePages).join(', ')}`));
     }
-    const globPaths = addressableGlobs.reduce((globPages, addressableGlob) =>
-      globPages.concat(walkSync(this.rootPath, {
-        directories: false,
-        globs: [addressableGlob.glob],
-        ignore: [CONFIG_FOLDER_NAME, SITE_FOLDER_NAME],
-      }).map(globPath => ({
-        src: globPath,
-        searchable: addressableGlob.searchable,
-        layout: addressableGlob.layout,
-        frontmatter: addressableGlob.frontmatter,
-      }))), []);
-    // Add pages collected by walkSync and merge properties for pages
+    const pagesFromGlobs = _.flatMap(pages.filter(page => page.glob), page => walkSync(this.rootPath, {
+      directories: false,
+      globs: Array.isArray(page.glob) ? page.glob : [page.glob],
+      ignore: [CONFIG_FOLDER_NAME, SITE_FOLDER_NAME],
+    }).map(filePath => ({
+      src: filePath,
+      searchable: page.searchable,
+      layout: page.layout,
+      frontmatter: page.frontmatter,
+    })));
+    /*
+     Add pages collected from globs and merge properties for pages
+     Page properties collected from src have priority over page properties from globs,
+     while page properties from later entries take priority over earlier ones.
+     */
     const filteredPages = {};
-    globPaths.concat(this.addressablePages).forEach((page) => {
+    pagesFromGlobs.concat(pagesFromSrc).forEach((page) => {
       const filteredPage = _.omitBy(page, _.isUndefined);
-      if (page.src in filteredPages) {
-        filteredPages[page.src] = { ...filteredPages[page.src], ...filteredPage };
-      } else {
-        filteredPages[page.src] = filteredPage;
-      }
+      filteredPages[page.src] = page.src in filteredPages
+        ? { ...filteredPages[page.src], ...filteredPage }
+        : filteredPage;
     });
     this.addressablePages = Object.values(filteredPages);
 

--- a/src/template/default/site.json
+++ b/src/template/default/site.json
@@ -18,10 +18,7 @@
       "title": "Landing Page"
     },
     {
-      "glob": "**/index.md"
-    },
-    {
-      "glob": "**/*.+(md|mbd)"
+      "glob": ["**/index.md", "**/*.+(md|mbd)"]
     }
   ],
   "deploy": {

--- a/src/template/minimal/site.json
+++ b/src/template/minimal/site.json
@@ -18,14 +18,10 @@
         "title": "Hello World"
       },
       {
-        "glob": "**/index.md"
-      },
-      {
-        "glob": "**/*.+(md|mbd)"
+        "glob": ["**/index.md", "**/*.+(md|mbd)"]
       }
     ],
     "deploy": {
       "message": "Site Update."
     }
-  }
-  
+}

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -152,6 +152,16 @@
       "headingKeywords": {}
     },
     {
+      "title": "Hello World",
+      "head": "overwriteLayoutHead.md",
+      "layout": "testLayout",
+      "src": "testLayoutsOverride.md",
+      "globalOverrideProperty": "Overridden by global override",
+      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "headings": {},
+      "headingKeywords": {}
+    },
+    {
       "src": "testExternalScripts.md",
       "title": "Hello World",
       "layout": "default",
@@ -165,16 +175,6 @@
       "head": "overwriteLayoutHead.md",
       "layout": "testLayout",
       "src": "testLayouts.md",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
-      "headings": {},
-      "headingKeywords": {}
-    },
-    {
-      "title": "Hello World",
-      "head": "overwriteLayoutHead.md",
-      "layout": "testLayout",
-      "src": "testLayoutsOverride.md",
       "globalOverrideProperty": "Overridden by global override",
       "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},

--- a/test/functional/test_site/site.json
+++ b/test/functional/test_site/site.json
@@ -17,7 +17,7 @@
       "layout": "testAfterSetup"
     },
     {
-      "src": "testEmptyFrontmatter.md",
+      "src": ["testEmptyFrontmatter.md", "testLayoutsOverride.md"],
       "title": "Hello World",
       "layout": "testLayout"
     },
@@ -34,15 +34,7 @@
       "title": "Hello World"
     },
     {
-      "src": "testLayoutsOverride.md",
-      "title": "Hello World",
-      "layout": "testLayout"
-    },
-    {
-      "glob": "**/index.md"
-    },
-    {
-      "glob": "**/test_md_fragment.md"
+      "glob": ["**/index.md", "**/test_md_fragment.md"]
     },
     {
       "src": "testAntiFOUCStyles.md",

--- a/test/functional/test_site_convert/expected/siteData.json
+++ b/test/functional/test_site_convert/expected/siteData.json
@@ -2,13 +2,6 @@
   "enableSearch": true,
   "pages": [
     {
-      "src": "index.md",
-      "title": "Landing Page",
-      "layout": "default",
-      "headings": {},
-      "headingKeywords": {}
-    },
-    {
       "src": "Home.md",
       "title": "",
       "layout": "default",
@@ -81,6 +74,13 @@
       "siteNav": "site-nav.md",
       "src": "contents/topic3b.md",
       "title": "",
+      "layout": "default",
+      "headings": {},
+      "headingKeywords": {}
+    },
+    {
+      "src": "index.md",
+      "title": "Landing Page",
       "layout": "default",
       "headings": {},
       "headingKeywords": {}

--- a/test/functional/test_site_templates/test_default/expected/siteData.json
+++ b/test/functional/test_site_templates/test_default/expected/siteData.json
@@ -3,23 +3,6 @@
   "pages": [
     {
       "header": "header.md",
-      "pageNav": 2,
-      "pageNavTitle": "Chapters of This Page",
-      "siteNav": "site-nav.md",
-      "src": "index.md",
-      "title": "Landing Page",
-      "layout": "default",
-      "headings": {
-        "heading-1": "Heading 1",
-        "sub-heading-1-1": "Sub Heading 1.1",
-        "sub-heading-1-2": "Sub Heading 1.2",
-        "heading-2": "Heading 2",
-        "heading-3": "Heading 3"
-      },
-      "headingKeywords": {}
-    },
-    {
-      "header": "header.md",
       "siteNav": "site-nav.md",
       "src": "contents/topic1.md",
       "title": "",
@@ -54,6 +37,23 @@
       "title": "",
       "layout": "default",
       "headings": {},
+      "headingKeywords": {}
+    },
+    {
+      "header": "header.md",
+      "pageNav": 2,
+      "pageNavTitle": "Chapters of This Page",
+      "siteNav": "site-nav.md",
+      "src": "index.md",
+      "title": "Landing Page",
+      "layout": "default",
+      "headings": {
+        "heading-1": "Heading 1",
+        "sub-heading-1-1": "Sub Heading 1.1",
+        "sub-heading-1-2": "Sub Heading 1.2",
+        "heading-2": "Heading 2",
+        "heading-3": "Heading 3"
+      },
       "headingKeywords": {}
     }
   ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] Enhancement to an existing feature

Resolves #789 

**What is the rationale for this request?**
Allow authors to specify an array of globs for the `globs` option, which can help reduce repeated configuration

**What changes did you make? (Give an overview)**
- Simple one line code change to allow said feature
- Small rewrite of the complex `reduce - concat` method of collecting pages with globs and `walkSync` using `flatMap` instead.
- Some other minor refactors to `collectAddressablePages`
- Update documentation accordingly
- Update existing `site.json` for test sites / docs and update test files accordingly.
  - Two of the test sites' expected `siteData.json`'s page entries order was swapped due to `walkSync` now collecting the pages from all globs in the array simultaneously. ( the properties remain the same though )

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
...
globs: Array.isArray(page.glob) ? page.glob : [page.glob],
...
```

**Is there anything you'd like reviewers to focus on?**
- ~Should we allow this for `src` as well?~

**Testing instructions:**
- `npm run test` should pass ( existing `site.json` for docs and test sites were updated to use new syntax )

**Proposed commit message: (wrap lines at 72 characters)**
Allow an array for specifying page src or glob

The site configuration does not allow using an array for specifying
pages in the src or glob property.
The method for collecting the addressable pages can also be
made slightly simpler in the process.

Let’s do so, reducing the amount of repeated configuration the
author potentially needs to write.
Let’s also simplify the method for collecting addressable pages
in the process.
