### PR TITLE
Add SiteConfig model

### DIFF
--- a/src/SiteConfig.js
+++ b/src/SiteConfig.js
@@ -1,0 +1,89 @@
+const {
+  HEADING_INDEXING_LEVEL_DEFAULT,
+} = require('./constants');
+
+/**
+ * Represents a read only site config read from the site configuration file,
+ * with default values for unspecified properties.
+ */
+class SiteConfig {
+  /**
+   * @param siteConfigJson The raw json read from the site configuration file
+   * @param cliBaseUrl As read from the --baseUrl option
+   */
+  constructor(siteConfigJson, cliBaseUrl) {
+    /**
+     * @type {string}
+     */
+    this.baseUrl = cliBaseUrl !== undefined
+      ? cliBaseUrl
+      : (siteConfigJson.baseUrl || '');
+    /**
+     * @type {boolean}
+     */
+    this.enableSearch = siteConfigJson.enableSearch === undefined || siteConfigJson.enableSearch;
+    /**
+     * @type {string}
+     */
+    this.faviconPath = siteConfigJson.faviconPath;
+    /**
+     * @type {number}
+     */
+    this.headingIndexingLevel = siteConfigJson.headingIndexingLevel || HEADING_INDEXING_LEVEL_DEFAULT;
+    /**
+     * @type {string}
+     */
+    this.theme = siteConfigJson.theme || false;
+
+    /**
+     * @type {Array}
+     */
+    this.pages = siteConfigJson.pages || [];
+
+    /**
+     * @type {Array}
+     */
+    this.ignore = siteConfigJson.ignore || [];
+    /**
+     * @type {Array}
+     */
+    this.externalScripts = siteConfigJson.externalScripts || [];
+    /**
+     * @type {string}
+     */
+    this.titlePrefix = siteConfigJson.titlePrefix || '';
+    /**
+     * @type {boolean}
+     */
+    this.disableHtmlBeautify = siteConfigJson.disableHtmlBeautify || false;
+    /**
+     * @type {Object<string, any>}
+     */
+    this.globalOverride = siteConfigJson.globalOverride || {};
+
+    /**
+     * @type {string}
+     */
+    this.timeZone = siteConfigJson.timeZone || 'UTC';
+    /**
+     * @type {string}
+     */
+    this.locale = siteConfigJson.locale || 'en-GB';
+
+    /**
+     * @type {Array}
+     */
+    this.plugins = siteConfigJson.plugins || [];
+    /**
+     * @type {Object<string, Object<string, any>>}
+     */
+    this.pluginsContext = siteConfigJson.pluginsContext || {};
+
+    /**
+     * @type {Object<string, Object<string, any>>}
+     */
+    this.deploy = siteConfigJson.deploy || {};
+  }
+}
+
+module.exports = SiteConfig;

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -297,11 +297,17 @@ test('Site read site config for default', async () => {
   };
   fs.vol.fromJSON(json, '');
 
-  const siteConfigDefaults = { enableSearch: true };
-  const expectedSiteConfig = { ...JSON.parse(SITE_JSON_DEFAULT), ...siteConfigDefaults };
+  const expectedSiteConfigDefaults = { enableSearch: true };
+  const expectedSiteConfig = { ...JSON.parse(SITE_JSON_DEFAULT), ...expectedSiteConfigDefaults };
   const site = new Site('./', '_site');
-  await site.readSiteConfig();
-  expect(site.siteConfig).toEqual(expectedSiteConfig);
+  const siteConfig = await site.readSiteConfig();
+
+  expect(siteConfig.baseUrl).toEqual(expectedSiteConfig.baseUrl);
+  expect(siteConfig.titlePrefix).toEqual(expectedSiteConfig.titlePrefix);
+  expect(siteConfig.ignore).toEqual(expectedSiteConfig.ignore);
+  expect(siteConfig.pages).toEqual(expectedSiteConfig.pages);
+  expect(siteConfig.deploy).toEqual(expectedSiteConfig.deploy);
+  expect(siteConfig.enableSearch).toEqual(expectedSiteConfig.enableSearch);
 });
 
 test('Site read site config for custom site config', async () => {
@@ -330,8 +336,13 @@ test('Site read site config for custom site config', async () => {
   fs.vol.fromJSON(json, '');
 
   const site = new Site('./', '_site');
-  await site.readSiteConfig();
-  expect(site.siteConfig).toEqual(customSiteJson);
+  const siteConfig = await site.readSiteConfig();
+
+  expect(siteConfig.baseUrl).toEqual(customSiteJson.baseUrl);
+  expect(siteConfig.pages).toEqual(customSiteJson.pages);
+  expect(siteConfig.ignore).toEqual(customSiteJson.ignore);
+  expect(siteConfig.deploy).toEqual(customSiteJson.deploy);
+  expect(siteConfig.enableSearch).toEqual(customSiteJson.enableSearch);
 });
 
 test('Site resolves variables referencing other variables', async () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: Code maintainability

**What is the rationale for this request?**
To consolidate all default value initialisation of the site config into a new model

**What changes did you make? (Give an overview)**
- Added a new SiteConfig model
- Moved all lazy 'default value' initialisations to this model

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
- `npm run test` should pass

**Proposed commit message: (wrap lines at 72 characters)**
Add SiteConfig model

The undefined properties of the site configuration object of Site are
lazily initialised throughout site generation.
This decreases the maintainability of site configuration logic.

Let’s consolidate all such initialisation to a new SiteConfig model.

