### PR TITLE
Use es6 default export for vue-components

### DIFF
--- a/packages/cli/test/functional/test_site/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_convert/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_convert/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_expressive_layout/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_expressive_layout/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_special_tags/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_special_tags/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/cli/test/functional/test_site_templates/test_minimal/expected/markbind/js/setup.js
+++ b/packages/cli/test/functional/test_site_templates/test_minimal/expected/markbind/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/core/asset/js/setup.js
+++ b/packages/core/asset/js/setup.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 
-Vue.use(MarkBindVue);
+Vue.use(MarkBindVue.default);
 
 function scrollToUrlAnchorHeading() {
   if (window.location.hash) {
@@ -113,13 +113,9 @@ function setup() {
 }
 
 function setupWithSearch() {
-  const { searchbar } = MarkBindVue.components;
   // eslint-disable-next-line no-unused-vars
   const vm = new Vue({
     el: '#app',
-    components: {
-      searchbar,
-    },
     data() {
       return {
         searchData: [],

--- a/packages/vue-components/src/index.js
+++ b/packages/vue-components/src/index.js
@@ -61,4 +61,4 @@ Object.keys(components).forEach((key) => {
   MarkBindVue.components[key] = components[key]
 })
 
-module.exports = MarkBindVue
+export default MarkBindVue;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: export syntax standardisation

**What changes did you make? (Give an overview)**
Changed the entry point export in vue-components

**Testing instructions:**
na

**Proposed commit message: (wrap lines at 72 characters)**
Use es6 default export for vue-components