### PR TITLE
Fix links in contributing.md and add code of conduct to siteNav

### DIFF
--- a/docs/_markbind/layouts/devGuide/navigation.md
+++ b/docs/_markbind/layouts/devGuide/navigation.md
@@ -5,5 +5,5 @@
 * [Developer Guide]({{baseUrl}}/devGuide/devGuide.html)
 * [Maintainer Guide]({{baseUrl}}/devGuide/maintainerGuide.html)
 * [Contributing]({{baseUrl}}/devGuide/contributing.html)
-
+  * [Code of Conduct]({{baseUrl}}/devGuide/contributing/code-of-conduct.html)
 </navigation>

--- a/docs/_markbind/navigation/devGuideSections.md
+++ b/docs/_markbind/navigation/devGuideSections.md
@@ -4,4 +4,6 @@
 
 * [Developer Guide]({{baseUrl}}/devGuide/devGuide.html)
 * [Maintainer Guide]({{baseUrl}}/devGuide/maintainerGuide.html)
+* [Contributing]({{baseUrl}}/devGuide/contributing.html)
+  * [Code of Conduct]({{baseUrl}}/devGuide/contributing/code-of-conduct.html)
 </navigation>

--- a/docs/devGuide/contributing.md
+++ b/docs/devGuide/contributing.md
@@ -14,7 +14,7 @@ This project and everyone participating in it are governed by our [Code of Condu
 
 ## Things to do before getting started
 
-Make sure you have the project set up and ready. We have guides detailing what we [expect our contributors to know]({{baseurl}}/devguide/devguide#requirement), our required [environment]({{baseurl}}/devGuide.html#environment) and our [development process]({{baseurl}}/devGuide.html#development-process).
+Make sure you have the project set up and ready. We have guides detailing what we [expect our contributors to know]({{baseUrl}}/devGuide/devGuide.html#requirement), our required [environment]({{baseUrl}}/devGuide/devGuide.html#environment) and our [development process]({{baseUrl}}/devGuide/devGuide.html#development-process).
 
 ## How to contribute
 
@@ -55,7 +55,7 @@ Unsure where to begin contributing to MarkBind?
 
 We recommend that you start off by visiting the [Getting Started](https://markbind.org/userGuide/gettingStarted.html) section in the User Guide and try out MarkBind as a user. Exploring and understanding the various features it provides.
 
-If you have not done so yet, we also recommend visiting the [Developer Guide]({{baseurl}}/devGuide/index.html) to learn about the [structure of the project]({{baseurl}}/devGuide/index.html#project-structure), how to set up the [developer environment]({{baseurl}}/devGuide/index.html#development-process), and how to run [tests]({{baseurl}}/devGuide/devGuide.html#testing).
+If you have not done so yet, we also recommend visiting the [Developer Guide]({{baseUrl}}/devGuide/index.html) to learn about the [structure of the project]({{baseUrl}}/devGuide/index.html#project-structure), how to set up the [developer environment]({{baseUrl}}/devGuide/index.html#development-process), and how to run [tests]({{baseUrl}}/devGuide/devGuide.html#testing).
 
 When you're ready, you can start by looking through these issues marked <a href="https://github.com/MarkBind/markbind/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+sort%3Acomments-desc" class="badge" style="color:white; background-color: #7057FF;">good first issue</a>.
 

--- a/docs/dg-site.json
+++ b/docs/dg-site.json
@@ -3,7 +3,7 @@
   "titlePrefix": "MarkBind",
   "pages": [
     {
-      "glob": ["**/*.mbd", "*.md", "devGuide/*.md"]
+      "glob": ["**/*.mbd", "*.md", "devGuide/*.md", "devGuide/*/*.md"]
     },
     {
       "src": "index.md",


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Documentation update
• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Preview in #1139 showed correctly, but links are broken in actual site.

**What changes did you make? (Give an overview)**

Comparing the output resolved href in the deployed site code,  
https://github.com/MarkBind/devdocs/blob/a43131f3fed86576c821e1a92696ece77b1768f3/devGuide/contributing.html#L61

I can conclude 
`{{baseUrl}}/devGuide/contributing/code-of-conduct.html` resolved correctly to 
`/devdocs/devGuide/contributing/code-of-conduct.html`

The reason why the code-of-conduct page was broken was because I forgot to configure `docs/dg-site.json`, hence it wasn't generated in the deployed site.

I incorrectly used `baseurl` instead of `baseUrl`. (This error did not show up in netifly and was not caught by anyone). Changed it accordingly. I believe that the rest of the links should now resolve correctly as well.

**Provide some example code that this change will affect:**

**Is there anything you'd like reviewers to focus on?**

**Testing instructions:**

Compare broken links in https://markbind.org/devdocs/devGuide/contributing.html, and see if the corresponding links send to the correct pages

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
Fix contributing.md links, update siteNav

Fix baseurl to baseUrl and added Code of Conduct to siteNav


<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
