### PR TITLE
Fix fontawsome icons don't show underlines to indicate modal/tooltip

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -382,8 +382,7 @@ li.footnote-item:target {
 
 /* styles for triggers */
 .trigger {
-    display: inline-block;
-    text-decoration: underline dotted;
+    border-bottom: 1px dashed currentColor;
 }
 
 .trigger-click {

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -387,7 +387,7 @@ li.footnote-item:target {
 
 .trigger-click {
     cursor: pointer;
-    text-decoration: underline dashed;
+    border-bottom: 1px dashed currentColor;
 }
 
 .modal.mb-zoom {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
This pull request restores the intended underline behavior of triggers. 

Fixes https://github.com/MarkBind/markbind/issues/995

**Proposed commit message: (wrap lines at 72 characters)**

Fix trigger underline. 
