### PR TITLE
Allow variable tags to contain malformed xml

### DIFF
--- a/src/lib/markbind/src/lib/markdown-it/markdown-it-escape-special-tags.js
+++ b/src/lib/markbind/src/lib/markdown-it/markdown-it-escape-special-tags.js
@@ -10,7 +10,7 @@ function escape_plugin(md, tagsToIgnore) {
   const HTML_OPEN_CLOSE_TAG_RE = require('markdown-it/lib/common/html_re').HTML_OPEN_CLOSE_TAG_RE;
 
   const specialTagsRegex = Array.from(tagsToIgnore)
-    .concat(['script|pre|style'])
+    .concat(['script|pre|style|variable'])
     .join('|');
   const startingSpecialTagRegex = new RegExp(`^<(${specialTagsRegex})(?=(\\s|>|$))`, 'i');
   const endingSpecialTagRegex = new RegExp(`<\\/(${specialTagsRegex})>`, 'i');

--- a/src/lib/markbind/src/patches/htmlparser2.js
+++ b/src/lib/markbind/src/patches/htmlparser2.js
@@ -110,6 +110,12 @@ var i = 0,
 	NO_MATCH                  = -2,
 	HAS_MATCHED               = -3;
 
+const DEFAULT_SPECIAL_TAGS = [
+	'script',
+	'style',
+	'variable',
+];
+
 function whitespace(c) {
 	return c === " " || c === "\n" || c === "\t" || c === "\f" || c === "\r";
 }
@@ -149,10 +155,7 @@ Tokenizer.prototype._stateText = function(c) {
 };
 
 
-Tokenizer.prototype.specialTagNames = [
-	'script',
-	'style',
-];
+Tokenizer.prototype.specialTagNames = [...DEFAULT_SPECIAL_TAGS];
 
 /**
  * Checks whether the token matches one of the first characters of the special tags,
@@ -485,7 +488,7 @@ Tokenizer.prototype._parse = function(){
  * Injects the tagsToIgnore into the Tokenizer's specialTagNames.
  */
 function injectIgnoreTags(tagsToIgnore) {
-	Tokenizer.prototype.specialTagNames = ['script', 'style', ...tagsToIgnore];
+	Tokenizer.prototype.specialTagNames = [...DEFAULT_SPECIAL_TAGS, ...tagsToIgnore];
 }
 
 module.exports = injectIgnoreTags;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes the first point mentioned here https://github.com/MarkBind/markbind/pull/1168#issuecomment-612330854

**What is the rationale for this request?**
Simple patch to allow `<variable>` tags to hold any content built on #1047 


**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
`npm run test` should pass

**Proposed commit message: (wrap lines at 72 characters)**
Allow variable tags to contain malformed xml

With the special tags patch, variables are able to contain custom
content possibly containing malformed xml.

Let’s add variable to the list of special tags to do so.