### PR TITLE
Make highlighting effective for code-formatted text

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }

--- a/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
@@ -11,7 +11,7 @@ code {
     word-break: normal;
 }
 
-mark > code {
+mark code {
     background: #ffffffd4;
 }
 

--- a/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
@@ -11,6 +11,10 @@ code {
     word-break: normal;
 }
 
+mark > code {
+    background: #ffffffd4;
+}
+
 pre.hljs > code {
     background: none;
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes #1210 
Related to #1209 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What changes did you make? (Give an overview)**

Make the background transparent for code-formatted text under <mark> tag (i.e. highlighting)

**Provide some example code that this change will affect:**

na

**Is there anything you'd like reviewers to focus on?**

na

**Testing instructions:**

`npm run test`

**Proposed commit message: (wrap lines at 72 characters)**

Currently the background color of code tag is opaque, therefore the
highlighting will be covered by the code-formatted text. Let's
introduce transparency to code tag style when it's placed under
mark tag so that highlighting is effective in this case.