### PR TITLE
Use markdown-it-footnotes source instead of bundle

### DIFF
--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -167,10 +167,10 @@
           <p><strong>Test footnotes</strong></p>
           <div>
             <p><strong>Normal footnotes:</strong>
-              Here is a footnote reference,<span for="pop:footnote1" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote1'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote1" id="footnoteref1">[1]</a></sup></span> and another.<span for="pop:footnote2" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote2'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote2" id="footnoteref2">[2]</a></sup></span></p>
-            <p>Here is a repeated footnote to <span for="pop:footnote1" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote1'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote1" id="footnoteref1:1">[1]</a></sup></span></p>
+              Here is a footnote reference,<span for="pop:footnote1" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote1'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn1" id="fnref1">[1]</a></sup></span> and another.<span for="pop:footnote2" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote2'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn2" id="fnref2">[2]</a></sup></span></p>
+            <p>Here is a repeated footnote to <span for="pop:footnote1" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote1'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn1" id="fnref1:1">[1:1]</a></sup></span></p>
             <p><strong>Inline footnotes:</strong>
-              Here is an inline note.<span for="pop:footnote3" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote3'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote3" id="footnoteref3">[3]</a></sup></span></p>
+              Here is an inline note.<span for="pop:footnote3" v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['pop:footnote3'].show()" class="trigger"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn3" id="fnref3">[3]</a></sup></span></p>
           </div>
           <p><strong>Json Variable</strong></p>
           <div> front back </div>
@@ -669,15 +669,15 @@
         <hr class="footnotes-sep">
         <section class="footnotes">
           <ol class="footnotes-list">
-            <li id="footnote1" class="footnote-item">
+            <li id="fn1" class="footnote-item">
               <p>Here is the footnote. Footnotes will appear at the bottom of the page.</p>
             </li>
-            <li id="footnote2" class="footnote-item">
+            <li id="fn2" class="footnote-item">
               <p>Here's one with multiple blocks.</p>
               <p>Subsequent paragraphs are indented to show that they
                 belong to the previous footnote.</p>
             </li>
-            <li id="footnote3" class="footnote-item">
+            <li id="fn3" class="footnote-item">
               <p>Inlines notes are easier to write, since
                 you don't have to pick an identifier and move down to type the
                 note.</p>

--- a/packages/core/src/lib/markdown-it/markdown-it-footnotes.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-footnotes.js
@@ -1,373 +1,412 @@
-/**
- * Modified from https://github.com/revin/markdown-it-task-lists/blob/master/index.js, 3.0.1
+/*
+ Copyright (c) 2014-2015 Vitaly Puzrin, Alex Kocharin
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/*!https://github.com//markdown-it/markdown-it-footnote @license MIT */(function (f) { if (typeof exports === 'object' && typeof module !== 'undefined') { module.exports = f(); } else if (typeof define === 'function' && define.amd) { define([], f); } else { let g; if (typeof window !== 'undefined') { g = window; } else if (typeof global !== 'undefined') { g = global; } else if (typeof self !== 'undefined') { g = self; } else { g = this; }g.markdownitFootnote = f(); } }(() => {
-  let define; let module; let exports; return (function e(t, n, r) { function s(o, u) { if (!n[o]) { if (!t[o]) { const a = typeof require === 'function' && require; if (!u && a) return a(o, !0); if (i) return i(o, !0); const f = new Error(`Cannot find module '${o}'`); throw f.code = 'MODULE_NOT_FOUND', f; } const l = n[o] = { exports: {} }; t[o][0].call(l.exports, (e) => { const n = t[o][1][e]; return s(n || e); }, l, l.exports, e, t, n, r); } return n[o].exports; } var i = typeof require === 'function' && require; for (let o = 0; o < r.length; o++)s(r[o]); return s; }({
-    1: [
-      function (require, module, exports) {
-        // Process footnotes
-        //
+/*
+ Markdown-it-footnotes plugin 3.0.2 source adapted to fit MarkBind's needs, to:
+ - show a popover along with the footnote link
+ - remove footnote backreferences
+
+ Changes are delimited with a // CHANGE HERE comment
+ */
+
+// Process footnotes
+//
+'use strict';
+
+////////////////////////////////////////////////////////////////////////////////
+// Renderer partials
+
+function render_footnote_anchor_name(tokens, idx, options, env/*, slf*/) {
+  var n = Number(tokens[idx].meta.id + 1).toString();
+  var prefix = '';
+
+  if (typeof env.docId === 'string') {
+    prefix = '-' + env.docId + '-';
+  }
+
+  return prefix + n;
+}
+
+function render_footnote_caption(tokens, idx/*, options, env, slf*/) {
+  var n = Number(tokens[idx].meta.id + 1).toString();
+
+  if (tokens[idx].meta.subId > 0) {
+    n += ':' + tokens[idx].meta.subId;
+  }
+
+  return '[' + n + ']';
+}
+
+function render_footnote_ref(tokens, idx, options, env, slf) {
+  var id      = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+  var caption = slf.rules.footnote_caption(tokens, idx, options, env, slf);
+  var refid   = id;
+
+  if (tokens[idx].meta.subId > 0) {
+    refid += ':' + tokens[idx].meta.subId;
+  }
+
+  // CHANGE here
+  // Old code:
+  // return '<sup class="footnote-ref"><a href="#fn' + id + '" id="fnref' + refid + '">' + caption + '</a></sup>';
+  // Additions: <trigger> for footnote popover and aria-describedby label
+  return '<trigger for="pop:footnote' + id + '"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn' + id
+    + '" id="fnref' + refid + '">'
+    + caption
+    + '</a></sup></trigger>'
+}
+
+function render_footnote_block_open(tokens, idx, options) {
+  return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
+    '<section class="footnotes">\n' +
+    '<ol class="footnotes-list">\n';
+}
+
+function render_footnote_block_close() {
+  return '</ol>\n</section>\n';
+}
+
+function render_footnote_open(tokens, idx, options, env, slf) {
+  var id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+
+  if (tokens[idx].meta.subId > 0) {
+    id += ':' + tokens[idx].meta.subId;
+  }
+
+  return '<li id="fn' + id + '" class="footnote-item">';
+}
+
+function render_footnote_close() {
+  return '</li>\n';
+}
+
+function render_footnote_anchor(tokens, idx, options, env, slf) {
+  var id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
+
+  if (tokens[idx].meta.subId > 0) {
+    id += ':' + tokens[idx].meta.subId;
+  }
+
+  // CHANGE HERE
+  // Below line adds backreferences, but doesn't work well with panels, so disabled for now.
+  // Old code:
+  // /* ↩ with escape code to prevent display as Apple Emoji on iOS */
+  // return ' <a href="#fnref' + id + '" class="footnote-backref">\u21a9\uFE0E</a>';
+
+  return '';
+}
 
 
-        // //////////////////////////////////////////////////////////////////////////////
-        // Renderer partials
+module.exports = function footnote_plugin(md) {
+  var parseLinkLabel = md.helpers.parseLinkLabel,
+    isSpace = md.utils.isSpace;
 
-        function render_footnote_anchor_name(tokens, idx, options, env/* , slf */) {
-          const n = Number(tokens[idx].meta.id + 1).toString();
-          let prefix = '';
+  md.renderer.rules.footnote_ref          = render_footnote_ref;
+  md.renderer.rules.footnote_block_open   = render_footnote_block_open;
+  md.renderer.rules.footnote_block_close  = render_footnote_block_close;
+  md.renderer.rules.footnote_open         = render_footnote_open;
+  md.renderer.rules.footnote_close        = render_footnote_close;
+  md.renderer.rules.footnote_anchor       = render_footnote_anchor;
 
-          if (typeof env.docId === 'string') {
-            prefix = `-${env.docId}-`;
-          }
+  // helpers (only used in other rules, no tokens are attached to those)
+  md.renderer.rules.footnote_caption      = render_footnote_caption;
+  md.renderer.rules.footnote_anchor_name  = render_footnote_anchor_name;
 
-          return prefix + n;
+  // Process footnote block definition
+  function footnote_def(state, startLine, endLine, silent) {
+    var oldBMark, oldTShift, oldSCount, oldParentType, pos, label, token,
+      initial, offset, ch, posAfterColon,
+      start = state.bMarks[startLine] + state.tShift[startLine],
+      max = state.eMarks[startLine];
+
+    // line should be at least 5 chars - "[^x]:"
+    if (start + 4 > max) { return false; }
+
+    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+    for (pos = start + 2; pos < max; pos++) {
+      if (state.src.charCodeAt(pos) === 0x20) { return false; }
+      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+        break;
+      }
+    }
+
+    if (pos === start + 2) { return false; } // no empty footnote labels
+    if (pos + 1 >= max || state.src.charCodeAt(++pos) !== 0x3A /* : */) { return false; }
+    if (silent) { return true; }
+    pos++;
+
+    if (!state.env.footnotes) { state.env.footnotes = {}; }
+    if (!state.env.footnotes.refs) { state.env.footnotes.refs = {}; }
+    label = state.src.slice(start + 2, pos - 2);
+    state.env.footnotes.refs[':' + label] = -1;
+
+    token       = new state.Token('footnote_reference_open', '', 1);
+    token.meta  = { label: label };
+    token.level = state.level++;
+    state.tokens.push(token);
+
+    oldBMark = state.bMarks[startLine];
+    oldTShift = state.tShift[startLine];
+    oldSCount = state.sCount[startLine];
+    oldParentType = state.parentType;
+
+    posAfterColon = pos;
+    initial = offset = state.sCount[startLine] + pos - (state.bMarks[startLine] + state.tShift[startLine]);
+
+    while (pos < max) {
+      ch = state.src.charCodeAt(pos);
+
+      if (isSpace(ch)) {
+        if (ch === 0x09) {
+          offset += 4 - offset % 4;
+        } else {
+          offset++;
         }
-
-        function render_footnote_caption(tokens, idx/* , options, env, slf */) {
-          let n = Number(tokens[idx].meta.id + 1).toString();
-
-          return `[${n}]`;
-        }
-
-        function render_footnote_ref(tokens, idx, options, env, slf) {
-          const id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-          const caption = slf.rules.footnote_caption(tokens, idx, options, env, slf);
-          let refid = id;
-
-          if (tokens[idx].meta.subId > 0) {
-            refid += `:${tokens[idx].meta.subId}`;
-          }
-
-          return `<trigger for="pop:footnote${id}"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#footnote${id}" id="footnoteref${refid}">${caption}</a></sup></trigger>`;
-        }
-
-        function render_footnote_block_open(tokens, idx, options) {
-          return `${options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n'
-              }<section class="footnotes">\n`
-            + '<ol class="footnotes-list">\n';
-        }
-
-        function render_footnote_block_close() {
-          return '</ol>\n</section>\n';
-        }
-
-        function render_footnote_open(tokens, idx, options, env, slf) {
-          let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-
-          if (tokens[idx].meta.subId > 0) {
-            id += `:${tokens[idx].meta.subId}`;
-          }
-
-          return `<li id="footnote${id}" class="footnote-item">`;
-        }
-
-        function render_footnote_close() {
-          return '</li>\n';
-        }
-
-        function render_footnote_anchor(tokens, idx, options, env, slf) {
-          let id = slf.rules.footnote_anchor_name(tokens, idx, options, env, slf);
-
-          if (tokens[idx].meta.subId > 0) {
-            id += `:${tokens[idx].meta.subId}`;
-          }
-
-          return '';
-          // Below line adds backreferences, but doesn't work well with panels, so disabled for now.
-          /* â†© with escape code to prevent display as Apple Emoji on iOS */
-          // return ` <a aria-label='Back to content' href='#footnoteref${id}' class='footnote-backref'>[${id}]</a>`;
-        }
-
-
-        module.exports = function footnote_plugin(md) {
-          const { parseLinkLabel } = md.helpers;
-          const { isSpace } = md.utils;
-
-          md.renderer.rules.footnote_ref = render_footnote_ref;
-          md.renderer.rules.footnote_block_open = render_footnote_block_open;
-          md.renderer.rules.footnote_block_close = render_footnote_block_close;
-          md.renderer.rules.footnote_open = render_footnote_open;
-          md.renderer.rules.footnote_close = render_footnote_close;
-          md.renderer.rules.footnote_anchor = render_footnote_anchor;
-
-          // helpers (only used in other rules, no tokens are attached to those)
-          md.renderer.rules.footnote_caption = render_footnote_caption;
-          md.renderer.rules.footnote_anchor_name = render_footnote_anchor_name;
-
-          // Process footnote block definition
-          function footnote_def(state, startLine, endLine, silent) {
-            let oldBMark; let oldTShift; let oldSCount; let oldParentType; let pos; let label; let token;
-            let initial; let offset; let ch; let posAfterColon;
-            const start = state.bMarks[startLine] + state.tShift[startLine];
-            const max = state.eMarks[startLine];
-
-            // line should be at least 5 chars - "[^x]:"
-            if (start + 4 > max) { return false; }
-
-            if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
-            if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
-
-            for (pos = start + 2; pos < max; pos++) {
-              if (state.src.charCodeAt(pos) === 0x20) { return false; }
-              if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
-                break;
-              }
-            }
-
-            if (pos === start + 2) { return false; } // no empty footnote labels
-            if (pos + 1 >= max || state.src.charCodeAt(++pos) !== 0x3A /* : */) { return false; }
-            if (silent) { return true; }
-            pos++;
-
-            if (!state.env.footnotes) { state.env.footnotes = {}; }
-            if (!state.env.footnotes.refs) { state.env.footnotes.refs = {}; }
-            label = state.src.slice(start + 2, pos - 2);
-            state.env.footnotes.refs[`:${label}`] = -1;
-
-            token = new state.Token('footnote_reference_open', '', 1);
-            token.meta = { label };
-            token.level = state.level++;
-            state.tokens.push(token);
-
-            oldBMark = state.bMarks[startLine];
-            oldTShift = state.tShift[startLine];
-            oldSCount = state.sCount[startLine];
-            oldParentType = state.parentType;
-
-            posAfterColon = pos;
-            initial = offset = state.sCount[startLine] + pos - (state.bMarks[startLine] + state.tShift[startLine]);
-
-            while (pos < max) {
-              ch = state.src.charCodeAt(pos);
-
-              if (isSpace(ch)) {
-                if (ch === 0x09) {
-                  offset += 4 - offset % 4;
-                } else {
-                  offset++;
-                }
-              } else {
-                break;
-              }
-
-              pos++;
-            }
-
-            state.tShift[startLine] = pos - posAfterColon;
-            state.sCount[startLine] = offset - initial;
-
-            state.bMarks[startLine] = posAfterColon;
-            state.blkIndent += 4;
-            state.parentType = 'footnote';
-
-            if (state.sCount[startLine] < state.blkIndent) {
-              state.sCount[startLine] += state.blkIndent;
-            }
-
-            state.md.block.tokenize(state, startLine, endLine, true);
-
-            state.parentType = oldParentType;
-            state.blkIndent -= 4;
-            state.tShift[startLine] = oldTShift;
-            state.sCount[startLine] = oldSCount;
-            state.bMarks[startLine] = oldBMark;
-
-            token = new state.Token('footnote_reference_close', '', -1);
-            token.level = --state.level;
-            state.tokens.push(token);
-
-            return true;
-          }
-
-          // Process inline footnotes (^[...])
-          function footnote_inline(state, silent) {
-            let labelStart;
-            let labelEnd;
-            let footnoteId;
-            let token;
-            let tokens;
-            const max = state.posMax;
-            const start = state.pos;
-
-            if (start + 2 >= max) { return false; }
-            if (state.src.charCodeAt(start) !== 0x5E/* ^ */) { return false; }
-            if (state.src.charCodeAt(start + 1) !== 0x5B/* [ */) { return false; }
-
-            labelStart = start + 2;
-            labelEnd = parseLinkLabel(state, start + 1);
-
-            // parser failed to find ']', so it's not a valid note
-            if (labelEnd < 0) { return false; }
-
-            // We found the end of the link, and know for a fact it's a valid link;
-            // so all that's left to do is to call tokenizer.
-            //
-            if (!silent) {
-              if (!state.env.footnotes) { state.env.footnotes = {}; }
-              if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
-              footnoteId = state.env.footnotes.list.length;
-
-              state.md.inline.parse(
-                state.src.slice(labelStart, labelEnd),
-                state.md,
-                state.env,
-                tokens = [],
-              );
-
-              token = state.push('footnote_ref', '', 0);
-              token.meta = { id: footnoteId };
-
-              state.env.footnotes.list[footnoteId] = { tokens };
-            }
-
-            state.pos = labelEnd + 1;
-            state.posMax = max;
-            return true;
-          }
-
-          // Process footnote references ([^...])
-          function footnote_ref(state, silent) {
-            let label;
-            let pos;
-            let footnoteId;
-            let footnoteSubId;
-            let token;
-            const max = state.posMax;
-            const start = state.pos;
-
-            // should be at least 4 chars - "[^x]"
-            if (start + 3 > max) { return false; }
-
-            if (!state.env.footnotes || !state.env.footnotes.refs) { return false; }
-            if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
-            if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
-
-            for (pos = start + 2; pos < max; pos++) {
-              if (state.src.charCodeAt(pos) === 0x20) { return false; }
-              if (state.src.charCodeAt(pos) === 0x0A) { return false; }
-              if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
-                break;
-              }
-            }
-
-            if (pos === start + 2) { return false; } // no empty footnote labels
-            if (pos >= max) { return false; }
-            pos++;
-
-            label = state.src.slice(start + 2, pos - 1);
-            if (typeof state.env.footnotes.refs[`:${label}`] === 'undefined') { return false; }
-
-            if (!silent) {
-              if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
-
-              if (state.env.footnotes.refs[`:${label}`] < 0) {
-                footnoteId = state.env.footnotes.list.length;
-                state.env.footnotes.list[footnoteId] = { label, count: 0 };
-                state.env.footnotes.refs[`:${label}`] = footnoteId;
-              } else {
-                footnoteId = state.env.footnotes.refs[`:${label}`];
-              }
-
-              footnoteSubId = state.env.footnotes.list[footnoteId].count;
-              state.env.footnotes.list[footnoteId].count++;
-
-              token = state.push('footnote_ref', '', 0);
-              token.meta = { id: footnoteId, subId: footnoteSubId, label };
-            }
-
-            state.pos = pos;
-            state.posMax = max;
-            return true;
-          }
-
-          // Glue footnote tokens to end of token stream
-          function footnote_tail(state) {
-            let i; let l; let j; let t; let lastParagraph; let list; let token; let tokens; let current; let currentLabel;
-            let insideRef = false;
-            const refTokens = {};
-
-            if (!state.env.footnotes) { return; }
-            state.tokens = state.tokens.filter((tok) => {
-              //console.log("(" + JSON.stringify(tok) + ");")
-              if (tok.type === 'footnote_reference_open') {
-                insideRef = true;
-                current = [];
-                currentLabel = tok.meta.label;
-                return false;
-              }
-              if (tok.type === 'footnote_reference_close') {
-                insideRef = false;
-                // prepend ':' to avoid conflict with Object.prototype members
-                refTokens[`:${currentLabel}`] = current;
-                return false;
-              }
-              if (insideRef) { current.push(tok); }
-              return !insideRef;
-            });
-
-            if (!state.env.footnotes.list) { return; }
-            list = state.env.footnotes.list;
-
-            token = new state.Token('footnote_block_open', '', 1);
-            state.tokens.push(token);
-
-            for (i = 0, l = list.length; i < l; i++) {
-              token = new state.Token('footnote_open', '', 1);
-              token.meta = { id: i, label: list[i].label };
-              state.tokens.push(token);
-
-              if (list[i].tokens) {
-                tokens = [];
-
-                token = new state.Token('paragraph_open', 'p', 1);
-                token.block = true;
-                tokens.push(token);
-
-                token = new state.Token('inline', '', 0);
-                token.children = list[i].tokens;
-                token.content = '';
-                tokens.push(token);
-
-                token = new state.Token('paragraph_close', 'p', -1);
-                token.block = true;
-                tokens.push(token);
-              } else if (list[i].label) {
-                tokens = refTokens[`:${list[i].label}`];
-              }
-
-              state.tokens = state.tokens.concat(tokens);
-              if (state.tokens[state.tokens.length - 1].type === 'paragraph_close') {
-                lastParagraph = state.tokens.pop();
-              } else {
-                lastParagraph = null;
-              }
-
-              t = list[i].count > 0 ? list[i].count : 1;
-              for (j = 0; j < t; j++) {
-                token = new state.Token('footnote_anchor', '', 0);
-                token.meta = { id: i, subId: j, label: list[i].label };
-                state.tokens.push(token);
-              }
-
-              if (lastParagraph) {
-                state.tokens.push(lastParagraph);
-              }
-
-              token = new state.Token('footnote_close', '', -1);
-              state.tokens.push(token);
-            }
-
-            token = new state.Token('footnote_block_close', '', -1);
-            state.tokens.push(token);
-          }
-
-          md.block.ruler.before('reference', 'footnote_def', footnote_def, { alt: ['paragraph', 'reference'] });
-          md.inline.ruler.after('image', 'footnote_inline', footnote_inline);
-          md.inline.ruler.after('footnote_inline', 'footnote_ref', footnote_ref);
-          md.core.ruler.after('inline', 'footnote_tail', footnote_tail);
-        };
-      }, {},
-    ],
-  }, {}, [1]))(1);
-}));
+      } else {
+        break;
+      }
+
+      pos++;
+    }
+
+    state.tShift[startLine] = pos - posAfterColon;
+    state.sCount[startLine] = offset - initial;
+
+    state.bMarks[startLine] = posAfterColon;
+    state.blkIndent += 4;
+    state.parentType = 'footnote';
+
+    if (state.sCount[startLine] < state.blkIndent) {
+      state.sCount[startLine] += state.blkIndent;
+    }
+
+    state.md.block.tokenize(state, startLine, endLine, true);
+
+    state.parentType = oldParentType;
+    state.blkIndent -= 4;
+    state.tShift[startLine] = oldTShift;
+    state.sCount[startLine] = oldSCount;
+    state.bMarks[startLine] = oldBMark;
+
+    token       = new state.Token('footnote_reference_close', '', -1);
+    token.level = --state.level;
+    state.tokens.push(token);
+
+    return true;
+  }
+
+  // Process inline footnotes (^[...])
+  function footnote_inline(state, silent) {
+    var labelStart,
+      labelEnd,
+      footnoteId,
+      token,
+      tokens,
+      max = state.posMax,
+      start = state.pos;
+
+    if (start + 2 >= max) { return false; }
+    if (state.src.charCodeAt(start) !== 0x5E/* ^ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5B/* [ */) { return false; }
+
+    labelStart = start + 2;
+    labelEnd = parseLinkLabel(state, start + 1);
+
+    // parser failed to find ']', so it's not a valid note
+    if (labelEnd < 0) { return false; }
+
+    // We found the end of the link, and know for a fact it's a valid link;
+    // so all that's left to do is to call tokenizer.
+    //
+    if (!silent) {
+      if (!state.env.footnotes) { state.env.footnotes = {}; }
+      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+      footnoteId = state.env.footnotes.list.length;
+
+      state.md.inline.parse(
+        state.src.slice(labelStart, labelEnd),
+        state.md,
+        state.env,
+        tokens = []
+      );
+
+      token      = state.push('footnote_ref', '', 0);
+      token.meta = { id: footnoteId };
+
+      state.env.footnotes.list[footnoteId] = {
+        content: state.src.slice(labelStart, labelEnd),
+        tokens: tokens
+      };
+    }
+
+    state.pos = labelEnd + 1;
+    state.posMax = max;
+    return true;
+  }
+
+  // Process footnote references ([^...])
+  function footnote_ref(state, silent) {
+    var label,
+      pos,
+      footnoteId,
+      footnoteSubId,
+      token,
+      max = state.posMax,
+      start = state.pos;
+
+    // should be at least 4 chars - "[^x]"
+    if (start + 3 > max) { return false; }
+
+    if (!state.env.footnotes || !state.env.footnotes.refs) { return false; }
+    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+    for (pos = start + 2; pos < max; pos++) {
+      if (state.src.charCodeAt(pos) === 0x20) { return false; }
+      if (state.src.charCodeAt(pos) === 0x0A) { return false; }
+      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+        break;
+      }
+    }
+
+    if (pos === start + 2) { return false; } // no empty footnote labels
+    if (pos >= max) { return false; }
+    pos++;
+
+    label = state.src.slice(start + 2, pos - 1);
+    if (typeof state.env.footnotes.refs[':' + label] === 'undefined') { return false; }
+
+    if (!silent) {
+      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+
+      if (state.env.footnotes.refs[':' + label] < 0) {
+        footnoteId = state.env.footnotes.list.length;
+        state.env.footnotes.list[footnoteId] = { label: label, count: 0 };
+        state.env.footnotes.refs[':' + label] = footnoteId;
+      } else {
+        footnoteId = state.env.footnotes.refs[':' + label];
+      }
+
+      footnoteSubId = state.env.footnotes.list[footnoteId].count;
+      state.env.footnotes.list[footnoteId].count++;
+
+      token      = state.push('footnote_ref', '', 0);
+      token.meta = { id: footnoteId, subId: footnoteSubId, label: label };
+    }
+
+    state.pos = pos;
+    state.posMax = max;
+    return true;
+  }
+
+  // Glue footnote tokens to end of token stream
+  function footnote_tail(state) {
+    var i, l, j, t, lastParagraph, list, token, tokens, current, currentLabel,
+      insideRef = false,
+      refTokens = {};
+
+    if (!state.env.footnotes) { return; }
+
+    state.tokens = state.tokens.filter(function (tok) {
+      if (tok.type === 'footnote_reference_open') {
+        insideRef = true;
+        current = [];
+        currentLabel = tok.meta.label;
+        return false;
+      }
+      if (tok.type === 'footnote_reference_close') {
+        insideRef = false;
+        // prepend ':' to avoid conflict with Object.prototype members
+        refTokens[':' + currentLabel] = current;
+        return false;
+      }
+      if (insideRef) { current.push(tok); }
+      return !insideRef;
+    });
+
+    if (!state.env.footnotes.list) { return; }
+    list = state.env.footnotes.list;
+
+    token = new state.Token('footnote_block_open', '', 1);
+    state.tokens.push(token);
+
+    for (i = 0, l = list.length; i < l; i++) {
+      token      = new state.Token('footnote_open', '', 1);
+      token.meta = { id: i, label: list[i].label };
+      state.tokens.push(token);
+
+      if (list[i].tokens) {
+        tokens = [];
+
+        token          = new state.Token('paragraph_open', 'p', 1);
+        token.block    = true;
+        tokens.push(token);
+
+        token          = new state.Token('inline', '', 0);
+        token.children = list[i].tokens;
+        token.content  = list[i].content;
+        tokens.push(token);
+
+        token          = new state.Token('paragraph_close', 'p', -1);
+        token.block    = true;
+        tokens.push(token);
+
+      } else if (list[i].label) {
+        tokens = refTokens[':' + list[i].label];
+      }
+
+      state.tokens = state.tokens.concat(tokens);
+      if (state.tokens[state.tokens.length - 1].type === 'paragraph_close') {
+        lastParagraph = state.tokens.pop();
+      } else {
+        lastParagraph = null;
+      }
+
+      t = list[i].count > 0 ? list[i].count : 1;
+      for (j = 0; j < t; j++) {
+        token      = new state.Token('footnote_anchor', '', 0);
+        token.meta = { id: i, subId: j, label: list[i].label };
+        state.tokens.push(token);
+      }
+
+      if (lastParagraph) {
+        state.tokens.push(lastParagraph);
+      }
+
+      token = new state.Token('footnote_close', '', -1);
+      state.tokens.push(token);
+    }
+
+    token = new state.Token('footnote_block_close', '', -1);
+    state.tokens.push(token);
+  }
+
+  md.block.ruler.before('reference', 'footnote_def', footnote_def, { alt: [ 'paragraph', 'reference' ] });
+  md.inline.ruler.after('image', 'footnote_inline', footnote_inline);
+  md.inline.ruler.after('footnote_inline', 'footnote_ref', footnote_ref);
+  md.core.ruler.after('inline', 'footnote_tail', footnote_tail);
+};


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain:



<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Makes some changes to the `markdown-it-footnotes` file to make the changes easier to track from the original repo https://github.com/markdown-it/markdown-it-footnote
- footnotes as introduced in #885 used the dist bundle (which we don't need) instead of source file. this PR carries over the changes from #885 to the source file instead.
- reverts the stylistic changes (e.g. `var` -> `const`), preserving that of https://github.com/markdown-it/markdown-it-footnote
- clearly mark our changes with a `// CHANGE HERE` comment
- add the proper license attribution https://github.com/markdown-it/markdown-it-footnote/blob/master/LICENSE

**Proposed commit message: (wrap lines at 72 characters)**
Use markdown-it-footnotes source instead of bundle
