### PR TITLE
Fix octicon sizing

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -442,33 +442,8 @@ pre {
     outline: none;
 }
 
-/* Octicon heading sizes */
-h1 .octicon {
-    height: 48px;
-    width: 48px;
-}
-
-h2 .octicon {
-    height: 38px;
-    width: 38px;
-}
-
-h3 .octicon {
-    height: 33px;
-    width: 33px;
-}
-
-h4 .octicon {
-    height: 28px;
-    width: 28px;
-}
-
-h5 .octicon {
-    height: 24px;
-    width: 24px;
-}
-
-h6 .octicon {
-    height: 19px;
-    width: 19px;
+/* Octicon sizing */
+.octicon {
+    height: 1em;
+    width: 1em;
 }

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -441,3 +441,34 @@ pre {
 .copy-btn:focus {
     outline: none;
 }
+
+/* Octicon heading sizes */
+h1 .octicon {
+    height: 48px;
+    width: 48px;
+}
+
+h2 .octicon {
+    height: 38px;
+    width: 38px;
+}
+
+h3 .octicon {
+    height: 33px;
+    width: 33px;
+}
+
+h4 .octicon {
+    height: 28px;
+    width: 28px;
+}
+
+h5 .octicon {
+    height: 24px;
+    width: 24px;
+}
+
+h6 .octicon {
+    height: 19px;
+    width: 19px;
+}


### PR DESCRIPTION
• [X] Bug fix

Fixes #1096. 

**What is the rationale for this request?**

Currently, icons are sized by using CSS classes (`fa-2x` for example) that set the `font-size` property. Since octicons are not font-based but rather SVG-based, this style does not affect them, causing them to be incorrectly sized. 

<img width="377" alt="Screen Shot 2020-03-17 at 11 50 59 PM" src="https://user-images.githubusercontent.com/6095637/76875879-1db0a180-68ac-11ea-8897-216edaa03ee6.png">

<img width="896" alt="Screen Shot 2020-03-18 at 11 30 36 AM" src="https://user-images.githubusercontent.com/6095637/76923043-503eb680-690d-11ea-9eee-094370fde512.png">

**What changes did you make? (Give an overview)**

This PR sets the height and width for octicons to `1em`, allowing them to inherit their parent container's font size as its dimensions. 

<img width="369" alt="Screen Shot 2020-03-17 at 11 51 40 PM" src="https://user-images.githubusercontent.com/6095637/76876045-55b7e480-68ac-11ea-855c-df94f9b2ee10.png">

<img width="899" alt="Screen Shot 2020-03-18 at 11 29 59 AM" src="https://user-images.githubusercontent.com/6095637/76923162-9e53ba00-690d-11ea-8e85-192a2aa9decd.png">

**Testing instructions:**

1. Use an octicon where you would expect it to be a different size. Some examples are: 
    - Headings
    - `Box` icon with a custom `icon-size`
2. The size of the octicon should match where it's used

**Credits**
- @ang-zeyu for the generalized solution (in the comments below)
- @hcwong for the existing work on #1128 (which this PR fixes as well) 

**Proposed commit message: (wrap lines at 72 characters)**

Fix octicon sizing
