### PR TITLE
Change code fence html line break to newlines

### DIFF
--- a/packages/cli/test/functional/test_site/expected/requirements/UserStories._include_.html
+++ b/packages/cli/test/functional/test_site/expected/requirements/UserStories._include_.html
@@ -3,7 +3,10 @@
 <p>A commonly used format for writing user stories is:<br>
   <strong><code v-pre>As a</code></strong> <code v-pre>&lt;use type/role&gt;</code> <strong><code v-pre>I can</code></strong> <code v-pre>&lt;function&gt;</code> <strong><code v-pre>so that</code></strong> <code v-pre>&lt;benefit&gt;</code></p>
 <p>Here are some examples of user stories for the IVLE system:</p>
-<pre><code class="hljs bat" v-pre><span>* As a student, I can download files uploaded by lecturers, so that I can get my own <span class="hljs-built_in">copy</span> of the files.<br></span><span>* As a lecturer, I can create discussion forums, so that students can discuss things online.<br></span><span>* As a tutor, I can <span class="hljs-built_in">print</span> attendance sheets, so that I can take attendance during the class.<br></span></code></pre>
+<pre><code class="hljs bat" v-pre><span>* As a student, I can download files uploaded by lecturers, so that I can get my own <span class="hljs-built_in">copy</span> of the files.
+</span><span>* As a lecturer, I can create discussion forums, so that students can discuss things online.
+</span><span>* As a tutor, I can <span class="hljs-built_in">print</span> attendance sheets, so that I can take attendance during the class.
+</span></code></pre>
 <p>The <code v-pre>&lt;benefit&gt;</code> can be omitted if it is obvious. E.g. As a tutor, I can print attendance sheets.
   User stories are mainly used for early estimation and scheduling purposes.</p>
 <p>According to <ref xp-website>this<ref></ref>, the biggest difference between user stories and traditional requirements

--- a/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
+++ b/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
@@ -32,39 +32,100 @@
       <div id="content-wrapper">
         <p><strong>Test: Code blocks</strong></p>
         <p><strong>Normal fenced code should render correctly</strong></p>
-        <pre><code class="hljs" v-pre><span>Content in a fenced code block<br></span></code></pre>
+        <pre><code class="hljs" v-pre><span>Content in a fenced code block
+</span></code></pre>
         <p><strong>With syntax coloring should render correctly</strong></p>
-        <pre><code class="hljs xml" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span><br></span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span><br></span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span><br></span></code></pre>
+        <pre><code class="hljs xml" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span>
+</span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span>
+</span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span>
+</span></code></pre>
         <p><strong><code v-pre>no-line-numbers</code> attr should hide corresponding line numbers</strong></p>
-        <pre><code class="no-line-numbers hljs xml" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span><br></span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span><br></span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span><br></span></code></pre>
+        <pre><code class="no-line-numbers hljs xml" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span>
+</span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span>
+</span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span>
+</span></code></pre>
         <p><strong><code v-pre>start-from</code> attr should set inline css in <code v-pre>&lt;code&gt;</code> tag, enabling lines to start from a specific line number</strong></p>
-        <pre><code style="counter-reset: line 29;" class="hljs markdown" v-pre><span><span class="hljs-strong">*****</span><br></span><span>-----<br></span></code></pre>
+        <pre><code style="counter-reset: line 29;" class="hljs markdown" v-pre><span><span class="hljs-strong">*****</span>
+</span><span>-----
+</span></code></pre>
         <p><strong><code v-pre>highlight-lines</code> attr causes corresponding lines to have 'highlighted' class</strong></p>
-        <pre><code class="hljs markdown" v-pre><span class="highlighted">1  highlighted<br></span><span>2<br></span><span class="highlighted">3  highlighted<br></span><span>4<br></span><span class="highlighted">5  highlighted<br></span><span class="highlighted">6  highlighted<br></span><span class="highlighted">7  highlighted<br></span><span class="highlighted">8  highlighted<br></span><span>9<br></span><span>10<br></span></code></pre>
+        <pre><code class="hljs markdown" v-pre><span class="highlighted">1  highlighted
+</span><span>2
+</span><span class="highlighted">3  highlighted
+</span><span>4
+</span><span class="highlighted">5  highlighted
+</span><span class="highlighted">6  highlighted
+</span><span class="highlighted">7  highlighted
+</span><span class="highlighted">8  highlighted
+</span><span>9
+</span><span>10
+</span></code></pre>
         <p><strong><code v-pre>highlight-lines</code> attr with <code v-pre>start-from</code> attr should cause corresponding lines to have 'highlighted' class based on <code v-pre>start-from</code></strong></p>
-        <pre><code style="counter-reset: line 10;" class="hljs markdown" v-pre><span class="highlighted">11  highlighted<br></span><span>12<br></span><span class="highlighted">13  highlighted<br></span><span>14<br></span><span class="highlighted">15  highlighted<br></span><span class="highlighted">16  highlighted<br></span><span class="highlighted">17  highlighted<br></span><span class="highlighted">18  highlighted<br></span><span>19<br></span><span>20<br></span></code></pre>
+        <pre><code style="counter-reset: line 10;" class="hljs markdown" v-pre><span class="highlighted">11  highlighted
+</span><span>12
+</span><span class="highlighted">13  highlighted
+</span><span>14
+</span><span class="highlighted">15  highlighted
+</span><span class="highlighted">16  highlighted
+</span><span class="highlighted">17  highlighted
+</span><span class="highlighted">18  highlighted
+</span><span>19
+</span><span>20
+</span></code></pre>
         <p><strong>Should render correctly with heading</strong></p>
         <div class="code-block">
           <div class="code-block-heading"><span>A heading</span></div>
           <div class="code-block-content">
-            <pre><code heading="A heading" class="hljs" v-pre><span>&lt;foo&gt;<br></span><span>    &lt;bar&gt;<br></span><span>&lt;/foo&gt;<br></span></code></pre>
+            <pre><code heading="A heading" class="hljs" v-pre><span>&lt;foo&gt;
+</span><span>    &lt;bar&gt;
+</span><span>&lt;/foo&gt;
+</span></code></pre>
           </div>
         </div>
         <p><strong>Inline markdown contained in heading should also be rendered correctly</strong></p>
         <div class="code-block">
           <div class="code-block-heading inline-markdown-heading"><span><strong>Bold</strong>, <em>Italic</em>, <em><strong>Bold and Italic</strong></em>, <s>Strike through</s>, <strong><strong>Super Bold</strong></strong>, <ins>Underline</ins>, <mark>Highlight</mark>, 👍 ❗️ ❌ 🚧<br>We support page breaks</span></div>
           <div class="code-block-content">
-            <pre><code heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, :+1: :exclamation: :x: :construction:&lt;br&gt;We support page breaks" class="hljs" v-pre><span>&lt;foo&gt;<br></span><span>    &lt;bar&gt;<br></span><span>&lt;/foo&gt;<br></span></code></pre>
+            <pre><code heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, :+1: :exclamation: :x: :construction:&lt;br&gt;We support page breaks" class="hljs" v-pre><span>&lt;foo&gt;
+</span><span>    &lt;bar&gt;
+</span><span>&lt;/foo&gt;
+</span></code></pre>
           </div>
         </div>
         <p><strong>Code block with multiple linebreaks should not have the empty lines collapsed</strong></p>
-        <pre><code class="hljs" v-pre><span><br></span><span>Four empty lines below, one above<br></span><span><br></span><span><br></span><span><br></span><span><br></span><span>Four empty lines above, one below<br></span><span><br></span></code></pre>
+        <pre><code class="hljs" v-pre><span>
+</span><span>Four empty lines below, one above
+</span><span>
+</span><span>
+</span><span>
+</span><span>
+</span><span>Four empty lines above, one below
+</span><span>
+</span></code></pre>
         <p><strong>Code block without line numbers and multiple linebreaks should not have the empty lines collapsed</strong></p>
-        <pre><code class="no-line-numbers hljs" v-pre><span><br></span><span>Four empty lines below, one above<br></span><span><br></span><span><br></span><span><br></span><span><br></span><span>Four empty lines above, one below<br></span><span><br></span></code></pre>
+        <pre><code class="no-line-numbers hljs" v-pre><span>
+</span><span>Four empty lines below, one above
+</span><span>
+</span><span>
+</span><span>
+</span><span>
+</span><span>Four empty lines above, one below
+</span><span>
+</span></code></pre>
         <p><strong>Code block with syntax highlighting and multiple linebreaks should not have the empty lines collapsed</strong></p>
-        <pre><code class="hljs js" v-pre><span><br></span><span><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">fourEmptyLinesBelowOneAbove</span>(<span class="hljs-params"></span>) </span>{<br></span><span><br></span><span><br></span><span><br></span><span><br></span><span>} <span class="hljs-comment">// four empty lines above, one below</span><br></span><span><br></span></code></pre>
+        <pre><code class="hljs js" v-pre><span>
+</span><span><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">fourEmptyLinesBelowOneAbove</span>(<span class="hljs-params"></span>) </span>{
+</span><span>
+</span><span>
+</span><span>
+</span><span>
+</span><span>} <span class="hljs-comment">// four empty lines above, one below</span>
+</span><span>
+</span></code></pre>
         <p><strong>span with <code v-pre>hljs</code> class should span multiple lines <a href="https://github.com/MarkBind/markbind/pull/991#issuecomment-586547275">(Link for context)</a></strong></p>
-        <pre><code class="hljs markdown" v-pre><span><span class="hljs-strong">*****</span><br></span><span>-----<br></span></code></pre>
+        <pre><code class="hljs markdown" v-pre><span><span class="hljs-strong">*****</span>
+</span><span>-----
+</span></code></pre>
       </div>
 
 

--- a/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
+++ b/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
@@ -31,7 +31,10 @@
     <div id="flex-body">
       <div id="content-wrapper">
         <h1 id="569-stray-space-after-tooltip">569: Stray space after tooltip<a class="fa fa-anchor" href="#569-stray-space-after-tooltip" onclick="event.stopPropagation()"></a></h1>
-        <pre><code class="hljs" v-pre><span>&lt;tooltip&gt;tooltip&lt;/tooltip&gt;, test<br></span><span><br></span><span>&lt;trigger&gt;trigger&lt;/trigger&gt;, test<br></span></code></pre>
+        <pre><code class="hljs" v-pre><span>&lt;tooltip&gt;tooltip&lt;/tooltip&gt;, test
+</span><span>
+</span><span>&lt;trigger&gt;trigger&lt;/trigger&gt;, test
+</span></code></pre>
         <p><span data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger">tooltip</span>, test</p>
         <p><span v-b-popover.hover.top.html="popoverGenerator" v-b-tooltip.hover.top.html="tooltipContentGetter" v-on:mouseover="$refs['undefined'].show()" class="trigger">trigger</span>, test</p>
       </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -98,7 +98,10 @@
           </li>
         </ul>
         <p><strong>A <code v-pre>code</code> example:</strong></p>
-        <pre><code class="hljs html" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span><br></span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span><br></span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span><br></span></code></pre>
+        <pre><code class="hljs html" v-pre><span><span class="hljs-tag">&lt;<span class="hljs-name">foo</span>&gt;</span>
+</span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span>
+</span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span>
+</span></code></pre>
         <h2 id="sub-heading-1-1">Sub Heading 1.1<a class="fa fa-anchor" href="#sub-heading-1-1" onclick="event.stopPropagation()"></a></h2>
         <p>A <span effect="scale" placement="top" trigger="hover" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-html-for="_content">❗️ some <strong>important explanation</strong></span>tooltip</span>, a <span for="modal:modalinfo" trigger="click" v-b-popover.click.top.html="popoverGenerator" v-b-tooltip.click.top.html="tooltipContentGetter" v-on:click="$refs['modal:modalinfo'].show()" class="trigger-click">modal</span>, a <a href="https://markbind.org/">link</a>, a <span class="badge badge-danger">badge</span>, another <span class="badge badge-warning">badge</span>.</p>
         <b-modal id="modal:modalinfo" hide-footer size modal-class="mb-zoom" ref="modal:modalinfo"><template slot="modal-title">Modal Title</template>

--- a/packages/core/src/lib/markdown-it/index.js
+++ b/packages/core/src/lib/markdown-it/index.js
@@ -121,9 +121,9 @@ markdownIt.renderer.rules.fence = (tokens, idx, options, env, slf) => {
       return currentLineNumber === start;
     });
     if (inRange) {
-      return `<span class="highlighted">${line}<br></span>`;
+      return `<span class="highlighted">${line}\n</span>`;
     }
-    return `<span>${line}<br></span>`;
+    return `<span>${line}\n</span>`;
   }).join('');
 
   token.attrJoin('class', 'hljs');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes #1277

**What changes did you make? (Give an overview)**
Change `<br>` to `\n` in the code fence renderer

**Testing instructions:**
- newlines are also now copied
- manual copying still works #1125
- line numbers remain un-copied
- tested on chrome / firefox + windows / ubuntu

**Proposed commit message: (wrap lines at 72 characters)**
Change code fence html line break to newlines

The codeBlockCopyButtons plugin relies on the textContent of the code
fence html element.

The textContent does not convert html <br> elements into newlines.

Let's change the code fence markdown rendering function to use newlines
instead of <br> elements hence.

