### PR TITLE
Add frontend live / hot reload workflow

### DIFF
--- a/docs/devGuide/workflow.md
+++ b/docs/devGuide/workflow.md
@@ -22,9 +22,21 @@ The sections below has more information about various stages of submitting a PR.
 
 ## Writing code
 
-Use JavaScript ES6 features if possible for better performance, e.g. Promise instead of callback.
+#### General tips
 
-Do note [our style guides](styleGuides.html).
+* Use JavaScript ES6 features if possible for better performance, e.g. Promise instead of callback.
+* Do note [our style guides](styleGuides.html).
+
+#### Editing frontend features
+
+We update the frontend `markbind.min.js` and `markbind.min.css` bundles during release only, and not in pull requests.
+
+Hence, if you need to view the latest frontend changes (relating to `packages/core-web` or `packages/vue-components`), you can either:
+1. Run `npm run build:web` in the root directory, which builds the above bundles,
+   then run your markbind-cli [command](https://markbind.org/userGuide/cliCommands.html) of choice.
+2. Run `markbind serve -d` (with any other applicable options). (**recommended**)<br>
+   This adds the necessary webpack middlewares to the development server to compile the above bundles,
+   and enables live and hot reloading for frontend source files. 
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3396,6 +3396,11 @@
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -8476,6 +8481,11 @@
       "requires": {
         "whatwg-encoding": "^1.0.5"
       }
+    },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -17659,6 +17669,52 @@
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+        }
+      }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz",
+      "integrity": "sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==",
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "^1.2.0",
+        "querystring": "^0.2.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+          "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
         }
       }
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@markbind/core": "2.15.2",
+    "@markbind/core-web": "2.15.2",
     "bluebird": "^3.7.2",
     "chalk": "^3.0.0",
     "cheerio": "^0.22.0",

--- a/packages/core-web/package.json
+++ b/packages/core-web/package.json
@@ -38,6 +38,8 @@
     "vue-loader": "^15.9.3",
     "webpack": "^4.44.0",
     "webpack-cli": "^3.3.12",
+    "webpack-dev-middleware": "^3.7.2",
+    "webpack-hot-middleware": "^2.25.0",
     "webpack-merge": "^5.0.9"
   },
   "publishConfig": {

--- a/packages/core-web/webpack.dev.js
+++ b/packages/core-web/webpack.dev.js
@@ -1,20 +1,44 @@
+const path = require('path');
+const webpack = require('webpack');
 const { merge } = require('webpack-merge');
-
+const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+
 const config = require('./webpack.common.js');
 
-module.exports = merge(config, {
-  mode: 'development',
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          'vue-style-loader',
-          'css-loader',
-        ],
-      },
+module.exports = (publicPath) => {
+  const webpackDevConfig = merge(config, {
+    mode: 'development',
+    entry: {
+      markbind: ['webpack-hot-middleware/client', path.join(__dirname, 'src', 'index.js')],
+    },
+    output: {
+      publicPath,
+    },
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          use: [
+            'vue-style-loader',
+            'css-loader',
+          ],
+        },
+      ],
+    },
+    plugins: [
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoEmitOnErrorsPlugin(),
+      new VueLoaderPlugin(),
     ],
-  },
-  plugins: [new VueLoaderPlugin()],
-});
+  });
+
+  const compiler = webpack(webpackDevConfig);
+  return [
+    webpackDevMiddleware(compiler, {
+      publicPath,
+    }),
+    webpackHotMiddleware(compiler),
+  ];
+};

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -98,6 +98,10 @@ class Page {
    */
   constructor(pageConfig) {
     /**
+     * @type {boolean}
+     */
+    this.dev = pageConfig.dev;
+    /**
      * @type {Object<string, any>}
      */
     this.asset = pageConfig.asset;
@@ -309,6 +313,7 @@ class Page {
       asset,
       baseUrl: this.baseUrl,
       content: this.content,
+      dev: this.dev,
       faviconUrl: this.faviconUrl,
       footerHtml: this.pageSectionsHtml.footer || '',
       headerHtml: this.pageSectionsHtml.header || '',

--- a/packages/core/src/Page/page.njk
+++ b/packages/core/src/Page/page.njk
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{{ asset.glyphicons }}">
     <link rel="stylesheet" href="{{ asset.octicons }}">
     <link rel="stylesheet" href="{{ asset.highlight }}">
-    <link rel="stylesheet" href="{{ asset.markBindCss }}">
+    {%- if not dev -%}<link rel="stylesheet" href="{{ asset.markBindCss }}">{%- endif -%}
     <script src="{{ asset.polyfillJs }}"></script>
     <script src="{{ asset.vue }}"></script>
     <script src="{{ asset.markBindJs }}"></script>

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -113,7 +113,10 @@ const TOP_NAV_DEFAULT = '<header><navbar placement="top" type="inverse">\n'
 const MARKBIND_LINK_HTML = `<a href='${MARKBIND_WEBSITE_URL}'>MarkBind ${MARKBIND_VERSION}</a>`;
 
 class Site {
-  constructor(rootPath, outputPath, onePagePath, forceReload = false, siteConfigPath = SITE_CONFIG_NAME) {
+  constructor(rootPath, outputPath, onePagePath, forceReload = false,
+              siteConfigPath = SITE_CONFIG_NAME, dev) {
+    this.dev = !!dev;
+
     this.rootPath = rootPath;
     this.outputPath = outputPath;
     this.tempPath = path.join(rootPath, TEMP_FOLDER_NAME);
@@ -255,6 +258,7 @@ class Site {
     const sourcePath = path.join(this.rootPath, config.pageSrc);
     const resultPath = path.join(this.outputPath, Site.setExtension(config.pageSrc, '.html'));
     return new Page({
+      dev: this.dev,
       baseUrl: this.siteConfig.baseUrl,
       baseUrlMap: this.baseUrlMap,
       content: '',


### PR DESCRIPTION
quick follow up to #1306

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: devops

**What is the rationale for this request?**
Speed up frontend development x1000

**What changes did you make? (Give an overview)**
- Added live / hot reload as a `--dev` / `-d` option to `markbind serve`
  - tested with different baseUrl configurations, and the `-o` options.
  - other options in `markbind serve` should be independent of this
- Added this to the dev guide `workflow.md`
- Modify the page template to **not** output the css asset link in development.
  - this is necessary as deleting some styles in development may not take effect since the style may still be present in the css bundle

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
`markbind s -d` (with any other options)

**Proposed commit message: (wrap lines at 72 characters)**
Add frontend live / hot reload workflow

The frontend workflow requires launching webpack in watch mode. This is
then followed by manually copying the built bundles to the output
directory of the site, or terminating and then relaunching the MarkBind
command.

With a frontend entry point setup in the core-web package, and the
MarkBind /vue-strap fork merged into the main monorepo, let's take
advantage of this and add a live / hot reload workflow.
This provides a near instant edit-feedback development cycle that makes
frontend development much quicker.

This is integrated into the markbind serve command using the --dev
option.
