### PR TITLE
Standardise code style and remove eslint disables

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -273,10 +273,9 @@ class Page {
       : this.title;
     // construct temporary asset object with only POSIX-style paths
     const asset = {};
-    Object.entries(this.asset)
-      .forEach(([key, value]) => {
-        asset[key] = _.isString(value) ? ensurePosix(value) : value;
-      });
+    Object.entries(this.asset).forEach(([key, value]) => {
+      asset[key] = _.isString(value) ? ensurePosix(value) : value;
+    });
     return {
       asset,
       baseUrl: this.baseUrl,
@@ -386,8 +385,7 @@ class Page {
     this.headings = {};
     this.keywords = {};
     // Collect headings and keywords
-    this.collectHeadingsAndKeywordsInContent($(`#${CONTENT_WRAPPER_ID}`)
-      .html(), null, false, []);
+    this.collectHeadingsAndKeywordsInContent($(`#${CONTENT_WRAPPER_ID}`).html(), null, false, []);
   }
 
   /**
@@ -434,10 +432,11 @@ class Page {
           const src = panel.attribs.src.split('#')[0];
           const buildInnerDir = path.dirname(this.sourcePath);
           const resultInnerDir = path.dirname(this.resultPath);
-          const includeRelativeToBuildRootDirPath
-            = this.baseUrl ? path.relative(this.baseUrl, src) : src.substring(1);
-          const includeAbsoluteToBuildRootDirPath
-            = path.resolve(this.rootPath, includeRelativeToBuildRootDirPath);
+          const includeRelativeToBuildRootDirPath = this.baseUrl
+            ? path.relative(this.baseUrl, src)
+            : src.substring(1);
+          const includeAbsoluteToBuildRootDirPath = path.resolve(this.rootPath,
+                                                                 includeRelativeToBuildRootDirPath);
           const includeRelativeToInnerDirPath
             = path.relative(buildInnerDir, includeAbsoluteToBuildRootDirPath);
           const includePath = path.resolve(resultInnerDir, includeRelativeToInnerDirPath);
@@ -449,55 +448,37 @@ class Page {
           }
           if (panel.attribs.fragment) {
             $ = cheerio.load(includeContent);
-            this.collectHeadingsAndKeywordsInContent(
-              $(`#${panel.attribs.fragment}`)
-                .html(),
-              closestHeading,
-              shouldExcludeHeadings,
-              childSourceTraversalStack);
+            this.collectHeadingsAndKeywordsInContent($(`#${panel.attribs.fragment}`).html(), closestHeading,
+                                                     shouldExcludeHeadings, childSourceTraversalStack);
           } else {
-            this.collectHeadingsAndKeywordsInContent(
-              includeContent,
-              closestHeading,
-              shouldExcludeHeadings,
-              childSourceTraversalStack);
+            this.collectHeadingsAndKeywordsInContent(includeContent, closestHeading, shouldExcludeHeadings,
+                                                     childSourceTraversalStack);
           }
         } else {
-          this.collectHeadingsAndKeywordsInContent(
-            $(panel)
-              .html(),
-            closestHeading,
-            shouldExcludeHeadings,
-            sourceTraversalStack);
+          this.collectHeadingsAndKeywordsInContent($(panel).html(), closestHeading,
+                                                   shouldExcludeHeadings, sourceTraversalStack);
         }
       });
     $ = cheerio.load(content);
     if (this.headingIndexingLevel > 0) {
-      $('modal')
-        .remove();
-      $('panel')
-        .remove();
+      $('modal').remove();
+      $('panel').remove();
       if (!excludeHeadings) {
-        $(headingsSelector)
-          .each((i, heading) => {
-            this.headings[$(heading)
-              .attr('id')] = $(heading)
-              .text();
-          });
-      }
-      $('.keyword')
-        .each((i, keyword) => {
-          let closestHeading = Page.getClosestHeading($, headingsSelector, keyword);
-          if (excludeHeadings || !closestHeading) {
-            if (!lastHeading) {
-              logger.warn(`Missing heading for keyword: ${$(keyword)
-                .text()}`);
-              return;
-            }
-            closestHeading = lastHeading;
-          }
-          this.linkKeywordToHeading($, keyword, closestHeading);
+        $(headingsSelector).each((i, heading) => {
+          this.headings[$(heading).attr('id')] = $(heading).text();
         });
+      }
+      $('.keyword').each((i, keyword) => {
+        let closestHeading = Page.getClosestHeading($, headingsSelector, keyword);
+        if (excludeHeadings || !closestHeading) {
+          if (!lastHeading) {
+            logger.warn(`Missing heading for keyword: ${$(keyword).text()}`);
+            return;
+          }
+          closestHeading = lastHeading;
+        }
+        this.linkKeywordToHeading($, keyword, closestHeading);
+      });
     }
   }
 
@@ -508,13 +489,11 @@ class Page {
    * @param heading to link
    */
   linkKeywordToHeading($, keyword, heading) {
-    const headingId = $(heading)
-      .attr('id');
+    const headingId = $(heading).attr('id');
     if (!(headingId in this.keywords)) {
       this.keywords[headingId] = [];
     }
-    this.keywords[headingId].push($(keyword)
-      .text());
+    this.keywords[headingId].push($(keyword).text());
   }
 
   /**
@@ -532,8 +511,7 @@ class Page {
   collectFrontMatter(includedPage) {
     const $ = cheerio.load(includedPage);
     const frontMatter = $('frontmatter');
-    if (frontMatter.text()
-      .trim()) {
+    if (frontMatter.text().trim()) {
       // Retrieves the front matter from either the first frontmatter element
       // or from a frontmatter element that includes from another file
       // The latter case will result in the data being wrapped in a div
@@ -598,8 +576,7 @@ class Page {
     const layoutFileConfig = {
       ...fileConfig,
       cwf: layoutPagePath,
-      additionalVariables: {
-      },
+      additionalVariables: {},
     };
 
     layoutFileConfig.additionalVariables[LAYOUT_PAGE_BODY_VARIABLE] = `{{${LAYOUT_PAGE_BODY_VARIABLE}}}`;
@@ -724,21 +701,14 @@ class Page {
     if (siteNavDataSelector('navigation').length > 1) {
       throw new Error(`More than one <navigation> tag found in ${siteNavPath}`);
     } else if (siteNavDataSelector('navigation').length === 1) {
-      const siteNavHtml
-        = md.render(siteNavDataSelector('navigation')
-          .html()
-          .trim()
-          .replace(/\n\s*\n/g, '\n'));
+      const siteNavHtml = md.render(
+        siteNavDataSelector('navigation').html().trim().replace(/\n\s*\n/g, '\n'));
       // Add Bootstrap padding class to rendered unordered list
       const siteNavHtmlSelector = cheerio.load(siteNavHtml, { xmlMode: false });
-      siteNavHtmlSelector('ul')
-        .first()
-        .addClass('px-0');
-      siteNavHtmlSelector('ul ul')
-        .addClass('pl-3');
+      siteNavHtmlSelector('ul').first().addClass('px-0');
+      siteNavHtmlSelector('ul ul').addClass('pl-3');
       const formattedSiteNav = Page.formatSiteNav(siteNavHtmlSelector.html(), this.src);
-      siteNavDataSelector('navigation')
-        .replaceWith(formattedSiteNav);
+      siteNavDataSelector('navigation').replaceWith(formattedSiteNav);
     }
     // Wrap sections
     const wrappedSiteNav = `<nav id="${SITE_NAV_ID}" class="navbar navbar-light bg-transparent">\n`
@@ -758,42 +728,41 @@ class Page {
   generatePageNavHeadingHtml() {
     let headingHTML = '';
     const headingStack = [];
-    Object.keys(this.navigableHeadings)
-      .forEach((key) => {
-        const currentHeadingLevel = this.navigableHeadings[key].level;
-        const currentHeadingHTML = `<a class="nav-link py-1" href="#${key}">`
-          + `${this.navigableHeadings[key].text}&#x200E;</a>\n`;
-        const nestedHeadingHTML = '<nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">\n'
-          + `${currentHeadingHTML}`;
-        if (headingStack.length === 0 || headingStack[headingStack.length - 1] === currentHeadingLevel) {
-          // Add heading without nesting, into headingHTML
-          headingHTML += currentHeadingHTML;
+    Object.keys(this.navigableHeadings).forEach((key) => {
+      const currentHeadingLevel = this.navigableHeadings[key].level;
+      const currentHeadingHTML = `<a class="nav-link py-1" href="#${key}">`
+        + `${this.navigableHeadings[key].text}&#x200E;</a>\n`;
+      const nestedHeadingHTML = '<nav class="nav nav-pills flex-column my-0 nested no-flex-wrap">\n'
+        + `${currentHeadingHTML}`;
+      if (headingStack.length === 0 || headingStack[headingStack.length - 1] === currentHeadingLevel) {
+        // Add heading without nesting, into headingHTML
+        headingHTML += currentHeadingHTML;
+      } else {
+        // Stack has at least 1 other heading level
+        let topOfHeadingStack = headingStack[headingStack.length - 1];
+        if (topOfHeadingStack < currentHeadingLevel) {
+          // Increase nesting level by 1
+          headingHTML += nestedHeadingHTML;
         } else {
-          // Stack has at least 1 other heading level
-          let topOfHeadingStack = headingStack[headingStack.length - 1];
+          // Close any nested list with heading level higher than current
+          while (headingStack.length > 1 && topOfHeadingStack > currentHeadingLevel) {
+            headingHTML += '</nav>\n';
+            headingStack.pop();
+            topOfHeadingStack = headingStack[headingStack.length - 1];
+          }
           if (topOfHeadingStack < currentHeadingLevel) {
             // Increase nesting level by 1
             headingHTML += nestedHeadingHTML;
           } else {
-            // Close any nested list with heading level higher than current
-            while (headingStack.length > 1 && topOfHeadingStack > currentHeadingLevel) {
-              headingHTML += '</nav>\n';
-              headingStack.pop();
-              topOfHeadingStack = headingStack[headingStack.length - 1];
-            }
-            if (topOfHeadingStack < currentHeadingLevel) {
-              // Increase nesting level by 1
-              headingHTML += nestedHeadingHTML;
-            } else {
-              headingHTML += currentHeadingHTML;
-            }
+            headingHTML += currentHeadingHTML;
           }
         }
-        // Update heading level stack
-        if (headingStack.length === 0 || headingStack[headingStack.length - 1] !== currentHeadingLevel) {
-          headingStack.push(currentHeadingLevel);
-        }
-      });
+      }
+      // Update heading level stack
+      if (headingStack.length === 0 || headingStack[headingStack.length - 1] !== currentHeadingLevel) {
+        headingStack.push(currentHeadingLevel);
+      }
+    });
     // Ensure proper closing for any nested lists towards the end
     while (headingStack.length > 1
     && headingStack[headingStack.length - 1] > headingStack[headingStack.length - 2]) {
@@ -810,9 +779,7 @@ class Page {
   generatePageNavTitleHtml() {
     const { pageNavTitle } = this.frontMatter;
     return pageNavTitle
-      ? `<a class="navbar-brand ${PAGE_NAV_TITLE_CLASS}" href="#">`
-      + `${pageNavTitle.toString()}`
-      + '</a>'
+      ? `<a class="navbar-brand ${PAGE_NAV_TITLE_CLASS}" href="#">${pageNavTitle.toString()}</a>`
       : '';
   }
 
@@ -823,8 +790,7 @@ class Page {
     if (this.isPageNavigationSpecifierValid()) {
       const $ = cheerio.load(this.content, { xmlMode: false });
       this.navigableHeadings = {};
-      this.collectNavigableHeadings($(`#${CONTENT_WRAPPER_ID}`)
-        .html());
+      this.collectNavigableHeadings($(`#${CONTENT_WRAPPER_ID}`).html());
       const pageNavTitleHtml = this.generatePageNavTitleHtml();
       const pageNavHeadingHTML = this.generatePageNavHeadingHtml();
       this.pageSectionsHtml[`#${PAGE_NAV_ID}`]
@@ -851,9 +817,7 @@ class Page {
     const collectedTopContent = [];
     const collectedBottomContent = [];
     if (head) {
-      headFiles = head.replace(/, */g, ',')
-        .split(',')
-        .map(headFile => path.join(HEAD_FOLDER_PATH, headFile));
+      headFiles = head.replace(/, */g, ',').split(',').map(headFile => path.join(HEAD_FOLDER_PATH, headFile));
     } else {
       headFiles = [path.join(LAYOUT_FOLDER_PATH, this.frontMatter.layout, LAYOUT_HEAD)];
     }
@@ -873,24 +837,16 @@ class Page {
       // Split top and bottom contents
       const $ = cheerio.load(headFileMappedData, { xmlMode: false });
       if ($('head-top').length) {
-        collectedTopContent.push(njUtil.renderRaw($('head-top')
-          .html(), {
+        collectedTopContent.push(njUtil.renderRaw($('head-top').html(), {
           baseUrl,
           hostBaseUrl,
-        })
-          .trim()
-          .replace(/\n\s*\n/g, '\n')
-          .replace(/\n/g, '\n    '));
-        $('head-top')
-          .remove();
+        }).trim().replace(/\n\s*\n/g, '\n').replace(/\n/g, '\n    '));
+        $('head-top').remove();
       }
       collectedBottomContent.push(njUtil.renderRaw($.html(), {
         baseUrl,
         hostBaseUrl,
-      })
-        .trim()
-        .replace(/\n\s*\n/g, '\n')
-        .replace(/\n/g, '\n    '));
+      }).trim().replace(/\n\s*\n/g, '\n').replace(/\n/g, '\n    '));
     });
     this.headFileTopContent = collectedTopContent.join('\n    ');
     this.headFileBottomContent = collectedBottomContent.join('\n    ');
@@ -899,23 +855,16 @@ class Page {
   static insertTemporaryStyles(pageData) {
     const $ = cheerio.load(pageData);
     // inject temporary navbar styles
-    $('navbar')
-      .addClass(TEMP_NAVBAR_CLASS);
+    $('navbar').addClass(TEMP_NAVBAR_CLASS);
     // inject temporary dropdown styles
-    $('dropdown')
-      .each((i, element) => {
-        const attributes = element.attribs;
-        // TODO remove attributes.text once text attribute is fully deprecated
-        const placeholder = `<div>${attributes.header || attributes.text || ''}</div>`;
-        $(element)
-          .before(placeholder);
-        $(element)
-          .prev()
-          .addClass(attributes.class)
-          .addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
-        $(element)
-          .addClass(TEMP_DROPDOWN_CLASS);
-      });
+    $('dropdown').each((i, element) => {
+      const attributes = element.attribs;
+      // TODO remove attributes.text once text attribute is fully deprecated
+      const placeholder = `<div>${attributes.header || attributes.text || ''}</div>`;
+      $(element).before(placeholder);
+      $(element).prev().addClass(attributes.class).addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
+      $(element).addClass(TEMP_DROPDOWN_CLASS);
+    });
     return $.html();
   }
 
@@ -1011,12 +960,11 @@ class Page {
         })
         .then(() => {
           const resolvingFiles = [];
-          Page.unique(markbinder.getDynamicIncludeSrc())
-            .forEach((source) => {
-              if (!FsUtil.isUrl(source.to)) {
-                resolvingFiles.push(this.resolveDependency(source, builtFiles));
-              }
-            });
+          Page.unique(markbinder.getDynamicIncludeSrc()).forEach((source) => {
+            if (!FsUtil.isUrl(source.to)) {
+              resolvingFiles.push(this.resolveDependency(source, builtFiles));
+            }
+          });
           return Promise.all(resolvingFiles);
         })
         .then(() => {
@@ -1147,14 +1095,12 @@ class Page {
    */
   preRender(content) {
     let preRenderedContent = content;
-    Object.entries(this.plugins)
-      .forEach(([pluginName, plugin]) => {
-        if (plugin.preRender) {
-          preRenderedContent
-            = plugin.preRender(preRenderedContent, this.pluginsContext[pluginName] || {},
-                               this.frontMatter, this.getPluginConfig());
-        }
-      });
+    Object.entries(this.plugins).forEach(([pluginName, plugin]) => {
+      if (plugin.preRender) {
+        preRenderedContent = plugin.preRender(preRenderedContent, this.pluginsContext[pluginName] || {},
+                                              this.frontMatter, this.getPluginConfig());
+      }
+    });
     return preRenderedContent;
   }
 
@@ -1163,15 +1109,12 @@ class Page {
    */
   postRender(content) {
     let postRenderedContent = content;
-    Object.entries(this.plugins)
-      .forEach(([pluginName, plugin]) => {
-        if (plugin.postRender) {
-          postRenderedContent
-            = plugin.postRender(
-              postRenderedContent,
-              this.pluginsContext[pluginName] || {}, this.frontMatter, this.getPluginConfig());
-        }
-      });
+    Object.entries(this.plugins).forEach(([pluginName, plugin]) => {
+      if (plugin.postRender) {
+        postRenderedContent = plugin.postRender(postRenderedContent, this.pluginsContext[pluginName] || {},
+                                                this.frontMatter, this.getPluginConfig());
+      }
+    });
     return postRenderedContent;
   }
 
@@ -1187,19 +1130,18 @@ class Page {
     const scriptUtils = {
       buildScript: src => `<script src="${src}"></script>`,
     };
-    Object.entries(this.plugins)
-      .forEach(([pluginName, plugin]) => {
-        if (plugin.getLinks) {
-          const pluginLinks
-            = plugin.getLinks(content, this.pluginsContext[pluginName], this.frontMatter, linkUtils);
-          links = links.concat(pluginLinks);
-        }
-        if (plugin.getScripts) {
-          const pluginScripts
-            = plugin.getScripts(content, this.pluginsContext[pluginName], this.frontMatter, scriptUtils);
-          scripts = scripts.concat(pluginScripts);
-        }
-      });
+    Object.entries(this.plugins).forEach(([pluginName, plugin]) => {
+      if (plugin.getLinks) {
+        const pluginLinks = plugin.getLinks(content, this.pluginsContext[pluginName],
+                                            this.frontMatter, linkUtils);
+        links = links.concat(pluginLinks);
+      }
+      if (plugin.getScripts) {
+        const pluginScripts = plugin.getScripts(content, this.pluginsContext[pluginName],
+                                                this.frontMatter, scriptUtils);
+        scripts = scripts.concat(pluginScripts);
+      }
+    });
     this.asset.pluginLinks = links;
     this.asset.pluginScripts = scripts;
     return content;
@@ -1240,8 +1182,7 @@ class Page {
         userDefinedVariablesMap: this.userDefinedVariablesMap,
         rootPath: this.rootPath,
         cwf: file,
-      })
-        .then(result => Page.removeFrontMatter(result))
+      }).then(result => Page.removeFrontMatter(result))
         .then(result => this.collectPluginSources(result))
         .then(result => this.preRender(result))
         .then(result => markbinder.resolveBaseUrl(result, {
@@ -1275,12 +1216,11 @@ class Page {
         .then(() => {
           // Recursion call to resolve nested dependency
           const resolvingFiles = [];
-          Page.unique(markbinder.getDynamicIncludeSrc())
-            .forEach((src) => {
-              if (!FsUtil.isUrl(src.to)) {
-                resolvingFiles.push(this.resolveDependency(src, builtFiles));
-              }
-            });
+          Page.unique(markbinder.getDynamicIncludeSrc()).forEach((src) => {
+            if (!FsUtil.isUrl(src.to)) {
+              resolvingFiles.push(this.resolveDependency(src, builtFiles));
+            }
+          });
           return Promise.all(resolvingFiles);
         })
         .then(() => {
@@ -1296,11 +1236,8 @@ class Page {
 
   static addContentWrapper(pageData) {
     const $ = cheerio.load(pageData);
-    $(`#${CONTENT_WRAPPER_ID}`)
-      .removeAttr('id');
-    return `<div id="${CONTENT_WRAPPER_ID}">\n\n`
-      + `${$.html()}\n`
-      + '</div>';
+    $(`#${CONTENT_WRAPPER_ID}`).removeAttr('id');
+    return `<div id="${CONTENT_WRAPPER_ID}">\n\n${$.html()}\n</div>`;
   }
 
   static removePageHeaderAndFooter(pageData) {
@@ -1316,84 +1253,61 @@ class Page {
 
   static formatSiteNav(renderedSiteNav, src) {
     const $ = cheerio.load(renderedSiteNav);
-    const listItems = $.root()
-      .find('ul')
-      .first()
-      .children();
+    const listItems = $.root().find('ul').first().children();
     if (listItems.length === 0) {
       return renderedSiteNav;
     }
     // Tidy up the style of the unordered list <ul>
-    listItems.parent()
-      .addClass(`${SITE_NAV_LIST_CLASS}`);
+    listItems.parent().addClass(`${SITE_NAV_LIST_CLASS}`);
 
     // Set class of <a> to ${SITE_NAV_ID}__a to style links
-    listItems.find('a[href]')
-      .addClass(`${SITE_NAV_ID}__a`);
+    listItems.find('a[href]').addClass(`${SITE_NAV_ID}__a`);
 
     // Highlight current page
     const currentPageHtmlPath = src.replace(/\.(md|mbd)$/, '.html');
-    listItems.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`)
-      .addClass('current');
+    listItems.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`).addClass('current');
 
     listItems.each(function () {
       // Tidy up the style of each list item
-      $(this)
-        .addClass('mt-2');
+      $(this).addClass('mt-2');
       // Do not render dropdown menu for list items with <a> tag
-      if ($(this)
-        .children('a').length) {
-        const nestedList = $(this)
-          .children('ul')
-          .first();
+      if ($(this).children('a').length) {
+        const nestedList = $(this).children('ul').first();
         if (nestedList.length) {
           // Double wrap to counter replaceWith removing <li>
           nestedList.parent()
             .wrap('<li class="mt-2"></li>');
           // Recursively format nested lists without dropdown wrapper
-          nestedList.parent()
-            .replaceWith(Page.formatSiteNav(nestedList.parent()
-              .html(), src));
+          nestedList.parent().replaceWith(Page.formatSiteNav(nestedList.parent().html(), src));
         }
         // Found nested list, render dropdown menu
-      } else if ($(this)
-        .children('ul').length) {
-        const nestedList = $(this)
-          .children('ul')
-          .first();
-        const dropdownTitle = $(this)
-          .contents()
-          .not('ul');
+      } else if ($(this).children('ul').length) {
+        const nestedList = $(this).children('ul').first();
+        const dropdownTitle = $(this).contents().not('ul');
         // Replace the title with the dropdown wrapper
         dropdownTitle.remove();
         // Check if dropdown is expanded by default or if the current page is in a dropdown
-        const shouldExpandDropdown = dropdownTitle.toString()
-          .includes(DROPDOWN_EXPAND_KEYWORD)
-          || Boolean(nestedList.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`)
-            .text());
+        const shouldExpandDropdown = dropdownTitle.toString().includes(DROPDOWN_EXPAND_KEYWORD)
+          || Boolean(nestedList.find(`a[href='{{baseUrl}}/${currentPageHtmlPath}']`).text());
         if (shouldExpandDropdown) {
           const expandKeywordRegex = new RegExp(DROPDOWN_EXPAND_KEYWORD, 'g');
-          const dropdownTitleWithoutKeyword = dropdownTitle.toString()
-            .replace(expandKeywordRegex, '');
+          const dropdownTitleWithoutKeyword = dropdownTitle.toString().replace(expandKeywordRegex, '');
           const rotatedIcon = cheerio.load(DROPDOWN_BUTTON_ICON_HTML, { xmlMode: false })('i')
             .addClass('rotate-icon');
           nestedList.wrap('<div class="dropdown-container dropdown-container-open"></div>');
-          $(this)
-            .prepend('<button class="dropdown-btn dropdown-btn-open">'
-              + `${dropdownTitleWithoutKeyword} `
-              + `${rotatedIcon}\n`
-              + '</button>');
+          $(this).prepend('<button class="dropdown-btn dropdown-btn-open">'
+            + `${dropdownTitleWithoutKeyword} `
+            + `${rotatedIcon}\n`
+            + '</button>');
         } else {
           nestedList.wrap('<div class="dropdown-container"></div>');
-          $(this)
-            .prepend('<button class="dropdown-btn">'
-              + `${dropdownTitle} `
-              + `${DROPDOWN_BUTTON_ICON_HTML}\n`
-              + '</button>');
+          $(this).prepend('<button class="dropdown-btn">'
+            + `${dropdownTitle} `
+            + `${DROPDOWN_BUTTON_ICON_HTML}\n`
+            + '</button>');
         }
         // Recursively format nested lists
-        nestedList.replaceWith(Page.formatSiteNav(nestedList.parent()
-          .html(), src));
+        nestedList.replaceWith(Page.formatSiteNav(nestedList.parent().html(), src));
       }
     });
     return $.html();
@@ -1424,8 +1338,7 @@ class Page {
    * @param element to find closest heading
    */
   static getClosestHeading($, headingsSelector, element) {
-    const prevElements = $(element)
-      .prevAll();
+    const prevElements = $(element).prevAll();
     for (let i = 0; i < prevElements.length; i += 1) {
       const currentElement = $(prevElements[i]);
       if (currentElement.is(headingsSelector)) {
@@ -1436,12 +1349,10 @@ class Page {
         return childHeadings.last();
       }
     }
-    if ($(element)
-      .parent().length === 0) {
+    if ($(element).parent().length === 0) {
       return null;
     }
-    return Page.getClosestHeading($, headingsSelector, $(element)
-      .parent());
+    return Page.getClosestHeading($, headingsSelector, $(element).parent());
   }
 }
 

--- a/src/Site.js
+++ b/src/Site.js
@@ -296,8 +296,8 @@ class Site {
         siteNavCss: path.relative(path.dirname(resultPath),
                                   path.join(this.siteAssetsDestPath, 'css', 'site-nav.css')),
         bootstrapUtilityJs: path.relative(path.dirname(resultPath),
-                                          path.join(this.siteAssetsDestPath,
-                                                    'js', 'bootstrap-utility.min.js')),
+                                          path.join(this.siteAssetsDestPath, 'js',
+                                                    'bootstrap-utility.min.js')),
         bootstrapVueJs: path.relative(path.dirname(resultPath),
                                       path.join(this.siteAssetsDestPath, 'js', 'bootstrap-vue.min.js')),
         polyfillJs: path.relative(path.dirname(resultPath),
@@ -508,10 +508,9 @@ class Site {
    * @returns {*}
    */
   collectBaseUrl() {
-    const candidates
-      = walkSync(this.rootPath, { directories: false })
-        .filter(x => x.endsWith(this.siteConfigPath))
-        .map(x => path.resolve(this.rootPath, x));
+    const candidates = walkSync(this.rootPath, { directories: false })
+      .filter(x => x.endsWith(this.siteConfigPath))
+      .map(x => path.resolve(this.rootPath, x));
 
     this.baseUrlMap = new Set(candidates.map(candidate => path.dirname(candidate)));
 
@@ -915,10 +914,9 @@ class Site {
       .forEach(plugin => this.loadPlugin(plugin, false));
 
     const markbindPrefixRegex = new RegExp(`^${MARKBIND_PLUGIN_PREFIX}`);
-    defaultPlugins
-      .filter(plugin => !_.get(this.siteConfig,
-                               ['pluginsContext', plugin.replace(markbindPrefixRegex, ''), 'off'],
-                               false))
+    defaultPlugins.filter(plugin => !_.get(this.siteConfig,
+                                           ['pluginsContext', plugin.replace(markbindPrefixRegex, ''), 'off'],
+                                           false))
       .forEach(plugin => this.loadPlugin(plugin, true));
   }
 
@@ -965,14 +963,13 @@ class Site {
         return;
       }
 
-      plugin.getSpecialTags(plugin.pluginsContext)
-        .forEach((tagName) => {
-          if (!tagName) {
-            return;
-          }
+      plugin.getSpecialTags(plugin.pluginsContext).forEach((tagName) => {
+        if (!tagName) {
+          return;
+        }
 
-          tagsToIgnore.add(tagName.toLowerCase());
-        });
+        tagsToIgnore.add(tagName.toLowerCase());
+      });
     });
 
     injectHtmlParser2SpecialTags(tagsToIgnore);
@@ -1063,7 +1060,6 @@ class Site {
           }
         }
 
-        // eslint-disable-next-line no-param-reassign
         page.userDefinedVariablesMap = this.userDefinedVariablesMap;
         processingFiles.push(page.generate(builtFiles)
           .catch((err) => {
@@ -1226,8 +1222,8 @@ class Site {
           this.siteConfig.deploy = this.siteConfig.deploy || {};
           const basePath = this.siteConfig.deploy.baseDir || this.outputPath;
           if (!fs.existsSync(basePath)) {
-            reject(
-              new Error('The site directory does not exist. Please build the site first before deploy.'));
+            reject(new Error(
+              'The site directory does not exist. Please build the site first before deploy.'));
             return undefined;
           }
           const options = {};
@@ -1303,28 +1299,24 @@ class Site {
  */
 Site.prototype.buildAsset = delay(Site.prototype._buildMultipleAssets, 1000);
 
-Site.prototype.rebuildPageBeingViewed
-  = delay(Site.prototype._rebuildPageBeingViewed, 1000);
+Site.prototype.rebuildPageBeingViewed = delay(Site.prototype._rebuildPageBeingViewed, 1000);
 
 /**
  * Rebuild pages that are affected by changes in filePaths
  * @param filePaths a single path or an array of paths corresponding to the files that have changed
  */
-Site.prototype.rebuildAffectedSourceFiles
-  = delay(Site.prototype._rebuildAffectedSourceFiles, 1000);
+Site.prototype.rebuildAffectedSourceFiles = delay(Site.prototype._rebuildAffectedSourceFiles, 1000);
 
 /**
  * Rebuild all pages
  * @param filePaths a single path or an array of paths corresponding to the files that have changed
  */
-Site.prototype.rebuildSourceFiles
-  = delay(Site.prototype._rebuildSourceFiles, 1000);
+Site.prototype.rebuildSourceFiles = delay(Site.prototype._rebuildSourceFiles, 1000);
 
 /**
  * Remove assets that are specified in filePaths
  * @param filePaths a single path or an array of paths corresponding to the assets to remove
  */
-Site.prototype.removeAsset
-  = delay(Site.prototype._removeMultipleAssets, 1000);
+Site.prototype.removeAsset = delay(Site.prototype._removeMultipleAssets, 1000);
 
 module.exports = Site;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain:


**What is the rationale for this request?**
- Fix 'style regressions' from #979, and standardise some other ones
- Remove some leftover `eslint-disable-xx`'s

**What changes did you make? (Give an overview)**

Example of style regression fixed
```js
$('modal')	     
  .remove();	     
$('panel')	
  .remove();

// to
$('modal').remove();
$('panel').remove();
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
na

**Proposed commit message: (wrap lines at 72 characters)**
Standardise code style and remove eslint disables