### PR TITLE
Changes remaining references from filterTags to tags

### DIFF
--- a/docs/userGuide/syntax/tags.mbdf
+++ b/docs/userGuide/syntax/tags.mbdf
@@ -1,5 +1,5 @@
-<include src="../plugins/filterTags.mbdf" />
+<include src="../plugins/tags.mbdf" />
 
 <span id="short" class="d-none">
-  <include src="../plugins/filterTags.mbdf#short" />
+  <include src="../plugins/tags.mbdf#short" />
 </span>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
When we changed `filterTags.mbdf` -> `tags.mbdf`, we missed some references to that file in other pages. This causes the documentation site to fail to build.

**What changes did you make? (Give an overview)**
Fix the references to `filterTags.mbdf`


**Testing instructions:**
`markbind serve docs` should work

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
There are some existing references to filterTags.mbdf in the user guide. Let's
change them to tabs.mbdf instead.

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
