### PR TITLE
Fix several b-modal selector names

### DIFF
--- a/src/Page.js
+++ b/src/Page.js
@@ -338,7 +338,7 @@ class Page {
       return;
     }
     const $ = cheerio.load(content);
-    $('modal').remove();
+    $('b-modal').remove();
     this._collectNavigableHeadings($, $.root()[0], elementSelector);
   }
 
@@ -405,7 +405,7 @@ class Page {
   collectHeadingsAndKeywordsInContent(content, lastHeading, excludeHeadings, sourceTraversalStack) {
     let $ = cheerio.load(content);
     const headingsSelector = Page.generateHeadingSelector(this.headingIndexingLevel);
-    $('modal').remove();
+    $('b-modal').remove();
     $('panel').not('panel panel')
       .each((index, panel) => {
         const slotHeader = $(panel).children('[slot="header"]');
@@ -468,7 +468,7 @@ class Page {
       });
     $ = cheerio.load(content);
     if (this.headingIndexingLevel > 0) {
-      $('modal').remove();
+      $('b-modal').remove();
       $('panel').remove();
       if (!excludeHeadings) {
         $(headingsSelector).each((i, heading) => {

--- a/src/plugins/algolia.js
+++ b/src/plugins/algolia.js
@@ -25,7 +25,7 @@ function addNoIndexClasses(content) {
   const $ = cheerio.load(content, { xmlMode: false });
   const noIndexSelectors = [
     'dropdown',
-    'modal',
+    'b-modal',
     'panel:not([expanded])',
     'popover div[slot=content]',
     'question div[slot=hint]',

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -709,7 +709,6 @@
               <a class="nav-link py-1" href="#inner-panel-header-without-src">Inner panel header without src&#x200E;</a>
               <a class="nav-link py-1" href="#panel-with-src-from-another-markbind-site-header">Panel with src from another Markbind site header&#x200E;</a>
               <a class="nav-link py-1" href="#panel-with-src-from-another-markbind-site-header-2">Panel with src from another Markbind site header&#x200E;</a>
-              <a class="nav-link py-1" href="#panel-inside-modal">Panel inside modal&#x200E;</a>
               <a class="nav-link py-1" href="#unexpanded-panel-header">Unexpanded panel header&#x200E;</a>
             </nav>
             <a class="nav-link py-1" href="#markbind-plugin-pre-render">Markbind Plugin Pre-render&#x200E;</a>

--- a/test/functional/test_site/expected/siteData.json
+++ b/test/functional/test_site/expected/siteData.json
@@ -45,7 +45,6 @@
         "outer-nested-panel-without-src": "Outer nested panel without src",
         "panel-with-src-from-another-markbind-site-header": "Panel with src from another Markbind site header",
         "panel-with-src-from-another-markbind-site-header-2": "Panel with src from another Markbind site header",
-        "panel-inside-modal": "Panel inside modal",
         "unexpanded-panel-header": "Unexpanded panel header",
         "keyword-should-be-tagged-to-this-heading-not-the-panel-heading": "Keyword should be tagged to this heading, not the panel heading",
         "panel-normal-source-content-headings": "Panel normal source content headings",

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -40,7 +40,7 @@
           <li><a class="dropdown-item" href="/">Two</a></li>
         </dropdown>
         <p><strong>Modal content should have algolia-no-index class</strong></p>
-        <b-modal id="modal:trigger_id" hide-footer="" size="" modal-class="mb-zoom" ref="modal:trigger_id"><template slot="modal-title">Modal</template>
+        <b-modal id="modal:trigger_id" hide-footer="" size="" modal-class="mb-zoom" ref="modal:trigger_id" class="algolia-no-index"><template slot="modal-title">Modal</template>
           Content should have `algolia-no-index` class
         </b-modal>
         <span for="modal:trigger_id" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['modal:trigger_id'].show()" class="trigger">Trigger should not have `algolia-no-index` class</span>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #1217


**What changes did you make? (Give an overview)**
Change leftover `'modal'` selectors from the bootstrap vue migration to `'b-modal'`


**Testing instructions:**
- `npm run test` should pass

**Proposed commit message: (wrap lines at 72 characters)**
Fix several b-modal selector names

The bootstrap vue migration causes modal elements to be transformed into
b-modal.

Let’s change the leftover selector names to match the new name.

