### PR TITLE
Fix user guide b-btn usage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@
 Optimized for creating text-heavy websites %%e.g., eLearning websites, online instruction manuals, project documentation etc.%%.
 </span>
 
-<b-btn variant="primary" href="userGuide/">Get Started</b-btn>
+<a class="btn btn-primary" href="userGuide/">Get Started</a>
 
 <hr>
 
@@ -167,7 +167,7 @@ Installing MarkBind takes just one command. Creating a new MarkBind site too tak
 
 As MarkBind is also optimized for project documentation, it can easily [integrate with the workflow of a software project](userGuide/markBindInTheProjectWorkflow.html).
 
-<b-btn variant="primary" href="userGuide/">Get Started</b-btn>
+<a class="btn btn-primary" href="userGuide/">Get Started</a>
 
 </div>
 

--- a/docs/njk/common.njk
+++ b/docs/njk/common.njk
@@ -1,10 +1,10 @@
 {% macro previous_next(previous_page, next_page) %}
 <div class="clearfix">
 {% if previous_page != ''%}
-<span class="float-left"><b-btn variant="light" href="{{ baseUrl }}/userGuide/{{ previous_page }}.html"><md>:far-arrow-alt-circle-left: <include src="{{ previous_page }}.md#title" inline /></md></b-btn></span>
+<span class="float-left"><a class="btn btn-light" href="{{ baseUrl }}/userGuide/{{ previous_page }}.html"><md>:far-arrow-alt-circle-left: <include src="{{ previous_page }}.md#title" inline /></md></a></span>
 {% endif %}
 {% if next_page != ''%}
-<span class="float-right"><b-btn variant="light" href="{{ baseUrl }}/userGuide/{{ next_page }}.html"><md><include src="{{ next_page }}.md#title" inline /> :far-arrow-alt-circle-right:</md></b-btn></span>
+<span class="float-right"><a class="btn btn-light" href="{{ baseUrl }}/userGuide/{{ next_page }}.html"><md><include src="{{ next_page }}.md#title" inline /> :far-arrow-alt-circle-right:</md></a></span>
 {% endif %}
 </div>
 <br>


### PR DESCRIPTION
With bootstrap-vue tree shaken, b-btn components no longer work.

Let's change the user guide's buttons to simple anchor tags accordingly.

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Documentation update

Follow up to #1300 

**What is the rationale for this request?**
Our link-buttons currently use bootstrap vue's `b-btn`. With this removed, let's just use simple anchor tags instead.

**Proposed commit message: (wrap lines at 72 characters)**
Fix user guide b-btn usage