### PR TITLE
Octicons: support icon-size property

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
+++ b/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
@@ -1,7 +1,7 @@
 const octicons = require('@primer/octicons');
 
 module.exports = require('markdown-it-regexp')(
-  /:(fa[brs]|glyphicon|octicon)-([a-z-]+):/,
+    /:(fa[brs]|glyphicon|octicon)-([a-z-]+):/,
     (match, utils) => {
         let iconFontType = match[1];
         let iconFontName = match[2];

--- a/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
+++ b/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
@@ -1,20 +1,15 @@
 const octicons = require('@primer/octicons');
 
 module.exports = require('markdown-it-regexp')(
-    /:(fa[brs]|glyphicon|octicon)-([a-z-]+):([0-9])x/,
+  /:(fa[brs]|glyphicon|octicon)-([a-z-]+):/,
     (match, utils) => {
         let iconFontType = match[1];
         let iconFontName = match[2];
-        let iconSize = match[3];
-        const octiconSizeOptions = {height: 16, width: 12};
 
         if (iconFontType === 'glyphicon') {
             return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
         } else if (iconFontType === 'octicon') {
-            const sizeInNum = parseInt(iconSize, 10);
-            octiconSizeOptions.height *= sizeInNum;
-            octiconSizeOptions.width *= sizeInNum;
-            return octicons[iconFontName].toSVG(octiconSizeOptions);
+            return octicons[iconFontName].toSVG();
         } else { // If icon is a Font Awesome icon
             return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
         }

--- a/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
+++ b/src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons.js
@@ -1,15 +1,20 @@
 const octicons = require('@primer/octicons');
 
 module.exports = require('markdown-it-regexp')(
-    /:(fa[brs]|glyphicon|octicon)-([a-z-]+):/,
+    /:(fa[brs]|glyphicon|octicon)-([a-z-]+):([0-9])x/,
     (match, utils) => {
         let iconFontType = match[1];
         let iconFontName = match[2];
+        let iconSize = match[3];
+        const octiconSizeOptions = {height: 16, width: 12};
 
         if (iconFontType === 'glyphicon') {
             return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
         } else if (iconFontType === 'octicon') {
-            return octicons[iconFontName].toSVG();
+            const sizeInNum = parseInt(iconSize, 10);
+            octiconSizeOptions.height *= sizeInNum;
+            octiconSizeOptions.width *= sizeInNum;
+            return octicons[iconFontName].toSVG(octiconSizeOptions);
         } else { // If icon is a Font Awesome icon
             return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
         }

--- a/src/lib/markbind/src/parsers/componentParser.js
+++ b/src/lib/markbind/src/parsers/componentParser.js
@@ -19,7 +19,6 @@ cheerio.prototype.options.decodeEntities = false; // Don't escape HTML entities
  * @param attribute Attribute name to parse
  * @param isInline Whether to parse the attribute with only inline markdown-it rules
  * @param slotName Name attribute of the <slot> element to insert, which defaults to the attribute name
- * @param shouldDelete Whether to delete the said attrribute after it has been parsed
  */
 function _parseAttributeWithoutOverride(node, attribute, isInline, slotName = attribute) {
   const hasAttributeSlot = node.children

--- a/src/lib/markbind/src/parsers/componentParser.js
+++ b/src/lib/markbind/src/parsers/componentParser.js
@@ -42,7 +42,7 @@ function _parseAttributeWithoutOverride(node, attribute, isInline, slotName = at
 }
 
 /**
- * Parses the icon attribute of the box, if present, and applying the icon-size property for octicons
+ * Parses the icon attribute of the box, if present, and applies the icon-size property for octicons
  * @param node Element to parse
  */
 function _parseBoxIconSize(node) {

--- a/test/unit/markdown-it-icons.test.js
+++ b/test/unit/markdown-it-icons.test.js
@@ -1,4 +1,4 @@
-const expectedOcticon = require('@primer/octicons')['git-pull-request'].toSVG();
+const expectedOcticon = require('@primer/octicons')['git-pull-request'];
 
 const markdownIt = require('markdown-it')()
   .use(require('../../src/lib/markbind/src/lib/markdown-it-shared/markdown-it-icons'));


### PR DESCRIPTION
**What is the purpose of this pull request?**
• [x] Bug fix

Fixes #1096 

**What changes did you make? (Give an overview)**
The bug occured because there was the style property currently for icons only works for favicons. We do some HTML manipulation in the parser to detect if theres magnification and adjust the size accordingly. We cannot do this in the vue component as to change a svg's size, we need to change the element directly and its surrounding divs.


**Is there anything you'd like reviewers to focus on?**
I haven't really played with the parser code, so if its not in line with the current style, do let me know. Also, I'm not sure if this octicon icon with icon-size is used anywhere else. If so, I might want to generalize this solution. 

**Testing instructions:**
Run the code with octicons and use the icon-size property. Regardless the icon-size property is there or not, it should not break the code and the octicon should vary in size

**Proposed commit message: (wrap lines at 72 characters)**
Support icon-size property for octicons.
