### PR TITLE
Fix popover and tooltip positioning

### DIFF
--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -367,11 +367,13 @@ li.footnote-item:target {
 
 /* styles for triggers, popovers, tooltips */
 .trigger {
+    display: inline-block;
     border-bottom: 1px dotted currentColor;
 }
 
 .trigger-click {
     cursor: pointer;
+    display: inline-block;
     border-bottom: 1px dashed currentColor;
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fix a minor popover and tooltip positioning regression from #1133 
Fixes #1231 

![Untitled](https://user-images.githubusercontent.com/3306138/92987644-171b8380-f4f7-11ea-83cd-86f26c4a652b.png)


**What changes did you make? (Give an overview)**

Add `display: inline-block` back to the `trigger` classes

**Proposed commit message: (wrap lines at 72 characters)**
Fix popover and tooltip positioning