### PR TITLE
Fix redundant puml processes

### DIFF
--- a/docs/devGuide/writingPlugins.md
+++ b/docs/devGuide/writingPlugins.md
@@ -169,3 +169,12 @@ removing such potential conflicts.
 Note however, that variable interpolation syntax {% raw %}`{{ variable_name }}`{% endraw %} will act as per normal.
 Meaning, the user would still be able to use variables in your special tags!
 </box>
+
+## Lifecycle hooks
+
+You may also need to maintain some plugin state during site generation, then reset this when the site or pages are regenerated.
+
+To do this, you may implement the `beforeSiteGenerate` method.
+
+- `beforeSiteGenerate()`: Called during initial site generation and subsequent regenerations during live preview.
+  - No return value is required.

--- a/packages/core/src/plugins/default/markbind-plugin-plantuml.js
+++ b/packages/core/src/plugins/default/markbind-plugin-plantuml.js
@@ -68,9 +68,10 @@ function generateDiagram(imageOutputPath, content) {
 }
 
 module.exports = {
-  preRender: (content, pluginContext, frontmatter, config) => {
+  beforeSiteGenerate: () => {
     processedDiagrams.clear();
-
+  },
+  preRender: (content, pluginContext, frontmatter, config) => {
     // Processes all <puml> tags
     const $ = cheerio.load(content);
     $('puml').each((i, tag) => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: performance

Fully fixes #1243 
Follow up to https://github.com/MarkBind/markbind/pull/1245#issuecomment-656543043

**What is the rationale for this request?**
The puml plugin generated-diagram-tracking is ineffective as the data structure is cleared during `preRender`, which is called **per page**.

Let's add a **per site (re)generation** plugin hook to solve this

**What changes did you make? (Give an overview)**
- add `beforeSiteGenerate` hook
- implement this for the puml plugin, properly tracking the generated puml diagrams

**Testing instructions:**
The number of jvms spawned should only be the total number of puml **definitions**

**Proposed commit message: (wrap lines at 72 characters)**
Fix redundant puml jvm processes

The puml plugin tracks generated puml images, and does not regenerate
them if the same image has already been generated.

However, the Set data structure that tracks this is cleared during each
call of the plugin preRender hook, which is called per page.
Multiple pages may reference the same diagram, making the tracking
ineffective.

Let's add a new plugin hook, beforeSiteGenerate, that is called during
initial site generation and site regeneration during live preview.
This allows plugins to maintain and clear state during site
(re)generation.

Let's implement this hook in the puml plugin, and clear the Set data
structure in it instead, which properly tracks the generated puml
images.