### PR TITLE
Remove code fence wrap on hovering

### DIFF
--- a/packages/core/asset/css/markbind.css
+++ b/packages/core/asset/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site/expected/markbind/css/markbind.css
+++ b/test/functional/test_site/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_algolia_plugin/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_convert/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_convert/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_expressive_layout/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_special_tags/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_default/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }

--- a/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
+++ b/test/functional/test_site_templates/test_minimal/expected/markbind/css/markbind.css
@@ -84,10 +84,6 @@ code.hljs.inline {
     padding: 0;
 }
 
-code.hljs:hover {
-    white-space: pre-wrap;
-}
-
 .markbind-table {
     width: auto;
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix https://github.com/MarkBind/markbind/issues/1179

**What changes did you make? (Give an overview)**
- remove the pseudo class causing the wrap

**Proposed commit message: (wrap lines at 72 characters)**
Remove code fence wrap on hovering