### PR TITLE
Remove duplicate code in syntax doc

### DIFF
--- a/docs/_markbind/boilerplates/codeAndOutput.md
+++ b/docs/_markbind/boilerplates/codeAndOutput.md
@@ -1,0 +1,22 @@
+<!-- This boilerplate shows Markbind code and the rendered output of that code -->
+<!-- Has 2 variables. -->
+<!-- `code` - The MarkBind code content in this variable will appear in a code block containing the code, -->
+<!--          and as rendered output of the code. The code cannot start or end with empty lines due to `trim` -->
+<!-- `highlightStyle` (optional) - Defines the syntax coloring for the code block-->
+
+%%CODE:%%
+<div class="indented">
+
+```{{ highlightStyle | safe }}{.no-line-numbers}
+{{ code | safe | trim }}
+```
+</div>
+
+%%OUTPUT:%%
+<div class="indented">
+
+<box border-left-color="grey" background-color="white">
+
+{{ code | safe }}
+</box>
+</div>

--- a/docs/_markbind/boilerplates/codeAndOutputCode.md
+++ b/docs/_markbind/boilerplates/codeAndOutputCode.md
@@ -1,0 +1,23 @@
+<!-- This boilerplate is simimlar to codeAndOuput.md but specific for fenced code syntax. -->
+<!-- We need 4 backticks to make a fenced code block of fenced code block code -->
+<!-- Syntax coloring is fixed to Markdown because it is Markdown fenced code syntax -->
+<!-- Has 1 variable. -->
+<!-- `code` - The MarkBind code content in this variable will appear in a code block containing the code, -->
+<!--          and as rendered output of the code. The code cannot start or end with empty lines due to `trim` -->
+
+%%CODE:%%
+<div class="indented">
+
+````markdown{.no-line-numbers}
+{{ code | safe | trim }}
+````
+</div>
+
+%%OUTPUT:%%
+<div class="indented">
+
+<box border-left-color="grey" background-color="white">
+
+{{ code | safe }}
+</box>
+</div>

--- a/docs/userGuide/syntax/badges.mbdf
+++ b/docs/userGuide/syntax/badges.mbdf
@@ -1,9 +1,8 @@
 ## Badges
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 Normal:
 <span class="badge badge-primary">Primary</span>
 <span class="badge badge-secondary">Secondary</span>
@@ -22,38 +21,14 @@ Normal:
 <span class="badge badge-pill badge-info">Info</span>
 <span class="badge badge-pill badge-light">Light</span>
 <span class="badge badge-pill badge-dark">Dark</span>
-```
-</span>
-<span id="output">
-
-Normal:
-<span class="badge badge-primary">Primary</span>
-<span class="badge badge-secondary">Secondary</span>
-<span class="badge badge-success">Success</span>
-<span class="badge badge-danger">Danger</span>
-<span class="badge badge-warning">Warning</span>
-<span class="badge badge-info">Info</span>
-<span class="badge badge-light">Light</span>
-<span class="badge badge-dark">Dark</span>
-<br>Pills:
-<span class="badge badge-pill badge-primary">Primary</span>
-<span class="badge badge-pill badge-secondary">Secondary</span>
-<span class="badge badge-pill badge-success">Success</span>
-<span class="badge badge-pill badge-danger">Danger</span>
-<span class="badge badge-pill badge-warning">Warning</span>
-<span class="badge badge-pill badge-info">Info</span>
-<span class="badge badge-pill badge-light">Light</span>
-<span class="badge badge-pill badge-dark">Dark</span>
-
-</span>
+</variable>
 </include>
 
 You can use Badges in combination with headings, buttons, links, etc.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 Links:
 <a href="#" class="badge badge-primary">Primary</a>
 <a href="#" class="badge badge-pill badge-warning">Warning</a>
@@ -67,24 +42,7 @@ Headings:
 
 ### Feature X <span class="badge badge-danger">beta</span> {.no-index}
 ##### Feature Y <span class="badge badge-pill badge-success">stable</span> {.no-index}
-```
-</span>
-<span id="output">
-
-Links:
-<a href="#" class="badge badge-primary">Primary</a>
-<a href="#" class="badge badge-pill badge-warning">Warning</a>
-
-Buttons:
-<button type="button" class="btn btn-primary">
-  Difficulty Level <span class="badge badge-light">4</span>
-</button>
-
-Headings:
-
-### Feature X <span class="badge badge-danger">beta</span> {.no-index}
-##### Feature Y <span class="badge badge-pill badge-success">stable</span> {.no-index}
-</span>
+</variable>
 </include>
 
 

--- a/docs/userGuide/syntax/blockquotes.mbdf
+++ b/docs/userGuide/syntax/blockquotes.mbdf
@@ -1,32 +1,21 @@
 ## Blockquotes
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 Normal text
 > Blockquote, first paragraph
 >
 > Second paragraph
 >> Nested quoteblock
-```
-</span>
-<span id="output">
-
-Normal text
-> Blockquote, first paragraph
->
-> Second paragraph
->> Nested blockquote
-</span>
+</variable>
 </include>
 
 Alternatively, you can use `<blockquote>` tags:
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 Normal text
 <blockquote>
 Blockquote, first paragraph
@@ -36,20 +25,7 @@ Second paragraph
 Nested blockquote
 </blockquote>
 </blockquote>
-```
-</span>
-<span id="output">
-
-Normal text
-<blockquote>
-Blockquote, first paragraph
-
-Second paragraph
-<blockquote>
-Nested blockquote
-</blockquote>
-</blockquote>
-</span>
+</variable>
 </include>
 
 <small>More info: https://www.markdownguide.org/basic-syntax#blockquotes-1</small>

--- a/docs/userGuide/syntax/boxes.mbdf
+++ b/docs/userGuide/syntax/boxes.mbdf
@@ -2,10 +2,9 @@
 
 **Box comes with different built-in types.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box>
     default
 </box>
@@ -39,53 +38,14 @@
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </box>
 </box>
-```
-</span>
-<span id="output">
-
-<box>
-    default
-</box>
-<box type="info">
-    info
-</box>
-<box type="warning">
-    warning
-</box>
-<box type="success">
-    success
-</box>
-<box type="important">
-    important
-</box>
-<box type="wrong">
-    wrong
-</box>
-<box type="tip">
-    tip
-</box>
-<box type="definition">
-    definition
-</box>
-<box type="info" dismissible>
-    dismissible info
-</box>
-<box type="success" header="#### Header :rocket: { .no-index }" icon-size="2x">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    <box type="warning" header="You can use **markdown** here! :pizza:" dismissible>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    </box>
-</box>
-
-</span>
+</variable>
 </include>
 
 **Markbind also supports a light color scheme for boxes**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box type="info" light>
     info light
 </box>
@@ -107,32 +67,7 @@
 <box type="definition" light>
     definition light
 </box>
-```
-</span>
-<span id="output">
-
-<box type="info" light>
-    info light
-</box>
-<box type="warning" light>
-    warning light
-</box>
-<box type="success" light>
-    success light
-</box>
-<box type="important" light>
-    important light
-</box>
-<box type="wrong" light>
-    wrong light
-</box>
-<box type="tip" light>
-    tip light
-</box>
-<box type="definition" light>
-    definition light
-</box>
-</span>
+</variable>
 </include>
 
 **MarkBind also supports a seamless style of boxes**
@@ -141,10 +76,9 @@
 As <code>light</code> and <code>seamless</code> are mutually exclusive styles, <code>light</code> takes priority over <code>seamless</code>.
 </box>
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box type="info" seamless>
     info seamless
 </box>
@@ -166,57 +100,21 @@ As <code>light</code> and <code>seamless</code> are mutually exclusive styles, <
 <box type="definition" seamless>
     definition seamless
 </box>
-```
-</span>
-<span id="output">
-
-<box type="info" seamless>
-    info seamless
-</box>
-<box type="warning" seamless>
-    warning seamless
-</box>
-<box type="success" seamless>
-    success seamless
-</box>
-<box type="important" seamless>
-    important seamless
-</box>
-<box type="wrong" seamless>
-    wrong seamless
-</box>
-<box type="tip" seamless>
-    tip seamless
-</box>
-<box type="definition" seamless>
-    definition seamless
-</box>
-</span>
+</variable>
 </include>
 
 **You can customize the Box's appearance.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box background-color="white" border-color="grey" border-left-color="blue">
     default, styled as empty box with blue left border
 </box>
 <box type="info" icon=":rocket:">
     info, with rocket icon
 </box>
-```
-</span>
-<span id="output">
-
-<box background-color="white" border-color="grey" border-left-color="blue">
-    default, styled as empty box with blue left border
-</box>
-<box type="info" icon=":rocket:">
-    info, with rocket icon
-</box>
-</span>
+</variable>
 </include>
 
 **You can remove the background, icon and borders of preset styles.**
@@ -226,10 +124,9 @@ Custom styles (<code>background-color</code>, <code>border-color</code>, <code>b
 </box>
 
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box no-icon no-background type="success">
     success box without a tick icon and backgound
 </box>
@@ -237,25 +134,14 @@ Custom styles (<code>background-color</code>, <code>border-color</code>, <code>b
 <box no-border type="definition" light>
     definition type box, light style without border
 </box>
-```
-</span>
-
-<span id="output">
-<box no-icon no-background type="success">
-    success box without a tick icon and backgound
-</box>
-
-<box no-border type="definition" light>
-    definition type box, light style without border
-</box>
-</span>
+</variable>
 </include>
 
 **You can also use icons and resize them accordingly.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <box type="warning" icon=":fas-camera:">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 </box>
@@ -265,21 +151,7 @@ Custom styles (<code>background-color</code>, <code>border-color</code>, <code>b
 <box type="warning" icon=":fas-camera:" icon-size="3x">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 </box>
-```
-</span>
-
-<span id="output">
-
-<box type="warning" icon=":fas-camera:">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-</box>
-<box type="warning" icon=":fas-camera:" icon-size="2x">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-</box>
-<box type="warning" icon=":fas-camera:" icon-size="3x">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-</box>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/code.mbdf
+++ b/docs/userGuide/syntax/code.mbdf
@@ -15,83 +15,48 @@ Features:
 ##### Syntax coloring
 To enable syntax coloring, specify a language next to the backticks before the fenced code block.
 <span id="main-example">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```xml
 <foo>
   <bar type="name">goo</bar>
 </foo>
 ```
-````
-</span>
-<span id="output">
-
-```xml
-<foo>
-  <bar type="name">goo</bar>
-</foo>
-```
-</span>
+</variable>
 </include>
 </span>
 
 ##### Line numbering
 Line numbers are provided by default. To hide line numbers, add the class `no-line-numbers` to the code block as below
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```xml {.no-line-numbers}
 <foo>
   <bar type="name">goo</bar>
 </foo>
 ```
-````
-</span>
-<span id="output">
-
-```xml {.no-line-numbers}
-<foo>
-  <bar type="name">goo</bar>
-</foo>
-```
-</span>
+</variable>
 </include>
 
 You can have your line numbers start with a value other than `1` with the `start-from` attribute.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```js {start-from=6}
 function add(a, b) {
     return a + b;
 }
 ```
-````
-</span>
-<span id="output">
-
-```js {start-from=6}
-function add(a, b) {
-    return a + b;
-}
-```
-</span>
+</variable>
 </include>
 
 
 ##### Line highlighting
 To highlight lines, add the attribute `highlight-lines` with the line numbers as value, as shown below. You can specify ranges or individual line numbers.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```java {highlight-lines="2,4,6-8"}
 import java.util.List;
 
@@ -105,90 +70,43 @@ public class Inventory {
     //...
 }
 ```
-````
-</span>
-<span id="output">
-
-```java {highlight-lines="2,4,6-8"}
-import java.util.List;
-
-public class Inventory {
-    private List<Item> items;
-
-    public int getItemCount(){
-        return items.size();
-    }
-
-    //...
-}
-```
-</span>
+</variable>
 </include>
 
 ##### Heading
 To add a heading, add the attribute `heading` with the heading text as the value, as shown below.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```xml {heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>
 </foo>
 ```
-````
-</span>
-<span id="output">
-
-```xml {heading="Heading title"}
-<foo>
-  <bar type="name">goo</bar>
-</foo>
-```
-</span>
+</variable>
 </include>
 
 Headings support inline Markdown, except for `Inline Code` and %%Dim%% text styles.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```{heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, :+1: :exclamation: :x: :construction:<br>We support page breaks"}
 <foo></foo>
 ```
-````
-</span>
-<span id="output">
-
-```{heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, :+1: :exclamation: :x: :construction:<br>We support page breaks"}
-<foo></foo>
-```
-</span>
+</variable>
 </include>
 
 ##### Using multiple features
 You can also use multiple features together, as shown below.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```` {.no-line-numbers}
+<include src="codeAndOutputCode.md" boilerplate >
+<variable name="code">
 ```xml {highlight-lines="2" heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>
 </foo>
 ```
-````
-</span>
-<span id="output">
-
-```xml {highlight-lines="2" heading="Heading title"}
-<foo>
-  <bar type="name">goo</bar>
-</foo>
-```
+</variable>
 </span>
 </include>
 
@@ -198,20 +116,11 @@ You can also use multiple features together, as shown below.
 
 MarkBind can apply syntax-coloring on inline code too.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```
-Consider the xml code `<bar type="name">goo</bar>`{.xml},
-or the java code `public static void main(String[] args)`{.java}.
-```
-
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="code">
 Consider the xml code `<bar type="name">goo</bar>`{.xml},<br>
 or the java code `public static void main(String[] args)`{.java}.
-</span>
+</variable>
 </include>
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/dropdowns.mbdf
+++ b/docs/userGuide/syntax/dropdowns.mbdf
@@ -2,10 +2,9 @@
 
 **You can use Dropdowns as a top level component.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <!--Notice how header attribute supports inline MarkDown-->
 <dropdown header="*Action*" type="primary">
   <li><a href="#dropdown" class="dropdown-item">Action</a></li>
@@ -25,35 +24,14 @@
 <dropdown header="Right aligned list" type="primary" menu-align-right>
   <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
 </dropdown>
-```
-</span>
-<span id="output">
-
-<dropdown header="*Action*" type="primary">
-  <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-  <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
-  <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-  <li role="separator" class="dropdown-divider"></li>
-  <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-</dropdown>
-
-<dropdown type="info">
-  <button slot="before" type="button" class="btn btn-info">Segmented</button>
-  <li><a href="#dropdown" class="dropdown-item">...</a></li>
-</dropdown>
-
-<dropdown header="Right aligned list" type="primary" menu-align-right>
-  <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-</dropdown>
-</span>
+</variable>
 </include>
 
 **You can also use Dropdowns as a nested component (e.g. part of a button group).**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <!-- In a button group -->
 <div class="btn-group d-flex" role="group">
   <a href="#dropdown" class="btn btn-danger w-100" role="button">Left</a>
@@ -73,28 +51,7 @@
   </dropdown>
   <a href="#dropdown" class="btn btn-success w-100" role="button">Right</a>
 </div>
-```
-</span>
-<span id="output">
-
-<div class="btn-group d-flex" role="group">
-  <a href="#dropdown" class="btn btn-danger w-100" role="button">Left</a>
-  <dropdown class="w-100">
-    <button slot="button" type="button" class="btn btn-warning dropdown-toggle w-100">
-      Action
-      <span class="caret"></span>
-    </button>
-    <ul slot="dropdown-menu" class="dropdown-menu">
-      <li><a href="#dropdown" class="dropdown-item">Action</a></li>
-      <li><a href="#dropdown" class="dropdown-item">Another action</a></li>
-      <li><a href="#dropdown" class="dropdown-item">Something else here</a></li>
-      <li role="separator" class="dropdown-divider"></li>
-      <li><a href="#dropdown" class="dropdown-item">Separated link</a></li>
-    </ul>
-  </dropdown>
-  <a href="#dropdown" class="btn btn-success w-100" role="button">Right</a>
-</div>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/embeds.mbdf
+++ b/docs/userGuide/syntax/embeds.mbdf
@@ -6,10 +6,11 @@
 
 Here are three ways of embedding YouTube videos and one example of how it will look in the page.
 
+<!-- We use outputBox.md instead of codeAndOuput.md as boilerplate, because there are 3 ways to code vs 1 example -->
 <include src="outputBox.md" boilerplate >
 <span id="code">
 
-```markdown
+```markdown{.no-line-numbers}
 @[youtube](v40b3ExbM0c)
 @[youtube](http://www.youtube.com/watch?v=v40b3ExbM0c)
 @[youtube](http://youtu.be/v40b3ExbM0c)
@@ -27,17 +28,11 @@ More media blocks, embedding services and additional options can be found in [Ma
 
 Here is an example of embedding a PowerPoint slide deck:
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 @[powerpoint](https://onedrive.live.com/embed?cid=A5AF047C4CAD67AB&resid=A5AF047C4CAD67AB%212070&authkey=&em=2)
-```
-</span>
-<span id="output">
-
-@[powerpoint](https://onedrive.live.com/embed?cid=A5AF047C4CAD67AB&resid=A5AF047C4CAD67AB%212070&authkey=&em=2)
-</span>
+</variable>
 </include>
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/emoji.mbdf
+++ b/docs/userGuide/syntax/emoji.mbdf
@@ -1,17 +1,11 @@
 ## Emoji
 
 <span id="main-example">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 :+1: :exclamation: :x: :construction:
-```
-</span>
-<span id="output">
-
-:+1: :exclamation: :x: :construction:
-</span>
+</variable>
 </include>
 </span>
 

--- a/docs/userGuide/syntax/footnotes.mbdf
+++ b/docs/userGuide/syntax/footnotes.mbdf
@@ -1,10 +1,9 @@
 ## Footnotes
 
 <span id="main-example-markbind">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 **Normal footnotes:**
 Here is a footnote reference,[^1] and another.[^longnote]
 
@@ -21,26 +20,7 @@ Here is an inline note.^[Inlines notes are easier to write, since
 you don't have to pick an identifier and move down to type the
 note.]
 
-```
-</span>
-<span id="output">
-
-**Normal footnotes:**
-Here is a footnote reference,[^1] and another.[^longnote]
-
-[^1]: Here is the footnote. Footnotes will appear at the bottom of the page.
-
-[^longnote]: Here's one with multiple blocks.
-
-    Subsequent paragraphs are indented to show that they
-belong to the previous footnote.
-
-
-**Inline footnotes:**
-Here is an inline note.^[Inlines notes are easier to write, since
-you don't have to pick an identifier and move down to type the
-note.]
-</span>
+</variable>
 </include>
 </span>
 

--- a/docs/userGuide/syntax/headings.mbdf
+++ b/docs/userGuide/syntax/headings.mbdf
@@ -3,21 +3,13 @@
 You can prepend the heading text with 1-6 `#` characters to indicate headings of levels 1-6.
 
 <span id="main-example">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 ### Heading level 3
 ...
 ###### Heading level 6
-```
-</span>
-<span id="output">
-
-### Heading level 3
-...
-###### Heading level 6
-</span>
+</variable>
 </include>
 </span>
 

--- a/docs/userGuide/syntax/horizontalrules.mbdf
+++ b/docs/userGuide/syntax/horizontalrules.mbdf
@@ -2,22 +2,13 @@
 
 Use three or more asterisks (`***`), dashes (`---`), or underscores (`___`) to indicate a horizontal line.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 *****
 -----
 ______________
-```
-</span>
-<span id="output">
-
-*****
------
-______________
-
-</span>
+</variable>
 </include>
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/images.mbdf
+++ b/docs/userGuide/syntax/images.mbdf
@@ -1,21 +1,16 @@
 ## Images
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 ![](https://markbind.org/images/logo-lightbackground.png)
-```
+</variable>
+</include>
+
 <box type="info">
   URLs can be specified as relative references. More info in: <i><a href="#intraSiteLinks">Intra-Site Links</a></i>
 </box>
 
-</span>
-<span id="output">
-
-![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
-</span>
-</include>
 
 <span id="short" class="d-none">
 ```markdown

--- a/docs/userGuide/syntax/lineBreaks.mbdf
+++ b/docs/userGuide/syntax/lineBreaks.mbdf
@@ -2,22 +2,13 @@
 
 The preferred way to indicate line breaks is to use a `<br>` tag.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 This is the second sentence.<br>
 This should be on a new line.
 This will not be in a new line.
-```
-</span>
-<span id="output">
-
-This is the second sentence.<br>
-This should be on a new line.
-This will not be in a new line.
-</span>
-</include>
+</variable>
 
 <small>Alternate syntax: https://www.markdownguide.org/basic-syntax#line-breaks</small>
 

--- a/docs/userGuide/syntax/links.mbdf
+++ b/docs/userGuide/syntax/links.mbdf
@@ -3,40 +3,23 @@
 Basic style:
 
 <span id="main-example">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 MarkBind home is at [here](https://markbind.org).
-```
-</span>
-<span id="output">
-
-MarkBind home is at [here](https://markbind.org).
-</span>
+</variable>
 </include>
 </span>
 
 _Reference style_ links (i.e., specify the URL in a separate place):
 
-<include src="outputBox.md" boilerplate >
-
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 MarkBind home is at [here][1].
 
 [1]: https://markbind.org
-
-```
-</span>
-<span id="output">
-
-MarkBind home is at [here][1]
-
-[1]: https://markbind.org
-
-</span>
+</variable>
 </include>
 
 <small>More info: https://www.markdownguide.org/basic-syntax#links</small>

--- a/docs/userGuide/syntax/lists.mbdf
+++ b/docs/userGuide/syntax/lists.mbdf
@@ -3,10 +3,9 @@
 
 ****Unordered lists:****
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 * Item 1
   * Sub item 1.1
   * Sub item 1.2<br>
@@ -14,41 +13,20 @@
     * Sub item 1.2.1
 * Item 2
 * Item 3
-```
-</span>
-<span id="output">
-
-* Item 1
-  * Sub item 1.1
-  * Sub item 1.2<br>
-    Second line
-    * Sub item 1.2.1
-* Item 2
-* Item 3
-</span>
+</variable>
 </include>
 
 ****Ordered lists:****
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 1. Item 1
    1. Sub item 1.1
    1. Sub item 1.2
 1. Item 2
 1. Item 3
-```
-</span>
-<span id="output">
-
-1. Item 1
-   1. Sub item 1.1
-   1. Sub item 1.2
-1. Item 2
-1. Item 3
-</span>
+</variable>
 </include>
 
 <small>More info on above list types: https://www.markdownguide.org/basic-syntax#lists</small>
@@ -56,46 +34,28 @@
 ****Task lists**** (from GFMD):
 
 <span id="main-example-gfmd">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 - [ ] Item 1
    - [ ] Sub item 1.1
    - [x] Sub item 1.2
 - [x] Item 2
 - [ ] Item 3
-```
-</span>
-<span id="output">
-
-- [ ] Item 1
-   - [ ] Sub item 1.1
-   - [x] Sub item 1.2
-- [x] Item 2
-- [ ] Item 3
-</span>
+</variable>
 </include>
 </span>
 
 
 ****Radio-button lists:****
 <span id="main-example-markbind">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 - ( ) Item 1
 - ( ) Item 2
 - (x) Item 3
-```
-</span>
-<span id="output">
-
-- ( ) Item 1
-- ( ) Item 2
-- (x) Item 3
-</span>
+</variable>
 </include>
 </span>
 

--- a/docs/userGuide/syntax/modals.mbdf
+++ b/docs/userGuide/syntax/modals.mbdf
@@ -2,10 +2,9 @@
 
 **Modals are to be used together with the [Trigger](#trigger) component for activation.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 More about <trigger for="modal:loremipsum">trigger</trigger>.
 <modal header="**Modal header** :rocket:" id="modal:loremipsum">
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
@@ -30,36 +29,7 @@ This is the same <trigger for="modal:loremipsum">trigger</trigger> as last one.
   consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
   Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </modal>
-
-```
-</span>
-<span id="output">
-
-  More about <trigger for="modal:loremipsum">trigger</trigger>.
-  <modal header="**Modal header** :rocket:" id="modal:loremipsum">
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  </modal>
-  <br>
-  This is the same <trigger for="modal:loremipsum">trigger</trigger> as last one.
-
-  <trigger for="modal:centered">This is a trigger for a centered modal</trigger>.
-
-  <modal header="**Centered** :rocket:" id="modal:centered" center>
-    Centered
-  </modal>
-
-  <trigger for="modal:ok-text">This is a trigger for a modal with a custom OK button</trigger>.
-
-  <modal header="OK button visible!" id="modal:ok-text" ok-text="Custom OK">
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
-    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  </modal>
-</span>
+</variable>
 </include>
 
 <panel header="More about triggers">

--- a/docs/userGuide/syntax/navBars.mbdf
+++ b/docs/userGuide/syntax/navBars.mbdf
@@ -8,10 +8,9 @@ Note: **Navbars** should be placed within a [header file]({{ baseUrl }}/userguid
   </markdown>
 </box>
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <navbar type="primary">
   <!-- Brand as slot -->
   <a slot="brand" href="/" title="Home" class="navbar-brand">MarkBind</a>
@@ -50,52 +49,7 @@ Note: **Navbars** should be placed within a [header file]({{ baseUrl }}/userguid
     <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link">Fork...</a>
   </li>
 </navbar>
-```
-
-</span>
-
-<span id="output">
-
-<navbar type="primary">
-  <!-- Brand as slot -->
-  <a slot="brand" href="/" title="Home" class="navbar-brand">MarkBind</a>
-  <!-- You can use dropdown component -->
-  <dropdown header="Dropdown" class="nav-link">
-    <li><a href="#navbar" class="dropdown-item">Option</a></li>
-  </dropdown>
-  <!-- For right positioning use slot -->
-  <li slot="right">
-    <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link">Fork...</a>
-  </li>
-</navbar>
-
-<navbar type="dark">
-  <!-- Brand as slot -->
-  <a slot="brand" href="/" title="Home" class="navbar-brand">MarkBind</a>
-  <!-- You can use dropdown component -->
-  <dropdown header="Dropdown" class="nav-link">
-    <li><a href="#navbar" class="dropdown-item">Option</a></li>
-  </dropdown>
-  <!-- For right positioning use slot -->
-  <li slot="right">
-    <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link">Fork...</a>
-  </li>
-</navbar>
-
-<navbar type="light">
-  <!-- Brand as slot -->
-  <a slot="brand" href="/" title="Home" class="navbar-brand">MarkBind</a>
-  <!-- You can use dropdown component -->
-  <dropdown header="Dropdown" class="nav-link">
-    <li><a href="#navbar" class="dropdown-item">Option</a></li>
-  </dropdown>
-  <!-- For right positioning use slot -->
-  <li slot="right">
-    <a href="https://github.com/MarkBind/markbind" target="_blank" class="nav-link">Fork...</a>
-  </li>
-</navbar>
-
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/panels.mbdf
+++ b/docs/userGuide/syntax/panels.mbdf
@@ -2,65 +2,42 @@
 
 **Panel is a flexible container that supports collapsing and expanding its content. It is expandable by default.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
-<panel header="This is your header for a Panel, click me to expand!">
-  ...
-</panel>
-```
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="This is your header for a Panel, click me to expand!">
   Lorem ipsum ...
 </panel>
-</span>
+</variable>
 </include>
 
 **With `minimized` attribute, panel is minimized into an inline block element. The `alt` attribute is for you to specify the minimized block header.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
-<panel header="How to cultivate a tomato plant at home" alt="Tomatoes" minimized>
-  ...
-</panel>
-```
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="How to cultivate a tomato plant at home" alt="Tomatoes" minimized>
   Lorem ipsum ...
 </panel>
-</span>
+</variable>
 </include>
 
 **With `expanded` attribute, you can set the panels to be expanded when loaded in.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
-<panel header="Have your readers click less to see the Panel's contents" expanded>
-```
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Have your readers click less to see the Panel's contents" expanded>
   Lorem ipsum ...
 </panel>
-</span>
+</variable>
 </include>
 
 **Panel provides many types that change its appearance.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="**light type panel (DEFAULT)**" type="light" minimized>
   ...
 </panel>
@@ -91,51 +68,15 @@
 <panel header="**minimal type panel**" type="minimal" minimized>
   ...
 </panel>
-```
-</span>
-<span id="output">
-
-<p>Click the Panels to see the expanded style.</p>
-  <panel header="**light type panel (DEFAULT)**" type="light" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**dark type panel**" type="dark" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**primary type panel**" type="primary" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**secondary type panel**" type="secondary" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**info type panel**" type="info" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**danger type panel**" type="danger" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**warning type panel**" type="warning" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**success type panel**" type="success" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**seamless type panel**" type="seamless" minimized>
-    Lorem ipsum ...
-  </panel>
-  <panel header="**minimal type panel**" type="minimal" minimized>
-    Lorem ipsum ...
-  </panel>
-</span>
+</variable>
 </include>
 
 
 **Show/Hide buttons using `no-switch` or `no-close`.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="This panel does not have a switch button" no-switch>
   ...
 </panel>
@@ -145,100 +86,56 @@
 <panel header="This panel does not have either buttons" no-close no-switch>
   ...
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="This panel does not have a switch button" no-switch>
-  ...
-</panel>
-<panel header="This panel does not have a close button" no-close>
-  ...
-</panel>
-<panel header="This panel does not have either buttons" no-close no-switch>
-  ...
-</panel>
-</span>
+</variable>
 </include>
 
 **Use markdown in the header (only inline level markdown are supported).**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="**Bold text** :rocket: ![](https://markbind.org/images/logo-lightbackground.png =x20)" type="seamless">
   ...
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="**Bold text** :rocket: ![](https://markbind.org/images/logo-lightbackground.png =x20)" type="seamless">
-  ...
-  </panel>
-</span>
+</variable>
 </include>
 
 **If `src` attribute is provided, the panel will take content from the `src` specified and add it to the Panel body.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Content loaded in from 'src'" src="extra/loadContent.html#fragment" minimized></panel>
-```
-</span>
-<span id="output">
-
-<panel header="Content loaded in from 'src'" src="extra/loadContent.html#fragment" minimized></panel>
-</span>
+</variable>
 </include>
 
 **If `popup-url` attribute is provided, a popup button will be shown. If clicked, it opens the specified url in a new window.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Try clicking on my pop-up button" popup-url="{{ baseUrl }}/userGuide/syntax/extra/loadContent.html">
   This panel has a popup.
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="Try clicking on my pop-up button" popup-url="{{ baseUrl }}/userGuide/syntax/extra/loadContent.html">
-  This panel has a popup.
-</panel>
-</span>
+</variable>
 </include>
 
 **If `preload` attribute is provided, the panel body will load the HTML when the page renders instead of after being expanded.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Right click and inspect my HTML before expanding me!" src="extra/loadContent.html#fragment" preload>
   <p>You should be able to find this text before expanding the Panel.</p>
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="Right click and inspect my HTML before expanding me!" src="extra/loadContent.html#fragment" preload>
-  <p>You should be able to find this text before expanding the Panel.</p>
-</panel>
-</span>
+</variable>
 </include>
 
 **You can nest Panels or other components within a Panel.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Parent Panel">
   <panel header="Level 1 Nested Panel">
     <panel header="Level 2 Nested Panel">
@@ -254,26 +151,7 @@
     Some Text
   </panel>
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="Parent Panel">
-  <panel header="Level 1 Nested Panel">
-    <panel header="Level 2 Nested Panel">
-      <tip-box type="success">
-        I'm a nested tip-box
-      </tip-box>
-      <panel header="Level 3 Nested Panel" type="minimal">
-        minimal-type panel
-      </panel>
-    </panel>
-  </panel>
-  <panel header="Level 1 Nested Panel" type="info">
-    Some Text
-  </panel>
-</panel>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/paragraphs.mbdf
+++ b/docs/userGuide/syntax/paragraphs.mbdf
@@ -2,22 +2,13 @@
 
 Use one or more empty lines to separate paragraphs.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 This is the first paragraph.
 
 This is another paragraph. This is the second sentence.
-```
-</span>
-<span id="output">
-
-This is the first paragraph.
-
-This is another paragraph. This is the second sentence.
-
-</span>
+</variable>
 </include>
 
 <span id="short" class="d-none">

--- a/docs/userGuide/syntax/pictures.mbdf
+++ b/docs/userGuide/syntax/pictures.mbdf
@@ -2,21 +2,13 @@
 
 **A `pic` component allows you to add captions below the image.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
-```
-</span>
-<span id="output">
-
-<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
-  MarkBind Logo
-</pic>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/popovers.mbdf
+++ b/docs/userGuide/syntax/popovers.mbdf
@@ -1,66 +1,8 @@
 ## Popovers
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
-<popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
-  <button class="btn btn-secondary">Popover on top</button>
-</popover>
-<popover effect="fade" content="Lorem ipsum dolor sit amet" placement="left">
-  <button class="btn btn-secondary">Popover on left</button>
-</popover>
-<popover effect="fade" content="Lorem ipsum dolor sit amet" placement="right">
-  <button class="btn btn-secondary">Popover on right</button>
-</popover>
-<popover effect="fade" content="Lorem ipsum dolor sit amet" placement="bottom">
-  <button class="btn btn-secondary">Popover on bottom</button>
-</popover>
-<hr>
-<h4 class="no-index">Header</h4>
-<popover effect="fade" header="Header" content="Lorem ipsum dolor sit amet" placement="top">
-  <button class="btn btn-secondary">Popover on top</button>
-</popover>
-<popover effect="fade" header="Header" content="Lorem ipsum dolor sit amet" placement="left">
-  <button class="btn btn-secondary">Popover on left</button>
-</popover>
-<popover effect="fade" header="Header" content="Lorem ipsum dolor sit amet" placement="right">
-  <button class="btn btn-secondary">Popover on right</button>
-</popover>
-<popover effect="fade" header="Header" content="Lorem ipsum dolor sit amet" placement="bottom">
-  <button class="btn btn-secondary">Popover on bottom</button>
-</popover>
-<hr />
-<h4 class="no-index">Trigger</h4>
-<p>
-  <popover effect="scale" header="Header" content="Lorem ipsum dolor sit amet" placement="top" trigger="hover">
-    <button class="btn btn-secondary">Mouseenter</button>
-  </popover>
-  <popover effect="scale" header="Header" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
-    <button class="btn btn-secondary">Click</button>
-  </popover>
-</p>
-<h4 class="no-index">Markdown</h4>
-<p>
-  <popover effect="scale" header="**Emoji header** :rocket:" content="++emoji++ content :cat:">
-    <button class="btn btn-secondary">Hover</button>
-  </popover>
-</p>
-<h4 class="no-index">Content using slot</h4>
-<popover effect="scale" header="**Emoji header** :rocket:">
-  <div slot="content">
-    This is a long content...
-  </div>
-  <button class="btn btn-secondary">Hover</button>
-</popover>
-<br />
-<br />
-<h4 class="no-index">Wrap Text</h4>
-<popover header="false" content="Nice!">What do you say</popover>
-```
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <popover effect="fade" content="Lorem ipsum dolor sit amet" placement="top">
   <button class="btn btn-secondary">Popover on top</button>
 </popover>
@@ -111,28 +53,19 @@
 <br />
 <h4 class="no-index">Wrap Text</h4>
 <popover header="false" content="Nice!">What do you say</popover>
-</span>
+</variable>
 </include>
 
 **Using trigger for Popover:**<br>
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 More about <trigger for="pop:trigger_id">trigger</trigger>.
 <popover id="pop:trigger_id" content="This popover is triggered by a trigger"></popover>
 <br>
 This is the same <trigger for="pop:trigger_id">trigger</trigger> as last one.
-```
-</span>
-<span id="output">
-
-More about <trigger for="pop:trigger_id">trigger</trigger>.
-<popover id="pop:trigger_id" content="This popover is triggered by a trigger"></popover>
-<br>
-This is the same <trigger for="pop:trigger_id">trigger</trigger> as last one.
-</span>
+</variable>
 </include>
 
 <panel header="More about triggers">

--- a/docs/userGuide/syntax/questions.mbdf
+++ b/docs/userGuide/syntax/questions.mbdf
@@ -2,10 +2,9 @@
 
 **Question component consists of a question body, a hint and an answer.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <question>
   The question body. <md>:grey_question:</md>
   <div slot="hint">
@@ -15,75 +14,41 @@
     Question answer. <md>:pencil:</md>
   </div>
 </question>
-```
-</span>
-<span id="output">
-
-<question>
-  The question body. <md>:grey_question:</md>
-  <div slot="hint">
-    Question hint. <md>:crystal_ball:</md>
-  </div>
-  <div slot="answer">
-    Question answer. <md>:pencil:</md>
-  </div>
-</question>
-</span>
+</variable>
 </include>
 
 
 **If you leave the hint and answer `<div>` blank, a default hint and answer will be provided instead.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <question>
   This question has no hint or answer.
   <div slot="hint"></div>
   <div slot="answer"></div>
 </question>
-```
-</span>
-<span id="output">
-
-<question>
-  This question has no hint or answer.
-  <div slot="hint"></div>
-  <div slot="answer"></div>
-</question>
-</span>
+</variable>
 </include>
 
 **Use the `has-input` attribute to add a text input box for users to enter their answer.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <question has-input>
   What is the distance from Earth to the Moon in kilometers? (Give your answer in 3 s.f)
   <div slot="hint">It is between 300,000 and 400,000 km</div>
   <div slot="answer">384,000 km <md>:full_moon:</md></div>
 </question>
-```
-</span>
-<span id="output">
-
-<question has-input>
-  What is the distance from Earth to the Moon in kilometers? (Give your answer in 3 s.f)
-  <div slot="hint">It is between 300,000 and 400,000 km</div>
-  <div slot="answer">384,000 km <md>:full_moon:</md></div>
-</question>
-</span>
+</variable>
 </include>
 
 **You are able to omit the hint or answer `<div>` independently, and they will not render.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <question>
   This question with an omitted hint.
   <div slot="answer">42 <md>:star:</md></div>
@@ -97,30 +62,14 @@
 <question>
   This question only has the question body.
 </question>
-```
-</span>
-<span id="output">
-
-<question>
-  This question with an omitted hint.
-  <div slot="answer">42 <md>:star:</md></div>
-</question>
-<question>
-  This question with an omitted answer.
-  <div slot="hint">The number of exponent bits in a 64-bit Floating Point. <md>:computer:</md></div>
-</question>
-<question>
-  This question only has the question body.
-</question>
-</span>
+</variable>
 </include>
 
 **Use the minimized Panel component to create and group questions inline.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Q1 :crown:" minimized>
   <question has-input>
     Who is the first king of Thailand?
@@ -134,39 +83,16 @@
     </div>
   </question>
 </panel>
-```
-</span>
-<span id="output">
-
-<panel header="Q1 :crown:" minimized>
-  <question has-input>
-    Who is the first king of Thailand?
-  </question>
-</panel>
-<panel header="Q2 :pizza:" minimized>
-  <question has-input>
-    Which country did the Hawaiian pizza originate from?
-    <div slot="hint">
-      Not Italy or Haiwaii <md>:smirk:</md>
-    </div>
-  </question>
-</panel>
-</span>
+</variable>
 </include>
 
 **Questions can also be loaded in from another file using Panel's `src` attribute.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <panel header="Questions loaded in from `quiz.md`" src="extra/quiz.md"></panel>
-```
-</span>
-<span id="output">
-
-<panel header="Questions loaded in from `quiz.md`" src="extra/quiz.md"></panel>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/tables.mbdf
+++ b/docs/userGuide/syntax/tables.mbdf
@@ -1,24 +1,14 @@
 ## Tables
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 Animal | Trainable?| Price | Remarks
 :----- | :-------: | ----: | ----
 Ants   | no        | 5     |
 Bees   | no        | 20    |
 Cats|yes|100|
-```
-</span>
-<span id="output">
-
-Animal | Trainable?| Price | Remarks
-:----- | :-------: | ----: | ----
-Ants   | no        | 5     |
-Bees   | no        | 20    |
-Cats|yes|100|
-</span>
+</variable>
 </include>
 
 * Colons (`:`) in the 2nd line are optional and they indicates whether to left/center/right-align the values in that column.

--- a/docs/userGuide/syntax/tabs.mbdf
+++ b/docs/userGuide/syntax/tabs.mbdf
@@ -1,9 +1,8 @@
 ## Tabs
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <tabs>
   <tab header="First tab">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ullamcorper ultrices lobortis.
@@ -23,30 +22,7 @@
     </tab>
   </tab-group>
 </tabs>
-```
-</span>
-<span id="output">
-
-  <tabs>
-    <tab header="First tab">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ullamcorper ultrices lobortis.
-    </tab>
-    <tab header="Disabled second tab :x:" disabled>
-    </tab>
-    <tab-group header="Third tab group :milky_way:">
-      <tab header="Stars :star:">
-        Some stuff about stars ...
-      </tab>
-      <tab header="Disabled Moon :new_moon:" disabled>
-      </tab>
-    </tab-group>
-    <tab-group header="Disabled fourth tab group" disabled>
-      <tab header="Hidden tab">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ullamcorper ultrices lobortis.
-      </tab>
-    </tab-group>
-  </tabs>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/textStyles.mbdf
+++ b/docs/userGuide/syntax/textStyles.mbdf
@@ -3,52 +3,31 @@
 Markdown text styles:
 
 <span id="main-example-markdown">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 **Bold**, _Italic_, ___Bold and Italic___, `Inline Code`
-```
-</span>
-<span id="output">
-
-**Bold**, _Italic_, ___Bold and Italic___, `Inline Code`
-
-</span>
+</variable>
 </include>
 </span>
 
 Additional syntax from GFMD:
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 ~~Strike through~~
-```
-</span>
-<span id="output">
-
-~~Strike through~~
-
-</span>
+</variable>
 </include>
 
 Syntax added by MarkBind:
 
 <span id="main-example-markbind">
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 ****Super Bold****, ++Underline++, ==Highlight==, %%Dim%%, Super^script^, Sub~script~
-```
-</span>
-<span id="output">
-
-****Super Bold****, ++Underline++, ==Highlight==, %%Dim%%, Super^script^, Sub~script~
-
-</span>
+</variable>
 </include>
 </span>
 

--- a/docs/userGuide/syntax/thumbnails.mbdf
+++ b/docs/userGuide/syntax/thumbnails.mbdf
@@ -2,10 +2,9 @@
 
 **A `thumbnail` component allows you to insert thumbnails using text, images, or icons.**
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <thumbnail circle src="../../images/deer.jpg" size="100"/>
 <thumbnail circle text=":book:" background="#dff5ff" size="100"/>
 <thumbnail circle text="___CS___" background="#333" font-color="white" size="100"/>
@@ -15,19 +14,7 @@
 <thumbnail text=":book:" background="#dff5ff" size="100"/>
 <thumbnail text="___CS___" background="#333" font-color="white" size="100"/>
 <thumbnail text=":fas-book:" font-color="darkgreen" border="3px solid darkgreen" size="100"/>
-```
-</span>#333
-<span id="output">
-<thumbnail circle src="../../images/deer.jpg" size="100"/>
-<thumbnail circle text=":book:" background="#dff5ff" size="100"/>
-<thumbnail circle text="___CS___" background="#333" font-color="white" size="100"/>
-<thumbnail circle text=":fas-book:" font-color="darkgreen" border="3px solid darkgreen" size="100"/>
-
-<thumbnail src="../../images/deer.jpg" size="100"/>
-<thumbnail text=":book:" background="#dff5ff" size="100"/>
-<thumbnail text="___CS___" background="#333" font-color="white" size="100"/>
-<thumbnail text=":fas-book:" font-color="darkgreen" border="3px solid darkgreen" size="100"/>
-</span>
+</variable>
 </include>
 
 ****Options****

--- a/docs/userGuide/syntax/tooltips.mbdf
+++ b/docs/userGuide/syntax/tooltips.mbdf
@@ -1,45 +1,8 @@
 ## Tooltips
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
-<tooltip content="Lorem ipsum dolor sit amet" placement="top">
-  <button class="btn btn-secondary">Popover on top</button>
-</tooltip>
-<tooltip content="Lorem ipsum dolor sit amet" placement="left">
-  <button class="btn btn-secondary">Popover on left</button>
-</tooltip>
-<tooltip content="Lorem ipsum dolor sit amet" placement="right">
-  <button class="btn btn-secondary">Popover on right</button>
-</tooltip>
-<tooltip content="Lorem ipsum dolor sit amet" placement="bottom">
-  <button class="btn btn-secondary">Popover on bottom</button>
-</tooltip>
-<hr />
-Trigger
-<p>
-  <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="click">
-    <button class="btn btn-secondary">Click</button>
-  </tooltip>
-  <br />
-  <br />
-  <tooltip effect="scale" content="Lorem ipsum dolor sit amet" placement="top" trigger="focus">
-    <input placeholder="Focus"></input>
-  </tooltip>
-</p>
-<h4>Markdown</h4>
-<tooltip effect="scale" content="*Hello* **World**">
-  <a href="">Hover me</a>
-</tooltip>
-<br />
-<br />
-<h4>Free Text</h4>
-<tooltip content="coupling is the degree of interdependence between software modules; a measure of how closely connected two routines or modules are; the strength of the relationships between modules."><i>coupling</i></tooltip>
-```
-</span>
-<span id="output">
-
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 <tooltip content="Lorem ipsum dolor sit amet" placement="top">
   <button class="btn btn-secondary">Popover on top</button>
 </tooltip>
@@ -73,28 +36,19 @@ Trigger
 
 **Free Text**:
 <tooltip content="coupling is the degree of interdependence between software modules; a measure of how closely connected two routines or modules are; the strength of the relationships between modules."><i>coupling</i></tooltip>
-</span>
+</variable>
 </include>
 
 **Using trigger for Tooltip:**<br>
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```html
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">html</variable>
+<variable name="code">
 More about <trigger for="tt:trigger_id">trigger</trigger>.
 <tooltip id="tt:trigger_id" content="This tooltip triggered by a trigger"></tooltip>
 <br>
 This is the same <trigger for="tt:trigger_id">trigger</trigger> as last one.
-```
-</span>
-<span id="output">
-
-More about <trigger for="tt:trigger_id">trigger</trigger>.
-<tooltip id="tt:trigger_id" content="This tooltip triggered by a trigger"></tooltip>
-<br>
-This is the same <trigger for="tt:trigger_id">trigger</trigger> as last one.
-</span>
+</variable>
 </include>
 
 <panel header="More about triggers">

--- a/docs/userGuide/tipsAndTricks.md
+++ b/docs/userGuide/tipsAndTricks.md
@@ -13,23 +13,13 @@
 
 For Markdown syntax: To display a literal character that are normally used for Markdown formatting, add a backslash (`\`) in front of the character.
 
-<include src="outputBox.md" boilerplate >
-<span id="code">
-
-```markdown
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
 \* item 1
 
-* item 1
-
-```
-</span>
-<span id="output">
-
-\* item 1
-
-* item 1
-</span>
-</include>
+* item 1 
+</variable>
 </span>
 
 <small>More info: [https://www.markdownguide.org/basic-syntax#escaping-characters](https://www.markdownguide.org/basic-syntax#escaping-characters)</small>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #1159
~~Requires #1193~~ (merged) 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Currently developers need to write the same code twice for syntax and component documentation: one for the code block in the "code" section and one to be rendered by MarkBind in the "output" section. However this duplication should have been avoided. And developers may forget to make sure that both sections are on parity with each other.

**What changes did you make? (Give an overview)**

Created a new boilerplate `codeAndOuput.md` that takes in MarkBind code assigned to the `code` variable declared in the main markdown file.
And renders two things: (1) the code block containing the code, and (2) the rendered output of the code

**Provide some example code that this change will affect:**

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**

Compare the following pages, and see if any of the examples regress or render wrongly, be it either the source code or the rendered output.

https://deploy-preview-1168--markbind-master.netlify.com/userguide/formattingcontents
https://markbind.org/userGuide/formattingContents.html

https://deploy-preview-1168--markbind-master.netlify.com/userguide/usingcomponents
https://markbind.org/userGuide/usingComponents.html


**Proposed commit message: (wrap lines at 72 characters)**
Remove duplicate code in syntax documentation

Right now, we have to type example code in our User Guides twice,
once as example syntax, and once to be rendered by Markbind.

This practice is prone to errors as we have to ensure the two code
are the same. And it makes the user documentation quite lengthy
in terms of the source md and mbdf files. 

Let's make a boilerplate that takes the example code, 
and renders it once as a code block containing the code
and once as the rendered MarkBind output of the code.
And use it in the User Guide.



<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
