### PR TITLE
Simplify site nav generation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -24,13 +24,17 @@ module.exports = {
   PAGE_NAV_ID: 'page-nav',
   PAGE_NAV_TITLE_CLASS: 'page-nav-title',
   SITE_NAV_ID: 'site-nav',
+  SITE_NAV_EMPTY_LINE_REGEX: new RegExp('\\r?\\n\\s*\\r?\\n', 'g'),
+  SITE_NAV_ANCHOR_CLASS: 'site-nav__a',
   SITE_NAV_LIST_CLASS: 'site-nav-list',
+  SITE_NAV_DROPDOWN_EXPAND_KEYWORD_REGEX: new RegExp(':expanded:', 'g'),
+  SITE_NAV_DROPDOWN_ICON_HTML: '<i class="dropdown-btn-icon">\n'
+    + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
+    + '</i>',
+  SITE_NAV_DROPDOWN_ICON_ROTATED_HTML: '<i class="dropdown-btn-icon rotate-icon">\n'
+    + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
+    + '</i>',
   TITLE_PREFIX_SEPARATOR: ' - ',
-
-  DROPDOWN_BUTTON_ICON_HTML: '<i class="dropdown-btn-icon">\n'
-  + '<span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>\n'
-  + '</i>',
-  DROPDOWN_EXPAND_KEYWORD: ':expanded:',
 
   TEMP_NAVBAR_CLASS: 'temp-navbar',
   TEMP_DROPDOWN_CLASS: 'temp-dropdown',


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [x] Other, please explain:

Code maintainability


**What is the rationale for this request?**
- simplify the recursive algorithm used in site nav generation to an iterative one
- should also bring some performance benefits since we are no longer constantly reparsing / outputting the html across recursive calls of `formatSiteNav`

**What changes did you make? (Give an overview)**
- merged `formatSiteNav` into `insertSiteNav` since the recursion is removed
- the new algorithm simply iterates through `ul` elements one by one, and its direct `li` child elements, formatting it the same way the old algorithm did
- extract some more constants to `constants.js`

**Testing instructions:**
- npm run `test` should pass ( no test file updates here )

**Proposed commit message: (wrap lines at 72 characters)**
Simplify site nav generation

The site nav generation algorithm is heavily recursive.

Let's remove the recursion in favour of a simple iterative process.