### PR TITLE
Restore colors to test output

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/MarkBind/markbind.git"
   },
   "scripts": {
-    "test": "jest && cd test/functional && node test.js",
+    "test": "jest --colors && cd test/functional && node test.js",
     "updatetest": "cd test/functional && node updatetest.js"
   },
   "dependencies": {

--- a/packages/cli/test/functional/test.js
+++ b/packages/cli/test/functional/test.js
@@ -18,6 +18,8 @@ function printFailedMessage(err, siteName) {
   console.log(`Test result: ${siteName} FAILED`);
 }
 
+process.env.FORCE_COLOR = '3';
+
 const execOptions = {
   stdio: ['inherit', 'inherit', 'inherit'],
 };

--- a/packages/cli/test/functional/updatetest.js
+++ b/packages/cli/test/functional/updatetest.js
@@ -17,6 +17,8 @@ function printFailedMessage(err, siteName) {
   console.log(`Failed to update: ${siteName}`);
 }
 
+process.env.FORCE_COLOR = '3';
+
 const execOptions = {
   stdio: ['inherit', 'inherit', 'inherit'],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest --colors"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.14.0",

--- a/packages/vue-components/package.json
+++ b/packages/vue-components/package.json
@@ -23,7 +23,7 @@
     "directory": "packages/vue-components"
   },
   "scripts": {
-    "test": "jest",
+    "test": "jest --colors",
     "updatetest": "jest --updateSnapshot"
   },
   "devDependencies": {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix: restore colors for tests' tty output

**What is the rationale for this request?**
#1291 switched over to `lerna run` for tests, which causes colors to be lost from test output in some instances.

**What changes did you make? (Give an overview)**
- pass `--colors` to `jest` commands (which use chalk under the hood) to force color output there
- set `FORCE_COLOR` env variable for [chalk](https://www.npmjs.com/package/chalk) in our functional tests to force color output there as well

**Proposed commit message: (wrap lines at 72 characters)**
Restore colors to test output

Lerna run test executes the npm test script of each package in a
subprocess, causing certain libraries like chalk to disable color
output since stdout is not a TTY.

Let's override this behavior, enabling color output for tests.

