### PR TITLE
Refactor Page dependency checking

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -129,7 +129,7 @@ program
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
+        if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);
         }
         return site.buildAsset(filePath);
@@ -141,7 +141,7 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
+        if (site.isDependencyOfPage(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);
         }
         return site.buildAsset(filePath);
@@ -153,7 +153,7 @@ program
     const removeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (fsUtil.isSourceFile(filePath) || site.isPluginSourceFile(filePath)) {
+        if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);
         }
         return site.removeAsset(filePath);

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -195,6 +195,17 @@ class Page {
   }
 
   /**
+   * Checks if the provided filePath is a dependency of the page
+   * @param {string} filePath to check
+   */
+  isDependency(filePath) {
+    return (this.includedFiles
+      && this.includedFiles.has(filePath))
+      || (this.pluginSourceFiles
+      && this.pluginSourceFiles.has(filePath));
+  }
+
+  /**
    * A template data object.
    * @typedef {Object<string, any>} TemplateData
    * @property {Object<string, any>} asset

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -12,9 +12,6 @@ module.exports = {
   // packages/core/src/utils.js
   markdownFileExts: ['md', 'mbd', 'mbdf'],
 
-  // packages/core/src/util/fsUtil.js
-  sourceFileExtNames: ['.html', '.md', '.mbd', '.mbdf'],
-
   // packages/core/src/plugins/algolia.js
   ALGOLIA_CSS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css',
   ALGOLIA_JS_URL: 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js',

--- a/packages/core/src/utils/fsUtil.js
+++ b/packages/core/src/utils/fsUtil.js
@@ -1,13 +1,7 @@
 const path = require('path');
 const fs = require('fs-extra-promise');
 
-const { sourceFileExtNames } = require('../constants');
-
 module.exports = {
-  isSourceFile(filePath) {
-    return sourceFileExtNames.includes(path.extname(filePath));
-  },
-
   isInRoot: (root, fileName) => {
     let normalizedRoot = path.normalize(root);
     if (normalizedRoot === '.') {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Bug Fix
• [x] Other, please explain: code maintenance

**What changes did you make? (Give an overview)**
- extract some repeated functionalities related to page dependency checking into reusable methods
- replace the misleading source file extension check to determine whether to build a page with these reusable methods
  - fixes a bug where the page rebuilding process would be run even if the file (which ends in one of the previously used source file extensions) is an asset, not a page

**Proposed commit message: (wrap lines at 72 characters)**
Refactor Page dependency checking

Checking for dependencies of a Page instance is done repeatedly using
interfacing with the page instance's properties.

During a file system event when serving a MarkBind site, the site's
source files are rebuilt if the file has a "source file extension".
This unnecessarily runs the source files rebuilding process even when
such files are used as assets.

Let's extract these page dependency checking into reusable methods as
such, and use these methods in place of the extension check.
