### PR TITLE
Refactor frontmatter processing

### DIFF
--- a/packages/cli/test/functional/test_site/expected/siteData.json
+++ b/packages/cli/test/functional/test_site/expected/siteData.json
@@ -2,36 +2,14 @@
   "enableSearch": true,
   "pages": [
     {
-      "title": "Open Bugs",
-      "header": "header.md",
       "src": "bugs/index.md",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "title": "Open Bugs",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "title": "Hello World",
-      "header": "header.md",
-      "footer": "footer.md",
-      "siteNav": "site-nav.md",
-      "pageNav": "default",
-      "pageNavTitle": "Testing Page Navigation",
-      "globalOverrideProperty": "Overridden by global override",
-      "frontMatterOverrideProperty": "Overridden by front matter override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by front matter override",
-      "head": "myCustomHead.md, myCustomHead2.md",
-      "tags": [
-        "tag-frontmatter-shown",
-        "tag-included-file",
-        "+tag-exp*",
-        "-tag-exp-hidden",
-        "-tag-site-override-shown",
-        "-tag-site-override-specific*"
-      ],
       "src": "index.md",
-      "layout": "default",
+      "title": "Hello World",
       "headings": {
         "panel-with-heading": "Panel with heading",
         "panel-without-heading-with-keyword": "Panel without heading with keyword",
@@ -104,9 +82,6 @@
     {
       "src": "sub_site/index.md",
       "title": "",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "feature-list": "Feature list"
       },
@@ -115,112 +90,74 @@
     {
       "src": "sub_site/nested_sub_site/index.md",
       "title": "",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "test_md_fragment.md",
       "title": "",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "some-heading": "Some heading"
       },
       "headingKeywords": {}
     },
     {
-      "layout": "testAfterSetup",
       "src": "testAfterSetup.md",
       "title": "Hello World",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testEmptyFrontmatter.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "title": "Hello World",
-      "head": "overwriteLayoutHead.md",
-      "layout": "testLayout",
       "src": "testLayoutsOverride.md",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "title": "Hello World",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testExternalScripts.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "title": "Test nunjucks path resolving",
-      "head": "overwriteLayoutHead.md",
-      "layout": "testLayout",
       "src": "testLayouts.md",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "title": "Test nunjucks path resolving",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testNunjucksPathResolving.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "sub_site/testNunjucksPathResolving.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "sub_site/nested_sub_site/testNunjucksPathResolving.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testAntiFOUCStyles.md",
       "title": "Hello World",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "title": "Anchor Generation Test",
       "src": "testAnchorGeneration.md",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
+      "title": "Anchor Generation Test",
       "headings": {
         "should-have-anchor-7": "should have anchor",
         "should-have-anchor-20": "should have anchor",
@@ -248,9 +185,6 @@
     {
       "src": "testTooltipSpacing.mbd",
       "title": "Tooltip Spacing Test",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "569-stray-space-after-tooltip": "569: Stray space after tooltip"
       },
@@ -259,27 +193,18 @@
     {
       "src": "testThumbnails.md",
       "title": "Thumbnails Test",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testPlantUML.md",
       "title": "PlantUML Test",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testImportVariables.md",
       "title": "Imported Variables Test",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "trying-to-access-a-page-variable": "Trying to access a page variable:",
         "trying-to-access-an-imported-variable-via-namespace": "Trying to access an imported variable via namespace:"
@@ -289,54 +214,36 @@
     {
       "src": "testPanelsWithImportedVariables.md",
       "title": "Panels with Imported Variables Test",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testCodeBlocks.md",
       "title": "Test: Code Blocks",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testIncludePluginsRendered.md",
       "title": "Included files should have plugins rendered on them",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testIncludeMultipleModals.md",
       "title": "Multiple inclusions of a modal should be supported",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testPopoverTrigger.md",
       "title": "Popover initiated by trigger should honor trigger attribute",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "testDates.md",
       "title": "Nunjucks date filter tests",
-      "layout": "default",
-      "globalOverrideProperty": "Overridden by global override",
-      "globalAndFrontMatterOverrideProperty": "Overridden by global override",
       "headings": {
         "dates": "Dates"
       },

--- a/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <meta name="default-head-top">
+  <meta name="head-top">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="MarkBind 2.15.2">
@@ -21,14 +21,22 @@
   <script src="markbind/js/jquery.min.js"></script>
   <link rel="stylesheet" href="/test_site/plugins/testMarkbindPlugin/testMarkbindPluginStylesheet.css">
   <link rel="stylesheet" href="/test_site/plugins/markbind-plugin-anchors/markbind-plugin-anchors.css">
-  <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-  <meta name="default-head-bottom">
+  <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
+  <meta name="head-bottom">
   <link rel="icon" href="/test_site/favicon.png">
 </head>
 
 <body>
   <div id="app">
     <div id="flex-body">
+      <nav id="site-nav" class="navbar navbar-light bg-transparent">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
+          <ul class="site-nav-list site-nav-list-root">
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[Layout Nav]</li>
+          </ul>
+        </div>
+      </nav>
       <div id="content-wrapper">
         <p>A page with an empty frontmatter should still build.</p>
       </div>
@@ -37,7 +45,7 @@
     </div>
     <footer>
       <div class="text-center">
-        Default footer
+        Layout footer
       </div>
     </footer>
   </div>
@@ -65,6 +73,6 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script src="markbind/layouts/default/scripts.js"></script>
+<script src="markbind/layouts/testLayout/scripts.js"></script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testExternalScripts.html
+++ b/packages/cli/test/functional/test_site/expected/testExternalScripts.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <meta name="default-head-top">
+  <meta name="head-top">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="MarkBind 2.15.2">
@@ -21,14 +21,22 @@
   <script src="markbind/js/jquery.min.js"></script>
   <link rel="stylesheet" href="/test_site/plugins/testMarkbindPlugin/testMarkbindPluginStylesheet.css">
   <link rel="stylesheet" href="/test_site/plugins/markbind-plugin-anchors/markbind-plugin-anchors.css">
-  <link rel="stylesheet" href="markbind/layouts/default/styles.css">
-  <meta name="default-head-bottom">
+  <link rel="stylesheet" href="markbind/layouts/testLayout/styles.css">
+  <link rel="stylesheet" href="markbind/css/site-nav.css">
+  <meta name="head-bottom">
   <link rel="icon" href="/test_site/favicon.png">
 </head>
 
 <body>
   <div id="app">
     <div id="flex-body">
+      <nav id="site-nav" class="navbar navbar-light bg-transparent">
+        <div class="border-right-grey nav-inner position-sticky slim-scroll">
+          <ul class="site-nav-list site-nav-list-root">
+            <li class="site-nav-custom-list-item site-nav-list-item-0">[Layout Nav]</li>
+          </ul>
+        </div>
+      </nav>
       <div id="content-wrapper">
         <p>The external script <a href="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">MathJax 2.75</a> should be included, and the following MathJax content should render:</p>
         <box>
@@ -41,7 +49,7 @@
     </div>
     <footer>
       <div class="text-center">
-        Default footer
+        Layout footer
       </div>
     </footer>
   </div>
@@ -70,6 +78,6 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script src="markbind/layouts/default/scripts.js"></script>
+<script src="markbind/layouts/testLayout/scripts.js"></script>
 
 </html>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/siteData.json
@@ -2,11 +2,8 @@
   "enableSearch": true,
   "pages": [
     {
-      "title": "Hello World",
-      "footer": "footer.md",
-      "siteNav": "site-nav.md",
       "src": "index.md",
-      "layout": "default",
+      "title": "Hello World",
       "headings": {},
       "headingKeywords": {}
     }

--- a/packages/cli/test/functional/test_site_convert/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_convert/expected/siteData.json
@@ -4,14 +4,12 @@
     {
       "src": "Home.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "Page-1.md",
       "title": "",
-      "layout": "default",
       "headings": {
         "page-1": "Page 1"
       },
@@ -20,68 +18,52 @@
     {
       "src": "_Footer.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "_Sidebar.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "about.md",
       "title": "",
-      "layout": "default",
       "headings": {
         "about": "About"
       },
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic1.md",
       "title": "",
-      "layout": "default",
       "headings": {
         "topic-1": "Topic 1"
       },
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic2.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic3a.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic3b.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     }

--- a/packages/cli/test/functional/test_site_expressive_layout/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_expressive_layout/expected/siteData.json
@@ -2,10 +2,8 @@
   "enableSearch": true,
   "pages": [
     {
-      "footer": "footer.md",
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default",
       "headings": {
         "welcome-to-markbind": "Welcome to Markbind"
       },

--- a/packages/cli/test/functional/test_site_special_tags/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_special_tags/expected/siteData.json
@@ -4,7 +4,6 @@
     {
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default",
       "headings": {
         "functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags": "Functional test for htmlparser2 and markdown-it patches for special tags",
         "so-far-as-to-comply-with-the-commonmark-spec": "So far as to comply with the commonmark spec"

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/siteData.json
@@ -2,51 +2,34 @@
   "enableSearch": true,
   "pages": [
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic1.md",
       "title": "",
-      "layout": "default",
       "headings": {
         "topic-1": "Topic 1"
       },
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic2.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic3a.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "siteNav": "site-nav.md",
       "src": "contents/topic3b.md",
       "title": "",
-      "layout": "default",
       "headings": {},
       "headingKeywords": {}
     },
     {
-      "header": "header.md",
-      "pageNav": 2,
-      "pageNavTitle": "Chapters of This Page",
-      "siteNav": "site-nav.md",
       "src": "index.md",
       "title": "Landing Page",
-      "layout": "default",
       "headings": {
         "heading-1": "Heading 1",
         "sub-heading-1-1": "Sub Heading 1.1",

--- a/packages/cli/test/functional/test_site_templates/test_minimal/expected/siteData.json
+++ b/packages/cli/test/functional/test_site_templates/test_minimal/expected/siteData.json
@@ -2,10 +2,8 @@
   "enableSearch": true,
   "pages": [
     {
-      "footer": "footer.md",
       "src": "index.md",
       "title": "Hello World",
-      "layout": "default",
       "headings": {
         "welcome-to-markbind": "Welcome to Markbind"
       },

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1225,7 +1225,8 @@ class Site {
         enableSearch: this.siteConfig.enableSearch,
         pages: this.pages.filter(page => page.searchable)
           .map(page => ({
-            ...page.frontMatter,
+            src: page.src,
+            title: page.title,
             headings: page.headings,
             headingKeywords: page.keywords,
           })),


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix
• [x] Other, please explain: refactor of frontmatter with a bugfix as a side effect


**What is the rationale for this request?**
We use the `frontmatter` object as a container for **both** frontmatter and page properties.

This decreases the readability of code. Let's make `frontmatter` actually represent the parsed frontmatter from the page, and add the few page properties previously only held in `frontmatter`.

This also
- consolidates frontmatter vs `site.json` config property prioritisation into one method (`processFrontMatter`).
- removes redundant metadata in the `siteData.json` output file

As a result of the refactor, a bugfix is also observed -- the `layout` in `site.json` wasn't taking effect when the frontmatter is empty or non-existent. (causing the default layout to be used in that case)
https://markbind.org/userGuide/siteJsonFile.html#pages


**Proposed commit message: (wrap lines at 72 characters)**
Refactor frontmatter processing

The Page model uses the parsed frontmatter object as a container for
other variables.
This convenience pollutes the intent of the object, decreasing code
readability.

Let's make the frontmatter object represent only the parsed data,
extracting out the other variables as instance variables of the Page
model.

As a result, this also:
- consolidates frontmatter property prioritisation into one method.
- removes redundant metadata in the siteData.json output file.
- fixes a bug where layouts specified in site.json are not respected
when the frontmatter is empty.
