### PR TITLE
Normalize inline puml line ending before hashing

### DIFF
--- a/src/util/pluginUtil.js
+++ b/src/util/pluginUtil.js
@@ -24,7 +24,9 @@ const pluginUtil = {
       return `${filePath}.png`;
     }
 
-    const hashedContent = cryptoJS.MD5(content).toString();
+    // This is to keep the hash consistent across windows / unix systems
+    const normalizedContent = content.replace(/\r\n/g, '\n');
+    const hashedContent = cryptoJS.MD5(normalizedContent).toString();
     return `${hashedContent}.png`;
   },
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

**What is the rationale for this request?**
To normalize the line endings in inline puml content used to get the file name of the puml image so that it is consistent across windows / unix systems

**What changes did you make? (Give an overview)**



<!-- Paste the example code below: -->
```js
const normalizedContent = content.replace(/\r\n/g, '\n');
const hashedContent = cryptoJS.MD5(normalizedContent).toString();
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
na

**Proposed commit message: (wrap lines at 72 characters)**
Normalize inline puml line ending before hashing
