### PR TITLE
Reorganise variable processing

### DIFF
--- a/src/Site.js
+++ b/src/Site.js
@@ -688,7 +688,6 @@ class Site {
     const filePathArray = Array.isArray(filePaths) ? filePaths : [filePaths];
     const uniquePaths = _.uniq(filePathArray);
     logger.info('Rebuilding affected source files');
-    this.variablePreprocessor.resetVariables();
     return new Promise((resolve, reject) => {
       this.regenerateAffectedPages(uniquePaths)
         .then(() => fs.removeAsync(this.tempPath))
@@ -706,7 +705,6 @@ class Site {
     const uniqueUrls = _.uniq(normalizedUrlArray);
     uniqueUrls.forEach(normalizedUrl => logger.info(
       `Building ${normalizedUrl} as some of its dependencies were changed since the last visit`));
-    this.variablePreprocessor.resetVariables();
 
     /*
      Lazy loading only builds the page being viewed, but the user may be quick enough

--- a/src/lib/markbind/src/constants.js
+++ b/src/lib/markbind/src/constants.js
@@ -5,11 +5,6 @@ module.exports = {
 
   BOILERPLATE_FOLDER_NAME: '_markbind/boilerplates',
 
-  /* Imported global variables will be assigned a namespace.
-   * A prefix is appended to reduce clashes with other variables in the page.
-   */
-  IMPORTED_VARIABLE_PREFIX: '$__MARKBIND__',
-
   // src/lib/markbind/src/utils.js
   markdownFileExts: ['md', 'mbd', 'mbdf'],
 };

--- a/src/lib/markbind/src/parser.js
+++ b/src/lib/markbind/src/parser.js
@@ -235,21 +235,15 @@ class Parser {
         decodeEntities: true,
       });
 
-      const outerContentRendered = this.variablePreprocessor.renderOuterVariables(content, file,
-                                                                                  additionalVariables);
-      this.variablePreprocessor.extractInnerVariables(outerContentRendered, context.cwf)
-        .forEach(src => this.staticIncludeSrc.push(src));
-      const innerContentRendered = this.variablePreprocessor.renderInnerVariables(outerContentRendered,
-                                                                                  file, context.cwf,
-                                                                                  additionalVariables);
+      const renderedContent = this.variablePreprocessor.renderPage(file, content, additionalVariables);
 
       const fileExt = utils.getExt(file);
       if (utils.isMarkdownFileExt(fileExt)) {
         context.source = 'md';
-        parser.parseComplete(innerContentRendered.toString());
+        parser.parseComplete(renderedContent.toString());
       } else if (fileExt === 'html') {
         context.source = 'html';
-        parser.parseComplete(innerContentRendered);
+        parser.parseComplete(renderedContent);
       } else {
         const error = new Error(`Unsupported File Extension: '${fileExt}'`);
         reject(error);

--- a/src/lib/markbind/src/preprocessors/componentPreprocessor.js
+++ b/src/lib/markbind/src/preprocessors/componentPreprocessor.js
@@ -244,9 +244,7 @@ function _preprocessInclude(node, context, config, parser) {
   const {
     renderedContent,
     childContext,
-    includedSrces,
   } = variablePreprocessor.renderIncludeFile(actualFilePath, element, context, filePath);
-  includedSrces.forEach(src => parser.staticIncludeSrc.push(src));
 
   _deleteIncludeAttributes(element);
 
@@ -317,6 +315,16 @@ function _preprocessVariables() {
   return utils.createEmptyNode();
 }
 
+function _preprocessImports(node, parser) {
+  if (node.attribs.from) {
+    parser.staticIncludeSrc.push({
+      from: node.attribs.cwf,
+      to: path.resolve(node.attribs.cwf, node.attribs.from),
+    });
+  }
+
+  return utils.createEmptyNode();
+}
 
 /*
  * Body
@@ -343,8 +351,9 @@ function preProcessComponent(node, context, config, parser) {
   case 'panel':
     return _preProcessPanel(element, context, config, parser);
   case 'variable':
-  case 'import':
     return _preprocessVariables();
+  case 'import':
+    return _preprocessImports(node, parser);
   case 'include':
     return _preprocessInclude(element, context, config, parser);
   case 'body':

--- a/src/lib/markbind/src/preprocessors/variablePreprocessor.js
+++ b/src/lib/markbind/src/preprocessors/variablePreprocessor.js
@@ -1,0 +1,496 @@
+const cheerio = require('cheerio');
+const fs = require('fs');
+const path = require('path');
+
+const _ = {};
+_.clone = require('lodash/clone');
+_.cloneDeep = require('lodash/cloneDeep');
+_.has = require('lodash/has');
+_.isArray = require('lodash/isArray');
+_.isEmpty = require('lodash/isEmpty');
+
+const md = require('../lib/markdown-it');
+const njUtil = require('../utils/nunjuckUtils');
+const urlUtils = require('../utils/urls');
+const logger = require('../../../../util/logger');
+
+const {
+  ATTRIB_CWF,
+  IMPORTED_VARIABLE_PREFIX,
+} = require('../constants');
+
+
+/**
+ * All variable extraction and rendering is done here.
+ *
+ * There are four broad categories of methods here
+ * 1. Site level variable extraction and storage methods
+ *    These methods provide interfaces to store a particular (sub)site's variables,
+ *    rendering them with the same (sub)site's previously extracted variables
+ *    before doing so in {@link userDefinedVariablesMap}.
+ *
+ * 2. Site level variable rendering methods
+ *    These methods use the processed variables in {@link userDefinedVariablesMap}
+ *    to render provided string content that belongs to a provided content file path.
+ *    Using the content file path, we are able to get the appropriate (sub)site's (that
+ *    the content belongs to) variables and then render them with it.
+ *
+ * 3. Page level variable extraction and storage methods
+ *    These methods are similar to (1), but extract variables from a page,
+ *    declared by <variable>s or <import>s.
+ *    There are also some utility methods here facilitating extraction of <variable>s
+ *    the are nested within an <include> element, and inline variables ('var-xx') declared
+ *    as attributes in the <include> itself.
+ *
+ * 4. Combined page and site variable rendering methods
+ *    These methods are similar to (2), but in addition to the site variables, they
+ *    render the content with the page variables extracted from (3) as well.
+ */
+class VariablePreprocessor {
+  constructor(rootPath, baseUrlMap) {
+    /**
+     * Root site path
+     * @type {string}
+     */
+    this.rootPath = rootPath;
+
+    /**
+     * Set of sites' root paths, for resolving the provided file path in
+     * rendering methods to the appropriate (sub)site's root path.
+     * @type {Set<string>}
+     */
+    this.baseUrlMap = baseUrlMap;
+
+    /**
+     * Map of sites' root paths to their variables
+     * @type {Object<string, Object<string, any>>}
+     */
+    this.userDefinedVariablesMap = {};
+
+    /*
+     * Page level
+     */
+
+    /**
+     * Map of file paths to another object containing its variable names matched to values
+     * @type {Object<string, Object<string, string>>}
+     */
+    this.fileVariableMap = {};
+
+    /**
+     * Map of file paths to another object containing its
+     * variable aliases matched to the respective imported file
+     * @type {Object<string, Object<string, string>>}
+     */
+    this.fileVariableAliasesMap = {};
+
+    /**
+     * Set of files that were already processed
+     * @type {Set<string>}
+     */
+    this.processedFiles = new Set();
+  }
+
+
+  /*
+   * --------------------------------------------------
+   * Site level variable storage methods
+   */
+
+
+  /**
+   * Adds a variable for a site with the specified name and value.
+   * @param site path of the site, as reflected by the Site instance's baseUrlMap
+   * @param name of the variable to add
+   * @param value of the variable
+   */
+  addUserDefinedVariable(site, name, value) {
+    this.userDefinedVariablesMap[site] = this.userDefinedVariablesMap[site] || {};
+    this.userDefinedVariablesMap[site][name] = value;
+  }
+
+  /**
+   * Renders the variable in addition to adding it, unlike {@link addUserDefinedVariable}.
+   * This is to allow using previously declared site variables in site variables declared later on.
+   */
+  renderAndAddUserDefinedVariable(site, name, value) {
+    const renderedVal = njUtil.renderRaw(value, this.userDefinedVariablesMap[site], {}, false);
+    this.addUserDefinedVariable(site, name, renderedVal);
+  }
+
+  /**
+   * Version of {@link addUserDefinedVariable} that adds to all sites.
+   */
+  addUserDefinedVariableForAllSites(name, value) {
+    Object.keys(this.userDefinedVariablesMap)
+      .forEach(base => this.addUserDefinedVariable(base, name, value));
+  }
+
+  resetUserDefinedVariablesMap() {
+    this.userDefinedVariablesMap = {};
+  }
+
+  /**
+   * Retrieves the appropriate **(sub)site** variables of the supplied file path.
+   * @param contentFilePath to look up.
+   * @return {*} The appropriate (closest upwards) site variables map
+   */
+  getParentSiteVariables(contentFilePath) {
+    const parentSitePath = urlUtils.getParentSiteAbsolutePath(contentFilePath, this.rootPath,
+                                                              this.baseUrlMap);
+    return this.userDefinedVariablesMap[parentSitePath];
+  }
+
+  /*
+   * --------------------------------------------------
+   * Site level variable rendering methods
+   */
+
+
+  /**
+   * Renders the supplied content using only the site variables belonging to the specified site of the file.
+   * @param contentFilePath of the specified content to render
+   * @param content string
+   */
+  renderSiteVariables(contentFilePath, content) {
+    const parentSite = urlUtils.getParentSiteAbsolutePath(contentFilePath, this.rootPath, this.baseUrlMap);
+    return njUtil.renderRaw(content, this.userDefinedVariablesMap[parentSite]);
+  }
+
+
+  /*
+   * --------------------------------------------------
+   * Page level variable storage methods
+   */
+
+
+  resetVariables() {
+    this.fileVariableMap = {};
+    this.fileVariableAliasesMap = {};
+    this.processedFiles.clear();
+  }
+
+  /**
+   * Returns an object containing the <import>ed variables for the specified file.
+   * For variables specified with aliases, we construct the sub object containing the
+   * names and values of the variables tied to the alias.
+   * @param file to get the imported variables for
+   */
+  getImportedVariableMap(file) {
+    const innerVariables = {};
+    const fileAliases = this.fileVariableAliasesMap[file];
+
+    Object.entries(fileAliases).forEach(([alias, actualPath]) => {
+      innerVariables[alias] = {};
+      const variables = this.fileVariableMap[actualPath];
+
+      Object.entries(variables).forEach(([name, value]) => {
+        innerVariables[alias][name] = value;
+      });
+    });
+
+    return innerVariables;
+  }
+
+  /**
+   * Retrieves a semi-unique alias for the given array of variable names from an import element
+   * by prepending the smallest variable name with $__MARKBIND__.
+   * Uses the alias declared in the 'as' attribute if there is one.
+   * @param variableNames of the import element, not referenced from the 'as' attribute
+   * @param node of the import element
+   * @return {string} Alias for the import element
+   */
+  static getAliasForImportVariables(variableNames, node) {
+    if (_.has(node.attribs, 'as')) {
+      return node.attribs.as;
+    }
+    const largestName = variableNames.sort()[0];
+    return IMPORTED_VARIABLE_PREFIX + largestName;
+  }
+
+  /**
+   * Extracts a pseudo imported variables for the supplied content.
+   * @param $ loaded cheerio object of the content
+   * @return {{}} pseudo imported variables of the content
+   */
+  static extractPseudoImportedVariables($) {
+    const importedVariables = {};
+    $('import[from]').each((index, element) => {
+      const variableNames = Object.keys(element.attribs).filter(name => name !== 'from' && name !== 'as');
+
+      // Add pseudo variables for the alias's variables
+      const alias = VariablePreprocessor.getAliasForImportVariables(variableNames, element);
+      importedVariables[alias] = new Proxy({}, {
+        get(obj, prop) {
+          return `{{${alias}.${prop}}}`;
+        },
+      });
+
+      // Add pseudo variables for inline variables in the import element
+      variableNames.forEach((name) => {
+        importedVariables[name] = `{{${alias}.${name}}}`;
+      });
+    });
+    return importedVariables;
+  }
+
+  /**
+   * Extract page variables from a page.
+   * @param fileName for error printing
+   * @param data to extract variables from
+   * @param includedVariables variables from parent include
+   */
+  extractPageVariables(fileName, data, includedVariables) {
+    const fileDir = path.dirname(fileName);
+    const $ = cheerio.load(data);
+
+    const importedVariables = VariablePreprocessor.extractPseudoImportedVariables($);
+    const pageVariables = {};
+    const userDefinedVariables = this.getContentParentSiteVariables(fileName);
+
+    const setPageVariableIfNotSetBefore = (variableName, rawVariableValue) => {
+      if (pageVariables[variableName]) {
+        return;
+      }
+
+      pageVariables[variableName] = njUtil.renderRaw(rawVariableValue, {
+        ...importedVariables,
+        ...pageVariables,
+        ...userDefinedVariables,
+        ...includedVariables,
+      }, {}, false);
+    };
+
+    $('variable').each((index, node) => {
+      const variableSource = $(node).attr('from');
+      if (variableSource !== undefined) {
+        try {
+          const variableFilePath = path.resolve(fileDir, variableSource);
+          const jsonData = fs.readFileSync(variableFilePath);
+          const varData = JSON.parse(jsonData);
+          Object.entries(varData).forEach(([varName, varValue]) => {
+            setPageVariableIfNotSetBefore(varName, varValue);
+          });
+        } catch (err) {
+          logger.warn(`Error ${err.message}`);
+        }
+      } else {
+        const variableName = $(node).attr('name');
+        if (!variableName) {
+          logger.warn(`Missing 'name' for variable in ${fileName}\n`);
+          return;
+        }
+        setPageVariableIfNotSetBefore(variableName, md.renderInline($(node).html()));
+      }
+    });
+
+    this.fileVariableMap[fileName] = pageVariables;
+
+    return { ...importedVariables, ...pageVariables };
+  }
+
+  /**
+   * Extracts inner (nested) variables of the content,
+   * resolving the <import>s with respect to the supplied contentFilePath.
+   * @param content to extract from
+   * @param contentFilePath of the content
+   * @return {[]} Array of files that were imported
+   */
+  extractInnerVariables(content, contentFilePath) {
+    let staticIncludeSrcs = [];
+    const $ = cheerio.load(content, {
+      xmlMode: false,
+      decodeEntities: false,
+    });
+
+    const aliases = {};
+    this.fileVariableAliasesMap[contentFilePath] = aliases;
+
+    $('import[from]').each((index, node) => {
+      const filePath = path.resolve(path.dirname(contentFilePath), node.attribs.from);
+      staticIncludeSrcs.push({ from: contentFilePath, to: filePath });
+
+      const variableNames = Object.keys(node.attribs).filter(name => name !== 'from' && name !== 'as');
+      const alias = VariablePreprocessor.getAliasForImportVariables(variableNames, node);
+      aliases[alias] = filePath;
+
+      // Render inner file content and extract inner variables recursively
+      const {
+        content: renderedContent,
+        childContext,
+      } = this.renderIncludeFile(filePath, node, {});
+      const userDefinedVariables = this.getContentParentSiteVariables(filePath);
+      staticIncludeSrcs = [
+        ...staticIncludeSrcs,
+        ...this.extractInnerVariablesIfNotProcessed(renderedContent, childContext.cwf, filePath),
+      ];
+
+      // Re-render page variables with imported variables
+      const innerVariables = this.getImportedVariableMap(filePath);
+      const variables = this.fileVariableMap[filePath];
+      Object.entries(variables).forEach(([variableName, value]) => {
+        variables[variableName] = njUtil.renderRaw(value, {
+          ...userDefinedVariables, ...innerVariables,
+        });
+      });
+    });
+
+    return staticIncludeSrcs;
+  }
+
+  /**
+   * Extracts inner variables {@link extractInnerVariables} only if not processed before
+   */
+  extractInnerVariablesIfNotProcessed(content, contentFilePath, filePathToExtract) {
+    if (!this.processedFiles.has(filePathToExtract)) {
+      this.processedFiles.add(filePathToExtract);
+      return this.extractInnerVariables(content, contentFilePath);
+    }
+    return [];
+  }
+
+  /**
+   * Extracts variables specified as <include var-xx="..."> in include elements,
+   * adding them to the supplied variables if it does not already exist.
+   * @param includeElement to extract inline variables from
+   * @param variables to add the extracted variables to
+   */
+  static extractIncludeInlineVariables(includeElement, variables) {
+    Object.keys(includeElement.attribs).forEach((attribute) => {
+      if (!attribute.startsWith('var-')) {
+        return;
+      }
+      const variableName = attribute.replace(/^var-/, '');
+      if (!variables[variableName]) {
+        variables[variableName] = includeElement.attribs[attribute];
+      }
+    });
+  }
+
+  /**
+   * Extracts variables specified as <variable> in include elements,
+   * adding them to the supplied variables if it does not already exist.
+   * @param includeElement to search child nodes for
+   * @param variables to add the extracted variables to
+   */
+  static extractIncludeChildElementVariables(includeElement, variables) {
+    if (!(includeElement.children && includeElement.children.length)) {
+      return;
+    }
+
+    includeElement.children.forEach((child) => {
+      if (child.name !== 'variable' && child.name !== 'span') {
+        return;
+      }
+      const variableName = child.attribs.name || child.attribs.id;
+      if (!variableName) {
+        // eslint-disable-next-line no-console
+        logger.warn(`Missing reference in ${includeElement.attribs[ATTRIB_CWF]}\n`
+          + `Missing 'name' or 'id' in variable for ${includeElement.attribs.src} include.`);
+        return;
+      }
+      if (!variables[variableName]) {
+        variables[variableName] = cheerio.html(child.children);
+      }
+    });
+  }
+
+
+  /**
+   * Extract variables from an <include> element.
+   * See https://markbind.org/userGuide/reusingContents.html#specifying-variables-in-an-include for usage.
+   * It is a subroutine for {@link renderIncludeFile}
+   * @param includeElement include element to extract variables from
+   * @param parentVariables defined by parent pages, which have greater priority
+   */
+  static extractIncludeVariables(includeElement, parentVariables) {
+    const includedVariables = { ...parentVariables };
+    VariablePreprocessor.extractIncludeInlineVariables(includeElement, includedVariables);
+    VariablePreprocessor.extractIncludeChildElementVariables(includeElement, includedVariables);
+
+    return includedVariables;
+  }
+
+
+  /*
+   * --------------------------------------------------
+   * Combined (both site and page variables) rendering methods
+   */
+
+
+  /**
+   * Renders an include file with the supplied context, returning the rendered
+   * content and new context with respect to the child content.
+   * @param filePath of the included file source
+   * @param node of the include element
+   * @param context object containing the variables for the current context
+   * @param asIfAt where the included file should be rendered from
+   */
+  renderIncludeFile(filePath, node, context, asIfAt = filePath) {
+    // Extract included variables from the include element, merging with the parent context variables
+    const includeVariables = VariablePreprocessor.extractIncludeVariables(node, context.variables);
+
+    // Extract page variables from the **included** file
+    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const userDefinedVariables = this.getContentParentSiteVariables(asIfAt);
+    const pageVariables = this.extractPageVariables(asIfAt, fileContent, includeVariables);
+
+    // Render the included content with all the variables
+    const content = njUtil.renderRaw(fileContent, {
+      ...pageVariables,
+      ...includeVariables,
+      ...userDefinedVariables,
+    });
+
+    const includedSrces = this.extractInnerVariablesIfNotProcessed(content, asIfAt, asIfAt);
+    const renderedContent = this.renderInnerVariables(content, asIfAt, asIfAt);
+
+    const childContext = _.cloneDeep(context);
+    childContext.cwf = asIfAt;
+    childContext.variables = includeVariables;
+
+    return {
+      includedSrces,
+      renderedContent,
+      childContext,
+    };
+  }
+
+
+  /**
+   * Extracts the content page's variables, then renders it.
+   * @param content to render
+   * @param contentFilePath of the content to render
+   * @param additionalVariables if any
+   */
+  renderOuterVariables(content, contentFilePath, additionalVariables = {}) {
+    const pageVariables = this.extractPageVariables(contentFilePath, content, {});
+    const userDefinedVariables = this.getContentParentSiteVariables(contentFilePath);
+
+    return njUtil.renderRaw(content, {
+      ...pageVariables,
+      ...userDefinedVariables,
+      ...additionalVariables,
+    });
+  }
+
+  /**
+   * Extracts the content's page's inner variables, then renders it.
+   * @param content to render
+   * @param contentFilePath of the content to render
+   * @param contentAsIfAtFilePath
+   * @param additionalVariables if any
+   */
+  renderInnerVariables(content, contentFilePath, contentAsIfAtFilePath, additionalVariables = {}) {
+    const userDefinedVariables = this.getContentParentSiteVariables(contentFilePath);
+    const innerVariables = this.getImportedVariableMap(contentAsIfAtFilePath);
+
+    return njUtil.renderRaw(content, {
+      ...userDefinedVariables,
+      ...additionalVariables,
+      ...innerVariables,
+    });
+  }
+}
+
+module.exports = VariablePreprocessor;

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -196,7 +196,7 @@
           <p>Page Variable Json Variable</p>
           <p><strong>Page Variable with HTML and MD</strong></p>
           <div></div>
-          Page Variable with <span style="color: blue;">HTML</span> and <strong>Markdown</strong>
+          <p>Page Variable with <span style="color: blue;">HTML</span> and <strong>Markdown</strong></p>
           <p><strong>Nested Page Variable</strong></p>
           <div>
             <span>
@@ -229,6 +229,8 @@
             <div></div>
             Page Variable Referencing Included Variable
           </div>
+          <p>Variables for includes should not be recognised as page variables, hence, there should be no text between <strong>this</strong></p>
+          <p>and <strong>this</strong>.</p>
           <h1 id="heading-with-multiple-keywords">Heading with multiple keywords<a class="fa fa-anchor" href="#heading-with-multiple-keywords" onclick="event.stopPropagation()"></a></h1>
           <p><span class="keyword">keyword 1</span>
             <span class="keyword">keyword 2</span></p>

--- a/test/functional/test_site/expected/testImportVariables._include_.html
+++ b/test/functional/test_site/expected/testImportVariables._include_.html
@@ -6,7 +6,7 @@
 <p>Test import variables that itself imports other variables:</p>
 <h2 id="trying-to-access-a-page-variable">Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
 <p>There should be something red below:</p>
-<div style="color:red">This is a page variable from <a href="http://variablestoimport.md">variablestoimport.md</a></div>
+<div style="color:red">This is a page variable from variablestoimport.md</div>
 Something should have appeared above in red.
 <h2 id="trying-to-access-an-imported-variable-via-namespace">Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
 <p>There should be something blue below:</p>

--- a/test/functional/test_site/expected/testImportVariables.html
+++ b/test/functional/test_site/expected/testImportVariables.html
@@ -34,7 +34,7 @@
         <p>Test import variables that itself imports other variables:</p>
         <h2 id="trying-to-access-a-page-variable">Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
         <p>There should be something red below:</p>
-        <div style="color:red">This is a page variable from <a href="http://variablestoimport.md">variablestoimport.md</a></div>
+        <div style="color:red">This is a page variable from variablestoimport.md</div>
         Something should have appeared above in red.
         <h2 id="trying-to-access-an-imported-variable-via-namespace">Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
         <p>There should be something blue below:</p>

--- a/test/functional/test_site/index.md
+++ b/test/functional/test_site/index.md
@@ -40,6 +40,7 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 **Page Variable with HTML and MD**
 
 <variable name="page_variable_with_HTML_and_MD">Page Variable with <span style="color: blue;">HTML</span> and **Markdown**</variable>
+
 {{ page_variable_with_HTML_and_MD }}
 
 **Nested Page Variable**
@@ -74,6 +75,12 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
   <variable name="included_variable">Included Variable</variable>
   <variable name="included_variable_overriding_page_variable">Included Variable Overriding Page Variable</variable>
 </include>
+
+Variables for includes should not be recognised as page variables, hence, there should be no text between **this**
+
+{{ included_variable_overriding_page_variable }}
+
+and **this**.
 
 # Heading with multiple keywords
 <span class="keyword">keyword 1</span>

--- a/test/unit/Site.test.js
+++ b/test/unit/Site.test.js
@@ -361,12 +361,12 @@ test('Site resolves variables referencing other variables', async () => {
   await site.collectBaseUrl();
   await site.collectUserDefinedVariablesMap();
 
-  const root = site.userDefinedVariablesMap[path.resolve('')];
+  const root = site.variablePreprocessor.userDefinedVariablesMap[path.resolve('')];
 
   // check all variables
   expect(root.level1).toEqual('variable');
   expect(root.level2).toEqual('variable');
-  const expectedTextSpan = '<span style="color: blue">Blue text</span>';
+  const expectedTextSpan = '&lt;span style=&quot;color: blue&quot;&gt;Blue text&lt;/span&gt;';
   expect(root.level3).toEqual(expectedTextSpan);
   expect(root.level4).toEqual(expectedTextSpan);
 });
@@ -391,10 +391,10 @@ test('Site read correct user defined variables', async () => {
   await site.collectBaseUrl();
   await site.collectUserDefinedVariablesMap();
 
-  const root = site.userDefinedVariablesMap[path.resolve('')];
-  const sub = site.userDefinedVariablesMap[path.resolve('sub')];
-  const subsub = site.userDefinedVariablesMap[path.resolve('sub/sub')];
-  const othersub = site.userDefinedVariablesMap[path.resolve('otherSub/sub')];
+  const root = site.variablePreprocessor.userDefinedVariablesMap[path.resolve('')];
+  const sub = site.variablePreprocessor.userDefinedVariablesMap[path.resolve('sub')];
+  const subsub = site.variablePreprocessor.userDefinedVariablesMap[path.resolve('sub/sub')];
+  const othersub = site.variablePreprocessor.userDefinedVariablesMap[path.resolve('otherSub/sub')];
 
   // check all baseUrls
   const baseUrl = '{{baseUrl}}';

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
-const MarkBind = require('../../src/lib/markbind/src/parser.js');
+const Parser = require('../../src/lib/markbind/src/parser.js');
+const VariablePreprocessor = require('../../src/lib/markbind/src/preprocessors/variablePreprocessor');
 const { USER_VARIABLES_DEFAULT } = require('./utils/data');
 
 jest.mock('fs');
@@ -9,11 +10,13 @@ jest.mock('../../src/util/logger');
 afterEach(() => fs.vol.reset());
 
 const ROOT_PATH = path.resolve('');
-const DEFAULT_USER_DEFINED_VARIABLES_MAP = {};
-DEFAULT_USER_DEFINED_VARIABLES_MAP[ROOT_PATH] = {
-  example: USER_VARIABLES_DEFAULT,
-  baseUrl: '{{baseUrl}}',
-};
+function getNewDefaultVariablePreprocessor() {
+  const DEFAULT_VARIABLE_PREPROCESSOR = new VariablePreprocessor(ROOT_PATH, new Set([ROOT_PATH]));
+  DEFAULT_VARIABLE_PREPROCESSOR.addUserDefinedVariable(ROOT_PATH, 'example', USER_VARIABLES_DEFAULT);
+  DEFAULT_VARIABLE_PREPROCESSOR.addUserDefinedVariable(ROOT_PATH, 'baseUrl', '{{baseUrl}}');
+
+  return DEFAULT_VARIABLE_PREPROCESSOR;
+}
 
 test('includeFile replaces <include> with <div>', async () => {
   const indexPath = path.resolve('index.md');
@@ -36,11 +39,10 @@ test('includeFile replaces <include> with <div>', async () => {
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -76,11 +78,10 @@ test('includeFile replaces <include src="exist.md" optional> with <div>', async 
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -112,11 +113,10 @@ test('includeFile replaces <include src="doesNotExist.md" optional> with empty <
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -151,11 +151,10 @@ test('includeFile replaces <include src="include.md#exists"> with <div>', async 
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -195,11 +194,10 @@ test('includeFile replaces <include src="include.md#exists" inline> with inline 
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -235,11 +233,10 @@ test('includeFile replaces <include src="include.md#exists" trim> with trimmed c
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -278,15 +275,10 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind({
-    errorHandler: (e) => {
-      expect(e.message).toEqual(expectedErrorMessage);
-    },
-  });
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -321,11 +313,10 @@ test('includeFile replaces <include src="include.md#exists" optional> with <div>
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -361,11 +352,10 @@ test('includeFile replaces <include src="include.md#doesNotExist" optional> with
   fs.vol.fromJSON(json, '');
   const baseUrlMap = new Set([ROOT_PATH]);
 
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = [
@@ -415,15 +405,10 @@ test('includeFile detects cyclic references for static cyclic includes', async (
     `\t${indexPath}`,
   ].join('\n');
 
-  const markbinder = new MarkBind({
-    errorHandler: (e) => {
-      expect(e.message).toEqual(expectedErrorMessage);
-    },
-  });
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const result = await markbinder.includeFile(indexPath, index, {
     baseUrlMap,
     rootPath: ROOT_PATH,
-    userDefinedVariablesMap: DEFAULT_USER_DEFINED_VARIABLES_MAP,
   });
 
   const expected = `<div style="color: red">${expectedErrorMessage}</div>`;
@@ -432,7 +417,7 @@ test('includeFile detects cyclic references for static cyclic includes', async (
 });
 
 test('renderFile converts markdown headers to <h1>', async () => {
-  const markbinder = new MarkBind();
+  const markbinder = new Parser({ variablePreprocessor: getNewDefaultVariablePreprocessor() });
   const rootPath = path.resolve('');
   const headerIdMap = {};
   const indexPath = path.resolve('index.md');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain:

Yet another part of #810 

Prelude to #931, #894 type of prs - my solution for #931 added quite some boilerplate, which I don't really think is sustainable anymore -- this should be a good point to refactor it

**What is the rationale for this request?**
- variable processing is rather decentralized and unmaintainable currently, some examples:
  - `Site.js` requires the entire `Parser` abstraction to reset site variables during live reload
  - massive 70-100+ line functions like `renderIncludeFile/extractPageVariables/...`
  - a lot of boilerplate code setup with minor variations e.g.

```js
const userDefinedVariables = config.userDefinedVariablesMap[parentSitePath];
// Extract included variables from the PARENT file
const includeVariables = Parser.extractIncludeVariables(node, context.variables);
// Extract page variables from the CHILD file
const pageVariables = Parser.extractPageVariables(asIfAt, fileContent,
                                                       userDefinedVariables, includeVariables);
const content = njUtil.renderRaw(fileContent, {
  ...pageVariables,
  ...includeVariables,
  ...userDefinedVariables,
}, {
  path: filePath,
});
```
    

**What changes did you make? (Give an overview)**
- Introduced a new abstraction, `variablePreprocessor`, which will be responsible for all variable storage and rendering

This doodle explains the intended endgame better (pink lines are read as 'uses'):
<img src="https://user-images.githubusercontent.com/3306138/79017840-e41a4000-7ba4-11ea-8835-1106b9d2fb92.jpg" width="80%" />

There are two logical parts to this refactor

The first (commit):

Completes and unifies where site variables are accessed and stored ( the first, second pink lines, and part of the fourth pink line )
- Some misc refactors like SLAP, guard clauses, better in code documentation, etc. are also made
- methods relating to functions 3 / 4 are simply moved from `parser` to `variablePreprocessor` without much change ( just some misc refactors like SLAP, etc per above )

The second (commit):

Completes and logically changes functions 3 / 4.

The variable processing flow before was such that `<import>`s and locally declared `<variable>`s were extracted and rendered separately. This inevitably results in more boilerplate ( e.g. note double extraction in the code above ), and uses dirty hacks like `Proxy` to force nunjucks to output namespaced variables back into themselves.

This commit unifies the two processes hence (see `extractPageVariables` / `renderPage` ), extracting and rendering both in one go while respecting the variable declaration order still. It also removes the need for `Proxy`s, and has some modest performance benefits due to the reduced number of passes.

**End goals:**

1. The main goal is to reduce repeated boilerplate in the example code above throughout and centralise all rendering, note how the above is turned into simply 1 / 2 lines. ( mostly 1 )

```
this.variablePreprocessor.extractPageVariables(file, content);
const renderedContent = this.variablePreprocessor.renderPage(file, content, {}, additionalVariables);
```

2. Misc
   - Better separation of concerns #810 
   - More unit focused code
   - Better in code documentation ( results in most of the added lines )
   - Better performance ( in part 2 - consistently about 10% due to the variable processing logic changes as mentioned above )

**Is there anything you'd like reviewers to focus on?**

The main motive for this is to solve #931 type of issues easily, and hopefully make variable processing development in the future easier.
With this in mind, could the architecture be further improved?



as an example for #931, with all site variable rendering now centralised, by intended solution is to let `variablePreprocessor` hold multiple nunjucks instances in the future, each configured with its root path to be the respective root paths of the (sub)sites.
This should allow any nunjucks tags that uses paths to resolve correctly across (sub)sites

**Testing instructions:**
- 2103 site should have no diffs, save for logs and timestamps
- all functional / unit tests should pass

**Proposed commit message: (wrap lines at 72 characters)**

(pending review of the commit structure)

Reorganise variable processing (part 1)

Processing variables involves a lot of boilerplate code with minor
variations. This decentralizes variable processing, decreasing code
maintainability and readability.

Let's embark on a two stage refactor to improve variable processing.
In this first refactor, we create the variablePreprocessor abstraction,
and completely migrate the use of userDefinedVariablesMap for site
variables to variablePreprocessor, reducing boilerplate code relating
to site variables.
Additionally, we move all page variable processing related methods to
variablePreprocessor from Parser, abstracting such methods into
smaller units of functionality where possible, and enhancing in code
documentation.

In the second part, we will similarly refactor page variable processing
methods to reduce more boilerplate, increasing code maintainability.