### PR TITLE
Add 'vue' to vue-components externals

### DIFF
--- a/packages/vue-components/webpack.common.js
+++ b/packages/vue-components/webpack.common.js
@@ -8,6 +8,9 @@ module.exports = {
     library: 'MarkBindVue',
     libraryTarget: 'umd',
   },
+  externals: {
+    vue: 'Vue',
+  },
   resolve: {
     modules: [path.resolve(__dirname), 'node_modules'],
   },


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain:

Follow up to #1300, resulting in total savings of ~250kb.

**Proposed commit message: (wrap lines at 72 characters)**
Add 'vue' to vue-components externals

Bootstrap-vue imports the vue library in its source code, causing vue
to also be included in the vue-components bundle.

Let's add it to the webpack externals config, resulting in further
savings of 70kb + 180kb over using the full bootstrap-vue bundle.
