### PR TITLE
Force webpack build context to core-web directory

### DIFF
--- a/packages/core-web/webpack.common.js
+++ b/packages/core-web/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  context: __dirname,
   entry: {
     markbind: path.join(__dirname, 'src', 'index.js'),
   },
@@ -29,6 +30,7 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
+              root: __dirname,
               rootMode: 'upward',
             },
           },


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Follow up to #1327

**What is the rationale for this request?**
Fix the newly introduced `--dev` option for frontend live/hot reload when serving a site outside of the markbind repo folder

**What changes did you make? (Give an overview)**
Explicitly set the build context for webpack, and project root for babel to be at the core-web folder

**Testing instructions:**


**Proposed commit message: (wrap lines at 72 characters)**
Force webpack build context to core-web directory

Webpack uses the current working directory as the build context from
which to resolve its loaders and modules,
and babel uses it as the conceptual project root directory.

When building frontend bundles, the working directory and thus build
context correctly resides at the core-web package.
When serving a site outside of the markbind/ project folder with the
--dev option however, it is not, causing the  core-web build process to
fail.

Let's explicitly set the build context for webpack and babel to the
core-web project folder hence.