### PR TITLE
Hide check button for legacy answerless questions

### DIFF
--- a/packages/vue-components/src/__tests__/__snapshots__/Questions.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/Questions.spec.js.snap
@@ -2039,14 +2039,7 @@ exports[`Text Questions of unanswered with shown hint, header without answer ren
       >
         <!---->
          
-        <button
-          class="btn btn-primary q-btn ml-1"
-          type="button"
-        >
-          
-          Check
-        
-        </button>
+        <!---->
          
         <!---->
          

--- a/packages/vue-components/src/questions/Question.vue
+++ b/packages/vue-components/src/questions/Question.vue
@@ -85,8 +85,9 @@
           >
             Hint
           </button>
+          <!-- Gracefully deprecate invalid question types without answers -->
           <button
-            v-if="qState.state === 0"
+            v-if="qState.state === 0 && !(!isValidTypeAndNotTextWithoutKeywords() && !$slots.answer)"
             key="check"
             type="button"
             class="btn btn-primary q-btn ml-1"


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #1293 

**What changes did you make? (Give an overview)**

Hide check button for legacy answerless questions



**Testing instructions:**
```
<question>
answer text
<template slot="hint">
some  hint
</template>
</question>
```

- no longer shows the check button for answerless questions correctly

- one preexisting snapshot test, which is a `text` type question without an answer & keywords now also hides the button


**Proposed commit message: (wrap lines at 72 characters)**
Hide check button for legacy answerless questions
