### PR TITLE
Fix enableSearch template variable

### DIFF
--- a/packages/core/src/Page/PageConfig.js
+++ b/packages/core/src/Page/PageConfig.js
@@ -30,6 +30,10 @@ class PageConfig {
      */
     this.dev = args.dev;
     /**
+     * @type {boolean}
+     */
+    this.enableSearch = args.enableSearch;
+    /**
      * @type {string}
      */
     this.faviconUrl = args.faviconUrl;

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -244,7 +244,7 @@ class Page {
       siteNav: this.siteNav,
       siteNavHtml: this.pageSectionsHtml[`#${SITE_NAV_ID}`] || '',
       title: prefixedTitle,
-      enableSearch: this.pageConfig.searchable,
+      enableSearch: this.pageConfig.enableSearch,
     };
   }
 

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -298,6 +298,7 @@ class Site {
       baseUrlMap: this.baseUrlMap,
       dev: this.dev,
       disableHtmlBeautify: this.siteConfig.disableHtmlBeautify,
+      enableSearch: this.siteConfig.enableSearch,
       faviconUrl: config.faviconUrl,
       frontmatterOverride: config.frontmatter,
       globalOverride: this.siteConfig.globalOverride,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix


**What is the rationale for this request?**
Fix a regression from #1343

**What changes did you make? (Give an overview)**
Restore the `enableSearch` variable

**Proposed commit message: (wrap lines at 72 characters)**
Fix enableSearch template variable

The searchable Page variable, which blacklists a page from being
indexed, is mistakenly used for in place of the enableSearch variable,
which controls whether the site's search functionality is enabled.

Let's correct this as such.