### PR TITLE
Fix padding and font weight for custom list items

### DIFF
--- a/asset/css/site-nav.css
+++ b/asset/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/src/Page.js
+++ b/src/Page.js
@@ -43,9 +43,11 @@ const {
   PLUGIN_SITE_ASSET_FOLDER_NAME,
   SITE_NAV_ID,
   SITE_NAV_EMPTY_LINE_REGEX,
-  SITE_NAV_LIST_ITEM_CONTENT_CLASS,
+  SITE_NAV_LIST_ITEM_CLASS,
+  SITE_NAV_DEFAULT_LIST_ITEM_CLASS,
   SITE_NAV_LIST_CLASS,
   SITE_NAV_LIST_CLASS_ROOT,
+  SITE_NAV_CUSTOM_LIST_ITEM_CLASS,
   SITE_NAV_DROPDOWN_EXPAND_KEYWORD_REGEX,
   SITE_NAV_DROPDOWN_ICON_HTML,
   SITE_NAV_DROPDOWN_ICON_ROTATED_HTML,
@@ -722,20 +724,22 @@ class Page {
       if (nestingLevel === 0) {
         $nav(ulElem).addClass(SITE_NAV_LIST_CLASS_ROOT);
       }
-      const listItemContentClasses = `${SITE_NAV_LIST_ITEM_CONTENT_CLASS} ${
-        SITE_NAV_LIST_ITEM_CONTENT_CLASS}-${nestingLevel}`;
+      const listItemLevelClass = `${SITE_NAV_LIST_ITEM_CLASS}-${nestingLevel}`;
+      const defaultListItemClass = `${SITE_NAV_DEFAULT_LIST_ITEM_CLASS} ${listItemLevelClass}`;
+      const customListItemClasses = `${SITE_NAV_CUSTOM_LIST_ITEM_CLASS} ${listItemLevelClass}`;
 
       $nav(ulElem).children('li').each((i2, liElem) => {
         const nestedLists = $nav(liElem).children('ul');
         const nestedAnchors = $nav(liElem).children('a');
         if (nestedLists.length === 0 && nestedAnchors.length === 0) {
+          $(liElem).addClass(customListItemClasses);
           return;
         }
 
         const listItemContent = $nav(liElem).contents().not('ul');
         const listItemContentHtml = $nav.html(listItemContent);
         listItemContent.remove();
-        $nav(liElem).prepend(`<div class="${listItemContentClasses}" onclick="handleSiteNavClick(this)">`
+        $nav(liElem).prepend(`<div class="${defaultListItemClass}" onclick="handleSiteNavClick(this)">`
           + `${listItemContentHtml}</div>`);
         if (nestedLists.length === 0) {
           return;

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,9 +25,11 @@ module.exports = {
   PAGE_NAV_TITLE_CLASS: 'page-nav-title',
   SITE_NAV_ID: 'site-nav',
   SITE_NAV_EMPTY_LINE_REGEX: new RegExp('\\r?\\n\\s*\\r?\\n', 'g'),
+  SITE_NAV_LIST_ITEM_CLASS: 'site-nav-list-item',
   SITE_NAV_LIST_CLASS: 'site-nav-list',
   SITE_NAV_LIST_CLASS_ROOT: 'site-nav-list-root',
-  SITE_NAV_LIST_ITEM_CONTENT_CLASS: 'site-nav-list-item-content',
+  SITE_NAV_DEFAULT_LIST_ITEM_CLASS: 'site-nav-default-list-item',
+  SITE_NAV_CUSTOM_LIST_ITEM_CLASS: 'site-nav-custom-list-item',
   SITE_NAV_DROPDOWN_EXPAND_KEYWORD_REGEX: new RegExp(':expanded:', 'g'),
   SITE_NAV_DROPDOWN_ICON_HTML: '<i class="site-nav-dropdown-btn-icon" '
     + 'onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">\n'

--- a/test/functional/test_site/expected/index.html
+++ b/test/functional/test_site/expected/index.html
@@ -49,107 +49,107 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">
               <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation" onclick="event.stopPropagation()"></a></h2>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/test_site/bugs/index.html">Open Bugs 🐛</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/test_site/bugs/index.html">Open Bugs 🐛</a></div>
             </li>
-            <li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">
               <h3 id="testing-site-nav">Testing Site-Nav<a class="fa fa-anchor" href="#testing-site-nav" onclick="event.stopPropagation()"></a></h3>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><strong>Dropdown </strong> <span aria-hidden="true" class="glyphicon glyphicon-search"></span> title ✏️
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><strong>Dropdown </strong> <span aria-hidden="true" class="glyphicon glyphicon-search"></span> title ✏️
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/">Dropdown link one</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/">Dropdown link one</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)">Nested Dropdown title 📐
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)">Nested Dropdown title 📐
                     <i class="site-nav-dropdown-btn-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
                   <ul class="site-nav-dropdown-container site-nav-list">
                     <li>
-                      <div class="site-nav-list-item-content site-nav-list-item-content-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></div>
+                      <div class="site-nav-default-list-item site-nav-list-item-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></div>
                     </li>
                     <li>
-                      <div class="site-nav-list-item-content site-nav-list-item-content-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link two</a></div>
+                      <div class="site-nav-default-list-item site-nav-list-item-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link two</a></div>
                     </li>
                   </ul>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/">Dropdown link two</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/">Dropdown link two</a></div>
                 </li>
               </ul>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><mark>Third Link</mark> 📋</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><mark>Third Link</mark> 📋</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Filler text <a href="https://www.youtube.com/"><span aria-hidden="true" class="glyphicon glyphicon-facetime-video"></span> Youtube 📺</a> filler text
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Filler text <a href="https://www.youtube.com/"><span aria-hidden="true" class="glyphicon glyphicon-facetime-video"></span> Youtube 📺</a> filler text
                 <i class="site-nav-dropdown-btn-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">The answer to everything in the universe</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">The answer to everything in the universe</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><mark>Dropdown title</mark> <span aria-hidden="true" class="glyphicon glyphicon-comment"></span> ✏️
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><mark>Dropdown title</mark> <span aria-hidden="true" class="glyphicon glyphicon-comment"></span> ✏️
                     <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
                   <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                     <li>
-                      <div class="site-nav-list-item-content site-nav-list-item-content-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></div>
+                      <div class="site-nav-default-list-item site-nav-list-item-2" onclick="handleSiteNavClick(this)"><a href="https://www.google.com/"><strong>Nested</strong> Dropdown link one</a></div>
                     </li>
                   </ul>
                 </li>
               </ul>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown Title Really Long Dropdown
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
-                <li>Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text</li>
+                <li class="site-nav-custom-list-item site-nav-list-item-1">Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text Really Really Long Text</li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)">Nested Dropdown Title
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)">Nested Dropdown Title
                     <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
                   <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
-                    <li>Hello Doge Hello Doge 🐶</li>
+                    <li class="site-nav-custom-list-item site-nav-list-item-2">Hello Doge Hello Doge 🐶</li>
                     <li>
-                      <div class="site-nav-list-item-content site-nav-list-item-content-2" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current"><strong>NESTED LINK</strong> Home 🏠</a></div>
+                      <div class="site-nav-default-list-item site-nav-list-item-2" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current"><strong>NESTED LINK</strong> Home 🏠</a></div>
                     </li>
-                    <li>Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit</li>
+                    <li class="site-nav-custom-list-item site-nav-list-item-2">Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit Text cut off from height limit</li>
                   </ul>
                 </li>
               </ul>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Test line break in navigation layout
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Test line break in navigation layout
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
-                <li>Nested line break text ✂️</li>
+                <li class="site-nav-custom-list-item site-nav-list-item-1">Nested line break text ✂️</li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current">Nested line break href</a>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current">Nested line break href</a>
                     <i class="site-nav-dropdown-btn-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
                   <ul class="site-nav-dropdown-container site-nav-list">
-                    <li>Nested Nested line break text ✂️</li>
+                    <li class="site-nav-custom-list-item site-nav-list-item-2">Nested Nested line break text ✂️</li>
                   </ul>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)">Nested line break dropdown menu
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)">Nested line break dropdown menu
                     <i class="site-nav-dropdown-btn-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                       <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
                   <ul class="site-nav-dropdown-container site-nav-list">
-                    <li>Line break item 2 📘</li>
+                    <li class="site-nav-custom-list-item site-nav-list-item-2">Line break item 2 📘</li>
                   </ul>
                 </li>
               </ul>

--- a/test/functional/test_site/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site/expected/testLayouts.html
+++ b/test/functional/test_site/expected/testLayouts.html
@@ -29,7 +29,7 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[Layout Nav]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[Layout Nav]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/test/functional/test_site/expected/testLayoutsOverride.html
@@ -29,7 +29,7 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[Layout Nav]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[Layout Nav]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/test/functional/test_site_algolia_plugin/expected/index.html
@@ -28,7 +28,7 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/test_site_algolia_plugin/index.html" class="current">Home <span aria-hidden="true" class="glyphicon glyphicon-home"></span></a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/test_site_algolia_plugin/index.html" class="current">Home <span aria-hidden="true" class="glyphicon glyphicon-home"></span></a></div>
             </li>
           </ul>
         </div>

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site_convert/expected/Home.html
+++ b/test/functional/test_site_convert/expected/Home.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/Page-1.html
+++ b/test/functional/test_site_convert/expected/Page-1.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/_Footer.html
+++ b/test/functional/test_site_convert/expected/_Footer.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/test/functional/test_site_convert/expected/_Sidebar.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/about.html
+++ b/test/functional/test_site_convert/expected/about.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/contents/topic1.html
+++ b/test/functional/test_site_convert/expected/contents/topic1.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html" class="current">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html" class="current">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_convert/expected/contents/topic2.html
+++ b/test/functional/test_site_convert/expected/contents/topic2.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html" class="current">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html" class="current">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_convert/expected/contents/topic3a.html
+++ b/test/functional/test_site_convert/expected/contents/topic3a.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html" class="current">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html" class="current">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_convert/expected/contents/topic3b.html
+++ b/test/functional/test_site_convert/expected/contents/topic3b.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html" class="current">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html" class="current">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_convert/expected/index.html
+++ b/test/functional/test_site_convert/expected/index.html
@@ -38,8 +38,8 @@
       <nav id="site-nav" class="navbar navbar-light bg-transparent">
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
-            <li>[[Home]]</li>
-            <li>[[Page-1]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Home]]</li>
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[[Page-1]]</li>
           </ul>
         </div>
       </nav>

--- a/test/functional/test_site_convert/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_convert/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site_expressive_layout/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_expressive_layout/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site_special_tags/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_special_tags/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html" class="current">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html" class="current">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html" class="current">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html" class="current">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html" class="current">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html" class="current">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -44,24 +44,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html" class="current">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html" class="current">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_templates/test_default/expected/index.html
+++ b/test/functional/test_site_templates/test_default/expected/index.html
@@ -45,24 +45,24 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/index.html" class="current">Home 🏠</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/index.html" class="current">Home 🏠</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic1.html">Topic 1</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/contents/topic2.html">Topic 2</a></div>
             </li>
             <li>
-              <div class="site-nav-list-item-content site-nav-list-item-content-0" onclick="handleSiteNavClick(this)">Topic 3
+              <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)">Topic 3
                 <i class="site-nav-dropdown-btn-icon site-nav-rotate-icon" onclick="handleSiteNavClick(this.parentNode, false); event.stopPropagation();">
                   <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span></i></div>
               <ul class="site-nav-dropdown-container site-nav-dropdown-container-open site-nav-list">
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3a.html">Topic 3a</a></div>
                 </li>
                 <li>
-                  <div class="site-nav-list-item-content site-nav-list-item-content-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
+                  <div class="site-nav-default-list-item site-nav-list-item-1" onclick="handleSiteNavClick(this)"><a href="/contents/topic3b.html">Topic 3b</a></div>
                 </li>
               </ul>
             </li>

--- a/test/functional/test_site_templates/test_default/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_templates/test_default/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }

--- a/test/functional/test_site_templates/test_minimal/expected/markbind/css/site-nav.css
+++ b/test/functional/test_site_templates/test_minimal/expected/markbind/css/site-nav.css
@@ -30,7 +30,7 @@
     margin: 0 -12px;
 }
 
-.site-nav-list-item-content {
+.site-nav-default-list-item {
     display: flex;
     padding: 0.5rem 0 0 2.8rem;
     transition: background-color 0.08s;
@@ -38,37 +38,42 @@
     cursor: pointer;
 }
 
-.site-nav-list-item-content-0 {
+.site-nav-custom-list-item {
+    padding: 0.5rem 0 0 2.8rem;
+    color: #454545;
+}
+
+.site-nav-list-item-0 {
     padding: 0.8rem 0 0.4rem 0.8rem;
     font-weight: 600;
     font-size: 1.05em;
 }
 
-.site-nav-list-item-content-1 {
+.site-nav-list-item-1 {
     padding: 0.5rem 0 0.3rem 1.3rem;
 }
 
-.site-nav-list-item-content-2 {
+.site-nav-list-item-2 {
     padding: 0.5rem 0 0.2rem 1.8rem;
     font-size: 0.95em;
 }
 
-.site-nav-list-item-content-3 {
+.site-nav-list-item-3 {
     padding: 0.5rem 0 0.2rem 2.4rem;
     font-size: 0.87em;
 }
 
-.site-nav-list-item-content:hover {
+.site-nav-default-list-item:hover {
     background-color: rgba(214, 233, 255, 0.35);
 }
 
-.site-nav-list-item-content a {
+.site-nav-default-list-item a {
     display: inline-block;
     height: 100%;
     color: #454545;
 }
 
-.site-nav-list-item-content:hover a {
+.site-nav-default-list-item:hover a {
     color: black;
     text-decoration: none;
 }


### PR DESCRIPTION


**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #1249

**What is the rationale for this request?**
Simply adds the custom styles used for default list items to custom list items, doing some class renaming to better differentiate the two.


**Testing instructions:**
custom list classes should now get the font-weight and padding styling, but without the highlight-on-hover

---

Code:
![Untitled](https://user-images.githubusercontent.com/3306138/84660885-18ff9600-af4c-11ea-92f4-97bd7598fef1.png)

---

Output:
![Untitled](https://user-images.githubusercontent.com/3306138/84660915-2288fe00-af4c-11ea-8142-ca925b2a3b56.png)

---

**Proposed commit message: (wrap lines at 72 characters)**
Fix padding and font weight for custom list items

Padding and font weight formatting are not applied for custom list
items without nested lists or anchors.

Let's add these, and rename the classes used for better naming
consistency.
