### PR TITLE
Tweak box styles and revamp box code

### DIFF
--- a/docs/userGuide/syntax/boxes.mbdf
+++ b/docs/userGuide/syntax/boxes.mbdf
@@ -1,6 +1,6 @@
 ## Boxes
 
-**Box comes with different built-in types.**
+**Boxes come with different built-in types.**
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
@@ -33,10 +33,12 @@
     dismissible info
 </box>
 <box type="success" header="#### Header :rocket:" icon-size="2x">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    <box type="warning" header="You can use **markdown** here! :pizza:" dismissible>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    </box>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+  <box type="warning" header="You can use **markdown** here! :pizza:" dismissible>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  </box>
 </box>
 </variable>
 </include>
@@ -46,6 +48,9 @@
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
 <variable name="code">
+<box light>
+    default light
+</box>
 <box type="info" light>
     info light
 </box>
@@ -67,18 +72,25 @@
 <box type="definition" light>
     definition light
 </box>
+<box type="definition" header="##### Header markdown :rocket:" light>
+    definition light with header markdown
+</box>
 </variable>
 </include>
 
 **MarkBind also supports a seamless style of boxes**
 
 <box type="info">
-As <code>light</code> and <code>seamless</code> are mutually exclusive styles, <code>light</code> takes priority over <code>seamless</code>.
+
+As `light` and `seamless` are mutually exclusive styles, `light` takes priority over `seamless`.
 </box>
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
 <variable name="code">
+<box seamless>
+    default seamless
+</box>
 <box type="info" seamless>
     info seamless
 </box>
@@ -97,32 +109,33 @@ As <code>light</code> and <code>seamless</code> are mutually exclusive styles, <
 <box type="tip" seamless>
     tip seamless
 </box>
-<box type="definition" seamless>
-    definition seamless
+<box type="definition" seamless dismissible>
+    dismissible definition seamless
+</box>
+<box type="definition" header="##### Header markdown :rocket:" seamless>
+    success seamless with header markdown
 </box>
 </variable>
 </include>
 
-**You can customize the Box's appearance.**
+**You can further customize the Box's appearance.**
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
 <variable name="code">
-<box background-color="white" border-color="grey" border-left-color="blue">
-    default, styled as empty box with blue left border
+<box background-color="#ffca6a" border-color="grey" border-left-color="#8b5a01">
+default type, styled as an orange box with a brown left border
 </box>
-<box type="info" icon=":rocket:">
-    info, with rocket icon
+<box type="info" color="red" icon=":rocket:">
+
+info, with a custom markdown rocket icon and `red` colored text.
+
+You can use any inline markdown in the `icon` property.
 </box>
 </variable>
 </include>
 
 **You can remove the background, icon and borders of preset styles.**
-
-<box type="info">
-Custom styles (<code>background-color</code>, <code>border-color</code>, <code>border-left-color</code>, <code>icon</code>) as introduced in the previous section, takes precedence over and are not affected by <code>no-background</code>, <code>no-border</code>, <code>no-icon</code>
-</box>
-
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
@@ -137,18 +150,23 @@ Custom styles (<code>background-color</code>, <code>border-color</code>, <code>b
 </variable>
 </include>
 
+<box header="Note" type="info" seamless>
+
+Custom styles **(** `background-color`, `border-color`, `border-left-color`, `icon` **)** as introduced in the previous section, takes precedence over the `no-background`, `no-border`, `no-icon` attributes.
+</box>
+
 **You can also use icons and resize them accordingly.**
 
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">html</variable>
 <variable name="code">
-<box type="warning" icon=":fas-camera:">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+<box type="success" icon=":fas-camera:">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </box>
 <box type="warning" icon=":fas-camera:" icon-size="2x">
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 </box>
-<box type="warning" icon=":fas-camera:" icon-size="3x">
+<box type="definition" icon=":fas-camera:" icon-size="3x">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 </box>
 </variable>
@@ -165,15 +183,13 @@ dismissible | `Boolean` | `false` | Adds a button to close the box to the top ri
 icon | `String` | `null` | Inline MarkDown text of the icon displayed on the left.
 icon-size | `String` | `null` | Resizes the icon. Supports integer-scaling of the icon dimensions e.g. `2x`, `3x`, `4x`, etc.
 header <hr style="margin-top:0.2rem; margin-bottom:0" /> <small>heading <br> (deprecated)</small> | `String` | `null` | Markdown text of the box header.
-type | `String` | `'none'` | Supports: `info`, `warning`, `success`, `important`, `wrong`, `tip`, `definition`, or empty for default.
+type | `String` | `''` | Supports: `info`, `warning`, `success`, `important`, `wrong`, `tip`, `definition`, or empty for default.
 light | `Boolean` | `false` | Uses a light color scheme for the box.
 seamless | `Boolean` | `false` | Uses a seamless style for the box. If `light` is specified, this style will not be activated.
 no-border | `Boolean` | `false` | Removes border, except if styled by `border-color` or `border-left-color`. 
 no-backgound | `Boolean` | `false` | Removes background, except if styled by `backgound-color` option.
 no-icon | `Boolean` | `false` | Removes icon, except if icon is displayed via `icon` option.
-type | `String` | `'none'` | Supports: `info`, `warning`, `success`, `important`, `wrong`, `tip`, `definition`, or empty for default.
-light | `Boolean` | `false` | Uses a light color scheme for the box.
-seamless | `Boolean` | `false` | Uses a seamless style for the box. If `light` is specified, this style will not be activated.
+
 
 <span id="short" class="d-none">
 ```html

--- a/packages/vue-components/.eslintignore
+++ b/packages/vue-components/.eslintignore
@@ -28,4 +28,3 @@ src/Pic.vue
 src/Question.vue
 src/Retriever.vue
 src/Thumbnail.vue
-src/TipBox.vue

--- a/packages/vue-components/.eslintrc.js
+++ b/packages/vue-components/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
       },
     ],
     'max-len': ['error', { 'code': 110 }],
+    'no-underscore-dangle': 'off',
     'operator-linebreak': ['error', 'before'],
     'quote-props': 'off',
     'vue/html-self-closing': [

--- a/packages/vue-components/src/TipBox.vue
+++ b/packages/vue-components/src/TipBox.vue
@@ -1,221 +1,290 @@
 <template>
-    <div class="alert box-container" :class="[boxStyle, addClass, lightStyle, seamlessStyle, noBackgroundStyle, noBorderStyle]" :style="customStyle">
-        <div v-if="headerBool" :class="['box-header-wrapper', { 'alert-dismissible': dismissible }]">
-            <div v-show="hasIcon" class="icon-wrapper" :class="[iconStyle]">
-                <slot name="icon">
-                    <span v-html="iconType"></span>
-                </slot>
-            </div>
-            <div class="box-header">
-                <slot name="_header"></slot>
-            </div>
-            <button v-show="dismissible" type="button" class="close close-with-heading" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-        <div v-if="horizontalDividerBool" class="horizontal-divider" :class="boxStyle" aria-hidden="true"></div>
-        <div :class="['box-body-wrapper', { 'alert-dismissible': dismissible && !headerBool, 'box-body-wrapper-with-heading': headerBool }]">
-            <div v-show="hasIcon && !headerBool" class="icon-wrapper" :class="[iconStyle]">
-                <slot name="icon">
-                    <span v-html="iconType"></span>
-                </slot>
-            </div>
-            <div v-if="verticalDividerBool" class="vertical-divider" :class="boxStyle" aria-hidden="true"></div>
-            <div class="contents" :class="[fontBlack, seamlessStyle]">
-                <slot></slot>
-            </div>
-            <button v-show="dismissible && !headerBool" type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
+  <div :class="['alert box-container', containerStyle(), addClass]" :style="customStyle()">
+    <!-- Header wrapper, not rendered if there is no header attribute -->
+    <div v-if="headerBool()" :class="['box-header-wrapper', { 'alert-dismissible': dismissible }]">
+      <!-- icon on the left of the header -->
+      <div v-if="iconBool()" :class="['icon-wrapper', iconStyle()]">
+        <slot name="icon">
+          <i :class="['fas', getFontAwesomeIconStyle()]"></i>
+        </slot>
+      </div>
+
+      <!-- header -->
+      <div class="box-header">
+        <slot name="_header"></slot>
+      </div>
+
+      <!-- dismiss button to the right of the header -->
+      <button
+        v-if="dismissible"
+        type="button"
+        class="close close-with-heading"
+        data-dismiss="alert"
+        aria-label="Close"
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
     </div>
+
+    <!-- Header wrapper -- body wrapper divider for seamless boxes with the header attribute -->
+    <div
+      v-if="horizontalDividerBool()"
+      class="horizontal-divider"
+      :class="getBootstrapAlertStyle()"
+      aria-hidden="true"
+    ></div>
+
+    <!-- Body wrapper -->
+    <div
+      :class="[
+        'box-body-wrapper',
+        {
+          'alert-dismissible': dismissible && !headerBool(),
+          'box-body-wrapper-with-heading': headerBool()
+        }]"
+    >
+      <!-- icon on the left, not shown if there is a header -->
+      <div v-if="iconBool() && !headerBool()" :class="['icon-wrapper', iconStyle()]">
+        <slot name="icon">
+          <i :class="['fas', getFontAwesomeIconStyle()]"></i>
+        </slot>
+      </div>
+
+      <!-- Icon -- content divider for seamless boxes without the header attribute -->
+      <div
+        v-if="verticalDividerBool()"
+        class="vertical-divider"
+        :class="getBootstrapAlertStyle()"
+        aria-hidden="true"
+      ></div>
+
+      <!-- Content wrapper -->
+      <div class="contents" :style="customColorStyle()">
+        <slot></slot>
+      </div>
+
+      <!-- dismiss button on the right, not shown if there is a header -->
+      <button
+        v-if="dismissible && !headerBool()"
+        type="button"
+        class="close"
+        data-dismiss="alert"
+        aria-label="Close"
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  </div>
 </template>
 
 <script>
 
-  export default {
-    props: {
-      dismissible: {
-        type: Boolean,
-        default: false
-      },
-      backgroundColor: {
-        type: String,
-        default: null
-      },
-      borderColor: {
-        type: String,
-        default: null
-      },
-      borderLeftColor: {
-        type: String,
-        default: null
-      },
-      color: {
-        type: String,
-        default: null
-      },
-      icon: {
-        type: String,
-        default: null
-      },
-      iconSize: {
-        type: String,
-        default: null
-      },
-      type: {
-        type: String,
-        default: 'none'
-      },
-      addClass: {
-        type: String,
-        default: ''
-      },
-      light: {
-        type: Boolean,
-        default: false,
-      },
-      seamless: {
-        type: Boolean,
-        default: false,
-      },
-      noIcon: {
-        type: Boolean,
-        default: false,
-      },
-      noBackground: {
-        type: Boolean,
-        default: false,
-      },
-      noBorder: {
-        type: Boolean,
-        default: false,
+export default {
+  props: {
+    dismissible: {
+      type: Boolean,
+      default: false,
+    },
+    backgroundColor: {
+      type: String,
+      default: null,
+    },
+    borderColor: {
+      type: String,
+      default: null,
+    },
+    borderLeftColor: {
+      type: String,
+      default: null,
+    },
+    color: {
+      type: String,
+      default: null,
+    },
+    icon: {
+      type: String,
+      default: null,
+    },
+    iconSize: {
+      type: String,
+      default: null,
+    },
+    type: {
+      type: String,
+      default: '',
+    },
+    addClass: {
+      type: String,
+      default: '',
+    },
+    light: {
+      type: Boolean,
+      default: false,
+    },
+    seamless: {
+      type: Boolean,
+      default: false,
+    },
+    noIcon: {
+      type: Boolean,
+      default: false,
+    },
+    noBackground: {
+      type: Boolean,
+      default: false,
+    },
+    noBorder: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  methods: {
+    isSeamless() {
+      return !this.light && this.seamless;
+    },
+    verticalDividerBool() {
+      return this.isSeamless() && !this.headerBool();
+    },
+    horizontalDividerBool() {
+      return this.isSeamless() && this.headerBool();
+    },
+    headerBool() {
+      return !!this.$slots._header;
+    },
+    iconBool() {
+      // this.$slots.icon is either undefined or an object
+      const isIconSlotFilled = !!this.$slots.icon;
+      return (!this.noIcon && this.type) || isIconSlotFilled;
+    },
+    containerStyle() {
+      let containerStyle;
+
+      if (this.light) {
+        containerStyle = `${this.getBootstrapBorderStyle()} alert-border-left`;
+      } else if (this.seamless) {
+        containerStyle = 'seamless';
+      } else {
+        containerStyle = this.getBootstrapAlertStyle();
+      }
+
+      if (this.noBackground) {
+        containerStyle += ' no-background';
+      }
+
+      if (this.noBorder) {
+        containerStyle += ' no-border';
+      }
+
+      return containerStyle;
+    },
+    customStyle() {
+      const style = {};
+      if (this.backgroundColor) {
+        style.backgroundColor = this.backgroundColor;
+        style.borderColor = this.backgroundColor;
+      }
+      if (this.borderColor) {
+        style.border = `1px solid ${this.borderColor}`;
+      }
+      if (this.borderLeftColor) {
+        style.borderLeft = `5px solid ${this.borderLeftColor}`;
+      }
+      return style;
+    },
+    customColorStyle() {
+      if (this.color) {
+        return { color: this.color };
+      }
+      return {};
+    },
+    iconStyle() {
+      let iconStyle = '';
+      if (this.iconSize) {
+        iconStyle += `fa-${this.iconSize}`;
+      }
+
+      if (this.light || this.seamless) {
+        iconStyle += ` ${this.getBootstrapTextStyle()}`;
+      }
+
+      return iconStyle;
+    },
+    getBootstrapAlertStyle() {
+      switch (this.type) {
+      case 'warning':
+        return 'alert-warning';
+      case 'info':
+        return 'alert-info';
+      case 'definition':
+        return 'alert-primary';
+      case 'success':
+      case 'tip':
+        return 'alert-success';
+      case 'important':
+      case 'wrong':
+        return 'alert-danger';
+      default:
+        return 'alert-default';
       }
     },
-    computed: {
-      isSeamless() {
-        return !this.light && this.seamless;
-      },
-      verticalDividerBool() {
-        return this.isSeamless && !this.headerBool;
-      },
-      horizontalDividerBool() {
-          return this.isSeamless && this.headerBool;
-      },
-      headerBool() {
-        return !!this.$slots._header;
-      },
-      boxStyle() {
-        switch (this.type) {
-          case 'warning':
-            return 'alert-warning'
-          case 'info':
-          case 'definition':
-            return 'alert-info'
-          case 'success':
-          case 'tip':
-            return 'alert-success'
-          case 'important':
-          case 'wrong':
-            return 'alert-danger'
-          default:
-            return 'alert-default'
-        }
-      },
-      lightStyle() {
-        if (this.light) {
-          switch (this.type) {
-            case 'warning':
-              return 'border-warning text-warning alert-border-left';
-            case 'info':
-            case 'definition':
-              return 'border-info text-info alert-border-left';
-            case 'success':
-            case 'tip':
-              return 'border-success text-success alert-border-left';
-            case 'important':
-            case 'wrong':
-              return 'border-danger text-danger alert-border-left';
-            default:
-              return 'alert-border-left';
-          }
-        }
-        return '';
-      },
-      customStyle() {
-        var style = {};
-        if (this.backgroundColor) {
-          style.backgroundColor = this.backgroundColor;
-          style.borderColor = this.backgroundColor;
-        }
-        if (this.borderColor) {
-          style.border = `1px solid ${this.borderColor}`;
-        }
-        if (this.borderLeftColor) {
-          style.borderLeft = `5px solid ${this.borderLeftColor}`;
-        }
-        if (this.color) {
-          style.color = this.color;
-        }
-        return style;
-      },
-      seamlessStyle() {
-        if (this.isSeamless) {
-          return 'seamless';
-        }
-        return '';
-      },
-      fontBlack() {
-        if (this.light) {
-          return 'font-black';
-        }
-        return '';
-      },
-      hasIcon() {
-        // this.$slots.icon is either undefined or an object
-        const isIconSlotFilled = !!this.$slots.icon;
-        return !this.noIcon || isIconSlotFilled;
-      },
-      iconType() {
-        switch (this.type) {
-          case 'wrong':
-            return '<i class="fas fa-times"></i>';
-          case 'warning':
-            return '<i class="fas fa-exclamation"></i>';
-          case 'info':
-            return '<i class="fas fa-info"></i>';
-          case 'success':
-            return '<i class="fas fa-check"></i>';
-          case 'important':
-            return '<i class="fas fa-flag"></i>';
-          case 'tip':
-            return '<i class="fas fa-lightbulb"></i>';
-          case 'definition':
-            return '<i class="fas fa-atlas"></i>';
-          default:
-            return '';
-        }
-      },
-      iconStyle() {
-        if (this.iconSize) {
-          return `fa-${this.iconSize}`;
-        }
-        return '';
-      },
-      noBackgroundStyle() {
-        if (this.noBackground) {
-          return 'no-background';
-        }
-        return '';
-      },
-      noBorderStyle() {
-        if (this.noBorder) {
-          return 'no-border';
-        }
+    getBootstrapTextStyle() {
+      switch (this.type) {
+      case 'warning':
+        return 'text-warning';
+      case 'info':
+        return 'text-info';
+      case 'definition':
+        return 'text-primary';
+      case 'success':
+      case 'tip':
+        return 'text-success';
+      case 'important':
+      case 'wrong':
+        return 'text-danger';
+      default:
         return '';
       }
-    }
-  }
+    },
+    getBootstrapBorderStyle() {
+      switch (this.type) {
+      case 'warning':
+        return 'border-warning';
+      case 'info':
+        return 'border-info';
+      case 'definition':
+        return 'border-primary';
+      case 'success':
+      case 'tip':
+        return 'border-success';
+      case 'important':
+      case 'wrong':
+        return 'border-danger';
+      default:
+        return '';
+      }
+    },
+    getFontAwesomeIconStyle() {
+      switch (this.type) {
+      case 'wrong':
+        return 'fa-times';
+      case 'warning':
+        return 'fa-exclamation';
+      case 'info':
+        return 'fa-info';
+      case 'success':
+        return 'fa-check';
+      case 'important':
+        return 'fa-flag';
+      case 'tip':
+        return 'fa-lightbulb';
+      case 'definition':
+        return 'fa-atlas';
+      default:
+        return '';
+      }
+    },
+  },
+};
 </script>
 
 <style scoped>
@@ -230,7 +299,7 @@
         flex-direction: row;
         align-items: center;
         width: 100%;
-        padding: 0.28em 1.25rem;
+        padding: 0.4rem 1.25rem 0.28rem 1.25rem;
         border-radius: 6px 6px 0 0;
     }
 
@@ -245,9 +314,8 @@
         padding: 0.75rem 0.5rem;
     }
 
-    .box-container.seamless {
-        background-color: transparent;
-        border-color: transparent;
+    .box-container.seamless > div.box-body-wrapper > .contents {
+        padding-left: 12px;
     }
 
     .heading {
@@ -276,9 +344,9 @@
     }
 
     .icon-wrapper {
-        display: flex;
-        justify-content: center;
-        margin-right: .5em;
+        display: inline;
+        text-align: center;
+        margin-right: 0.5em;
         min-width: 1em;
     }
 
@@ -296,10 +364,6 @@
         width: 100%;
     }
 
-    .contents.seamless {
-        padding-left: 12px;
-    }
-
     .contents > :last-child {
         margin-bottom: 0;
     }
@@ -314,10 +378,6 @@
         background-color: #f9f8f8;
         border-left: solid;
         border-width: 0px 0px 0px 5px;
-    }
-
-    .font-black {
-        color: #24292e;
     }
 
     .vertical-divider {

--- a/packages/vue-components/src/__tests__/__snapshots__/TipBox.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/TipBox.spec.js.snap
@@ -12,11 +12,7 @@ exports[`TipBox having custom background color renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -24,19 +20,7 @@ exports[`TipBox having custom background color renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -53,11 +37,7 @@ exports[`TipBox having custom border color renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -65,19 +45,7 @@ exports[`TipBox having custom border color renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -94,11 +62,7 @@ exports[`TipBox having custom border left color renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -106,19 +70,7 @@ exports[`TipBox having custom border left color renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -134,11 +86,7 @@ exports[`TipBox of default type with content renders correctly  1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -148,26 +96,14 @@ exports[`TipBox of default type with content renders correctly  1`] = `
       This is the default box
     </div>
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of definition type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-info border-info text-info alert-border-left"
+  class="alert box-container border-primary alert-border-left"
 >
   <!---->
    
@@ -177,57 +113,11 @@ exports[`TipBox of definition type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-primary"
     >
-      <span>
-        <i
-          class="fas fa-atlas"
-        />
-      </span>
-    </div>
-     
-    <!---->
-     
-    <div
-      class="contents font-black"
-    />
-     
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
-  </div>
-</div>
-`;
-
-exports[`TipBox of definition type renders correctly 1`] = `
-<div
-  class="alert box-container alert-info"
->
-  <!---->
-   
-  <!---->
-   
-  <div
-    class="box-body-wrapper"
-  >
-    <div
-      class="icon-wrapper"
-    >
-      <span>
-        <i
-          class="fas fa-atlas"
-        />
-      </span>
+      <i
+        class="fas fa-atlas"
+      />
     </div>
      
     <!---->
@@ -236,26 +126,14 @@ exports[`TipBox of definition type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
-exports[`TipBox of important type light style renders correctly 1`] = `
+exports[`TipBox of definition type renders correctly 1`] = `
 <div
-  class="alert box-container alert-danger border-danger text-danger alert-border-left"
+  class="alert box-container alert-primary"
 >
   <!---->
    
@@ -267,32 +145,48 @@ exports[`TipBox of important type light style renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-flag"
-        />
-      </span>
+      <i
+        class="fas fa-atlas"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`TipBox of important type light style renders correctly 1`] = `
+<div
+  class="alert box-container border-danger alert-border-left"
+>
+  <!---->
+   
+  <!---->
+   
+  <div
+    class="box-body-wrapper"
+  >
+    <div
+      class="icon-wrapper  text-danger"
     >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+      <i
+        class="fas fa-flag"
+      />
+    </div>
+     
+    <!---->
+     
+    <div
+      class="contents"
+    />
+     
+    <!---->
   </div>
 </div>
 `;
@@ -311,11 +205,9 @@ exports[`TipBox of important type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-flag"
-        />
-      </span>
+      <i
+        class="fas fa-flag"
+      />
     </div>
      
     <!---->
@@ -324,26 +216,14 @@ exports[`TipBox of important type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of info type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-info border-info text-info alert-border-left"
+  class="alert box-container border-info alert-border-left"
 >
   <!---->
    
@@ -353,34 +233,20 @@ exports[`TipBox of info type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-info"
     >
-      <span>
-        <i
-          class="fas fa-info"
-        />
-      </span>
+      <i
+        class="fas fa-info"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -399,11 +265,9 @@ exports[`TipBox of info type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-info"
-        />
-      </span>
+      <i
+        class="fas fa-info"
+      />
     </div>
      
     <!---->
@@ -412,26 +276,14 @@ exports[`TipBox of info type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of seamless style renders correctly 1`] = `
 <div
-  class="alert box-container alert-default seamless"
+  class="alert box-container seamless"
 >
   <!---->
    
@@ -440,11 +292,7 @@ exports[`TipBox of seamless style renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <div
       aria-hidden="true"
@@ -452,29 +300,17 @@ exports[`TipBox of seamless style renders correctly 1`] = `
     />
      
     <div
-      class="contents seamless"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of success type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-success border-success text-success alert-border-left"
+  class="alert box-container border-success alert-border-left"
 >
   <!---->
    
@@ -484,34 +320,20 @@ exports[`TipBox of success type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-success"
     >
-      <span>
-        <i
-          class="fas fa-check"
-        />
-      </span>
+      <i
+        class="fas fa-check"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -530,11 +352,9 @@ exports[`TipBox of success type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-check"
-        />
-      </span>
+      <i
+        class="fas fa-check"
+      />
     </div>
      
     <!---->
@@ -543,26 +363,14 @@ exports[`TipBox of success type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of tip type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-success border-success text-success alert-border-left"
+  class="alert box-container border-success alert-border-left"
 >
   <!---->
    
@@ -572,34 +380,20 @@ exports[`TipBox of tip type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-success"
     >
-      <span>
-        <i
-          class="fas fa-lightbulb"
-        />
-      </span>
+      <i
+        class="fas fa-lightbulb"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -618,11 +412,9 @@ exports[`TipBox of tip type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-lightbulb"
-        />
-      </span>
+      <i
+        class="fas fa-lightbulb"
+      />
     </div>
      
     <!---->
@@ -631,26 +423,14 @@ exports[`TipBox of tip type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of warning type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-warning border-warning text-warning alert-border-left"
+  class="alert box-container border-warning alert-border-left"
 >
   <!---->
    
@@ -660,34 +440,20 @@ exports[`TipBox of warning type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-warning"
     >
-      <span>
-        <i
-          class="fas fa-exclamation"
-        />
-      </span>
+      <i
+        class="fas fa-exclamation"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -706,11 +472,9 @@ exports[`TipBox of warning type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-exclamation"
-        />
-      </span>
+      <i
+        class="fas fa-exclamation"
+      />
     </div>
      
     <!---->
@@ -719,26 +483,14 @@ exports[`TipBox of warning type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
 
 exports[`TipBox of wrong type light style renders correctly 1`] = `
 <div
-  class="alert box-container alert-danger border-danger text-danger alert-border-left"
+  class="alert box-container border-danger alert-border-left"
 >
   <!---->
    
@@ -748,34 +500,20 @@ exports[`TipBox of wrong type light style renders correctly 1`] = `
     class="box-body-wrapper"
   >
     <div
-      class="icon-wrapper"
+      class="icon-wrapper  text-danger"
     >
-      <span>
-        <i
-          class="fas fa-times"
-        />
-      </span>
+      <i
+        class="fas fa-times"
+      />
     </div>
      
     <!---->
      
     <div
-      class="contents font-black"
+      class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -794,11 +532,9 @@ exports[`TipBox of wrong type renders correctly 1`] = `
     <div
       class="icon-wrapper"
     >
-      <span>
-        <i
-          class="fas fa-times"
-        />
-      </span>
+      <i
+        class="fas fa-times"
+      />
     </div>
      
     <!---->
@@ -807,19 +543,7 @@ exports[`TipBox of wrong type renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -827,7 +551,6 @@ exports[`TipBox of wrong type renders correctly 1`] = `
 exports[`TipBox with custom color renders correctly 1`] = `
 <div
   class="alert box-container alert-default"
-  style="color: pink;"
 >
   <!---->
    
@@ -836,31 +559,16 @@ exports[`TipBox with custom color renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
     <div
       class="contents"
+      style="color: pink;"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -876,11 +584,7 @@ exports[`TipBox with dismissible option renders correctly 1`] = `
   <div
     class="box-body-wrapper alert-dismissible"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -911,11 +615,7 @@ exports[`TipBox with header renders correctly 1`] = `
   <div
     class="box-header-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <div
       class="box-header"
@@ -923,19 +623,7 @@ exports[`TipBox with header renders correctly 1`] = `
       A header
     </div>
      
-    <button
-      aria-label="Close"
-      class="close close-with-heading"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
    
   <!---->
@@ -943,12 +631,7 @@ exports[`TipBox with header renders correctly 1`] = `
   <div
     class="box-body-wrapper box-body-wrapper-with-heading"
   >
-    <div
-      class="icon-wrapper"
-      style="display: none;"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -956,19 +639,7 @@ exports[`TipBox with header renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -996,19 +667,7 @@ exports[`TipBox with icon and icon-size renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -1036,19 +695,7 @@ exports[`TipBox with icon renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -1064,11 +711,7 @@ exports[`TipBox with no-background option renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -1076,19 +719,7 @@ exports[`TipBox with no-background option renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -1104,11 +735,7 @@ exports[`TipBox with no-border option renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-    >
-      <span />
-    </div>
+    <!---->
      
     <!---->
      
@@ -1116,19 +743,7 @@ exports[`TipBox with no-border option renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;
@@ -1144,16 +759,7 @@ exports[`TipBox with no-icon option renders correctly 1`] = `
   <div
     class="box-body-wrapper"
   >
-    <div
-      class="icon-wrapper"
-      style="display: none;"
-    >
-      <span>
-        <i
-          class="fas fa-check"
-        />
-      </span>
-    </div>
+    <!---->
      
     <!---->
      
@@ -1161,19 +767,7 @@ exports[`TipBox with no-icon option renders correctly 1`] = `
       class="contents"
     />
      
-    <button
-      aria-label="Close"
-      class="close"
-      data-dismiss="alert"
-      style="display: none;"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-      >
-        ×
-      </span>
-    </button>
+    <!---->
   </div>
 </div>
 `;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update
• [x] Bug fix
• [x] Enhancement to an existing feature
• [x] Other, please explain: code ~refactor~ revamp

Fixes #538 
Fixes #1233 
Fixes #1234 


**What is the rationale for this request?**
This started as a code refactor to remove cascaded styling for our numerous box styles which introduces a lot of coupling / redundant classes (see commit message).
In doing so, it was almost entirely rewritten, so I tackled some other minor issues as well.

**What changes did you make? (Give an overview)**
Refer to commit message for details:
- revamp box code
- tweak box styling
- enable linting for it
- give the docs some more style variations

**Is there anything you'd like reviewers to focus on?**
I suggest simply going to the past code and observing the coupling between the cascaded classes (some even redundant), and checking out the new one to see if it is satisfactory since it's almost a rewrite

need an opinion on the 2nd (`primary` coloring for `definition` boxes) and 4th (https://github.com/MarkBind/markbind/issues/987#issuecomment-579621614 - lighter colors for seamless boxes) style tweaks, not sure if it was an intentional design choice @damithc 

**Testing instructions:**
- everything in the docs (added more variations as well) displays as is before, save for the styling tweaks mentioned below

**Proposed commit message: (wrap lines at 72 characters)**
```
Tweak box styles and revamp box code

The box component has numerous possible styles which relies heavily on
highly cascaded classes' styles.
This introduces a high degree of coupling between the classes. Also, as
a result of the cascading, some classes are rendered but completely
overwritten by others, making them redundant.

Let's revamp the box template and code to fix this.
We centralize the dynamic styles of each element into computed
properties, and extract helper methods to make these computed
properties as lean as possible.

Also, the component was already heavily rewritten prior to this. Hence,
let's remove it from the eslint ignore list to achieve consistent code
styling.

While revamping the code, let's tweak the box styles a little as well:
- Add some more padding for the header wrapper to better accomodate
markdown taking up a lot of space.
- Use the bootstrap 'primary' coloring for definition type boxes,
providing better visual diversity.
- Separate the applying of colors to the content wrapper and icon
wrapper. In so doing, the color attribute applies only to the content
(#1234), and seamless boxes' content correctly inherit color (#1233).
- Use the lighter `text-xx` bootstrap classes for seamless boxes'
coloring instead which are more suitable against a common white
background than the overly dark `alert-xx` classes.
```