### PR TITLE
Add live preview support for nunjucks dependencies

### DIFF
--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -3,17 +3,20 @@
   layout: userGuide
 </frontmatter>
 
-#### Live Preview
+#### Live Preview <span style="font-size: 0.8em;">:fas-sync:</span>
 
 <span id="live-preview">
-<md>**_Live preview_ is the regenerating the site upon any change to source files and reloading the updated site in the Browser**.</md>
 
-{{ icon_info }} Live preview works for the following file types only: `css`, `.html`, `.md`, <tooltip content="MarkBind file">`.mbd`</tooltip>, <tooltip content="MarkBind fragment">`.mbdf`</tooltip>. Changes to `css` might may not be visible in the site until you do a manual refresh of the page.
+**_Live preview_** is:
+- Regeneration of affected content upon any change to <tooltip content="`.md`, `.mbd`, `.mbdf`, `.njk` files ... anything your content depends on!">source files</tooltip>, then reloading the updated site in the Browser.
+
+- Copying <tooltip content="files that don't affect page generation (eg. images), but are used in the site">assets</tooltip> to the site output folder.
 
 Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.
 
 </span>
 
+<br>
 
 #### `.mbd` extension
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "markdown-it-texmath": "^0.8.0",
     "markdown-it-video": "^0.6.3",
     "moment": "^2.24.0",
-    "nunjucks": "^3.2.0",
+    "nunjucks": "3.2.2",
     "path-is-inside": "^1.0.2",
     "progress": "^2.0.3",
     "simple-git": "^2.17.0",

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -696,6 +696,7 @@ class Site {
     const filePathArray = Array.isArray(filePaths) ? filePaths : [filePaths];
     const uniquePaths = _.uniq(filePathArray);
     this.runBeforeSiteGenerateHooks();
+    this.variableProcessor.invalidateCache(); // invalidate internal nunjucks cache for file changes
 
     return this.regenerateAffectedPages(uniquePaths)
       .then(() => fs.remove(this.tempPath))
@@ -742,8 +743,9 @@ class Site {
 
   _rebuildSourceFiles() {
     logger.info('Page added or removed, updating list of site\'s pages...');
-    const removedPageFilePaths = this.updateAddressablePages();
+    this.variableProcessor.invalidateCache(); // invalidate internal nunjucks cache for file removals
 
+    const removedPageFilePaths = this.updateAddressablePages();
     return this.removeAsset(removedPageFilePaths)
       .then(() => {
         if (this.onePagePath) {

--- a/packages/core/src/patches/nunjucks.js
+++ b/packages/core/src/patches/nunjucks.js
@@ -1,0 +1,149 @@
+/**
+ Patch for nunjucks to emit the 'load' event, even if the template is accessed from its internal cache.
+ https://mozilla.github.io/nunjucks/api.html#load-event
+
+ This allows page dependencies to be properly collected for live preview in {@link VariableRenderer}.
+
+ Patch is written against nunjucks v3.2.2
+ Changes are delimited with a // CHANGE HERE comment
+ */
+
+const { Environment, Template, lib } = require('nunjucks');
+
+/* eslint-disable */
+
+var noopTmplSrc = {
+  type: 'code',
+  obj: {
+    root: function root(env, context, frame, runtime, cb) {
+      try {
+        cb(null, '');
+      } catch (e) {
+        cb(handleError(e, null, null));
+      }
+    }
+  }
+};
+
+Environment.prototype.getTemplate = function getTemplate(name, eagerCompile, parentName, ignoreMissing, cb) {
+  var _this3 = this;
+
+  var that = this;
+  var tmpl = null;
+
+  if (name && name.raw) {
+    // this fixes autoescape for templates referenced in symbols
+    name = name.raw;
+  }
+
+  if (lib.isFunction(parentName)) {
+    cb = parentName;
+    parentName = null;
+    eagerCompile = eagerCompile || false;
+  }
+
+  if (lib.isFunction(eagerCompile)) {
+    cb = eagerCompile;
+    eagerCompile = false;
+  }
+
+  if (name instanceof Template) {
+    tmpl = name;
+  } else if (typeof name !== 'string') {
+    throw new Error('template names must be a string: ' + name);
+  } else {
+    for (var i = 0; i < this.loaders.length; i++) {
+      var loader = this.loaders[i];
+      tmpl = loader.cache[this.resolveTemplate(loader, parentName, name)];
+
+      if (tmpl) {
+        // CHANGE HERE
+
+        // pathsToNames in nunjucks.loaders.FileSystemLoader maintains a reverse mapping of fullPath: name
+        Object.entries(loader.pathsToNames).forEach(([fullPath, templateName]) => {
+          if (name === templateName) {
+            // Emit the load event
+            this.emit('load', name, {
+              src: tmpl,
+              path: fullPath, // we only need this
+              noCache: loader.noCache
+            }, loader)
+          }
+        });
+
+        break;
+      }
+    }
+  }
+
+  if (tmpl) {
+    if (eagerCompile) {
+      tmpl.compile();
+    }
+
+    if (cb) {
+      cb(null, tmpl);
+      return undefined;
+    } else {
+      return tmpl;
+    }
+  }
+
+  var syncResult;
+
+  var createTemplate = function createTemplate(err, info) {
+    if (!info && !err && !ignoreMissing) {
+      err = new Error('template not found: ' + name);
+    }
+
+    if (err) {
+      if (cb) {
+        cb(err);
+        return;
+      } else {
+        throw err;
+      }
+    }
+
+    var newTmpl;
+
+    if (!info) {
+      newTmpl = new Template(noopTmplSrc, _this3, '', eagerCompile);
+    } else {
+      newTmpl = new Template(info.src, _this3, info.path, eagerCompile);
+
+      if (!info.noCache) {
+        info.loader.cache[name] = newTmpl;
+      }
+    }
+
+    if (cb) {
+      cb(null, newTmpl);
+    } else {
+      syncResult = newTmpl;
+    }
+  };
+
+  lib.asyncIter(this.loaders, function (loader, i, next, done) {
+    function handle(err, src) {
+      if (err) {
+        done(err);
+      } else if (src) {
+        src.loader = loader;
+        done(null, src);
+      } else {
+        next();
+      }
+    } // Resolve name relative to parentName
+
+
+    name = that.resolveTemplate(loader, parentName, name);
+
+    if (loader.async) {
+      loader.getSource(name, handle);
+    } else {
+      handle(null, loader.getSource(name));
+    }
+  }, createTemplate);
+  return syncResult;
+}

--- a/packages/core/src/preprocessors/ComponentPreprocessor.js
+++ b/packages/core/src/preprocessors/ComponentPreprocessor.js
@@ -258,7 +258,8 @@ class ComponentPreprocessor {
     const {
       renderedContent,
       childContext,
-    } = this.variableProcessor.renderIncludeFile(actualFilePath, element, context, filePath);
+    } = this.variableProcessor.renderIncludeFile(actualFilePath, this.pageSources, element,
+                                                 context, filePath);
 
     ComponentPreprocessor._deleteIncludeAttributes(element);
 
@@ -321,25 +322,6 @@ class ComponentPreprocessor {
   }
 
   /*
-   * Variable and imports
-   */
-
-  static _preprocessVariables() {
-    return utils.createEmptyNode();
-  }
-
-  _preprocessImports(node) {
-    if (node.attribs.from) {
-      this.pageSources.staticIncludeSrc.push({
-        from: node.attribs.cwf,
-        to: path.resolve(node.attribs.cwf, node.attribs.from),
-      });
-    }
-
-    return utils.createEmptyNode();
-  }
-
-  /*
    * Body
    */
 
@@ -361,9 +343,8 @@ class ComponentPreprocessor {
     case 'panel':
       return this._preProcessPanel(element, context);
     case 'variable':
-      return ComponentPreprocessor._preprocessVariables();
     case 'import':
-      return this._preprocessImports(node);
+      return utils.createEmptyNode();
     case 'include':
       return this._preprocessInclude(element, context);
     case 'body':


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix
• [x] Enhancement to an existing feature

Fixes #672 

**What is the rationale for this request?**
Live preview does not regenerate pages when a nunjucks dependency has changed (e.g. from `{% include ... %}`

**What changes did you make? (Give an overview)**
- Use the convenient nunjucks https://mozilla.github.io/nunjucks/api.html#load-event api to implement this
- Patch nunjucks to also emit this event even when the rendered template is accessed from its internal cache
  - this is necessary since multiple files sharing the nunjucks environment may reference the same nunjucks dependency
- Bust the nunjucks internal cache during live preview page regeneration
  - freebie bug fix: nunjucks dependency removals and changes do not register during live preview even if the page (which depends on these nunjucks dependencies) is regenerated through other means (e.g. force reload option or editing the page) (#672)

_Alternative considered_:
nunjucks has a `watch` option https://mozilla.github.io/nunjucks/api.html#configure that recompiles templates on file system events, this:
- is expensive, requiring initiating one file watcher per nunjucks environment (i.e. per (sub)site), on top of our own
- only works for file changes and not removals by design
- we do some processing before nunjucks, making this unusable, as it directly compiles the template from the file

**Testing instructions:**
nunjucks + live preview works:
- file change
- file removal
- file additions already worked

**Proposed commit message: (wrap lines at 72 characters)**
Add live preview support for nunjucks dependencies
