### PR TITLE
Remove internal panel _header slot

### DIFF
--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -224,17 +224,17 @@
           <p><span class="keyword">keyword 1</span>
             <span class="keyword">keyword 2</span></p>
           <h1 id="heading-with-keyword-in-panel">Heading with keyword in panel<a class="fa fa-anchor" href="#heading-with-keyword-in-panel" onclick="event.stopPropagation()"></a></h1>
-          <panel expanded><template slot="_header">
+          <panel expanded><template slot="header">
               <p>Panel with keyword</p>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Panel with heading with keyword</strong></p>
-          <panel expanded id="panel-with-heading"><template slot="_header">
+          <panel expanded id="panel-with-heading"><template slot="header">
               <h1 id="panel-with-heading">Panel with heading<a class="fa fa-anchor" href="#panel-with-heading" onclick="event.stopPropagation()"></a></h1>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Expanded panel without heading with keyword</strong></p>
-          <panel expanded id="panel-without-heading-with-keyword"><template slot="_header">
+          <panel expanded id="panel-without-heading-with-keyword"><template slot="header">
               <h1 id="panel-without-heading-with-keyword">Panel without heading with keyword<a class="fa fa-anchor" href="#panel-without-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
             </template>
             <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading">Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading" onclick="event.stopPropagation()"></a></h1>
@@ -242,7 +242,7 @@
           </panel>
           <p></p>
           <p><strong>Unexpanded panel with heading with keyword</strong>
-            <panel id="panel-with-heading-with-keyword"><template slot="_header">
+            <panel id="panel-with-heading-with-keyword"><template slot="header">
                 <h1 id="panel-with-heading-with-keyword">Panel with heading with keyword<a class="fa fa-anchor" href="#panel-with-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
               </template></panel>
           </p>
@@ -336,7 +336,7 @@
           <p><strong>Boilerplate include</strong></p>
           <div name="Boilerplate Referencing">
             <p>
-              <panel src="/test_site/requirements/UserStories._include_.html" no-close><template slot="_header">
+              <panel src="/test_site/requirements/UserStories._include_.html" no-close><template slot="header">
                   <p>Boilerplate Includes</p>
                 </template></panel>
             </p>
@@ -347,7 +347,7 @@
             <p>Also, the boilerplate file name (e.g. <code v-pre>inside.md</code>) and the file that it is supposed to act as (<code v-pre>notInside.md</code>) can be different.</p>
             <p>This file should behaves as if it is in the <code v-pre>requirements</code> folder:</p>
             <p>
-              <panel src="/test_site/requirements/NonFunctionalRequirements._include_.html"><template slot="_header">
+              <panel src="/test_site/requirements/NonFunctionalRequirements._include_.html"><template slot="header">
                   <p>Tested with the folllowing include</p>
                 </template></panel>
             </p>
@@ -464,7 +464,7 @@
               and refine requirements based on their feedback. The next phase is to convert requirements into a product
               specification that specifies how the product will address the requirements.</p>
           </div>
-          <panel src="/test_site/requirements/SpecifyingRequirements._include_.html#preview" type="minimal" fragment="preview"><template slot="_header">
+          <panel src="/test_site/requirements/SpecifyingRequirements._include_.html#preview" type="minimal" fragment="preview"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           <p><strong>Include a file in a sub-folder that uses baseUrl</strong></p>
@@ -475,7 +475,7 @@
                 of understanding what a software product should do.</p>
             </div>
           </div>
-          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="_header">
+          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           <p><strong>Include a file in a sub-folder that uses baseUrl using baseUrl</strong></p>
@@ -486,7 +486,7 @@
                 of understanding what a software product should do.</p>
             </div>
           </div>
-          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="_header">
+          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           <p><strong>Include a file in a sub-site that uses baseUrl</strong></p>
@@ -494,7 +494,7 @@
             <div>
               <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
-          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="_header">
+          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           <p><strong>Include a file in a sub-site that uses baseUrl using baseUrl</strong></p>
@@ -502,7 +502,7 @@
             <div>
               <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
-          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="_header">
+          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           <p><strong>Trimmed include</strong></p>
@@ -550,7 +550,7 @@
               Heading
             </span></panel>
           <p><strong>Panel without src</strong></p>
-          <panel expanded id="panel-without-src-header"><template slot="_header">
+          <panel expanded id="panel-without-src-header"><template slot="header">
               <h2 id="panel-without-src-header">Panel without src header<a class="fa fa-anchor" href="#panel-without-src-header" onclick="event.stopPropagation()"></a></h2>
             </template>
             <div>
@@ -558,40 +558,40 @@
             </div>
           </panel>
           <p><strong>Panel with normal src</strong></p>
-          <panel src="/test_site/testPanels/PanelNormalSource._include_.html" expanded id="panel-with-normal-src-header"><template slot="_header">
+          <panel src="/test_site/testPanels/PanelNormalSource._include_.html" expanded id="panel-with-normal-src-header"><template slot="header">
               <h2 id="panel-with-normal-src-header">Panel with normal src header<a class="fa fa-anchor" href="#panel-with-normal-src-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with src from a page segment</strong></p>
-          <panel src="/test_site/testPanels/PanelSourceContainsSegment._include_.html#segment" expanded fragment="segment" id="panel-with-src-from-a-page-segment-header"><template slot="_header">
+          <panel src="/test_site/testPanels/PanelSourceContainsSegment._include_.html#segment" expanded fragment="segment" id="panel-with-src-from-a-page-segment-header"><template slot="header">
               <h2 id="panel-with-src-from-a-page-segment-header">Panel with src from a page segment header<a class="fa fa-anchor" href="#panel-with-src-from-a-page-segment-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with boilerplate</strong></p>
-          <panel src="/test_site/testPanels/boilerTestPanel._include_.html" expanded id="boilerplate-referencing"><template slot="_header">
+          <panel src="/test_site/testPanels/boilerTestPanel._include_.html" expanded id="boilerplate-referencing"><template slot="header">
               <h2 id="boilerplate-referencing">Boilerplate referencing<a class="fa fa-anchor" href="#boilerplate-referencing" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
-          <panel src="/test_site/testPanels/notInside._include_.html" expanded id="referencing-specified-path-in-boilerplate"><template slot="_header">
+          <panel src="/test_site/testPanels/notInside._include_.html" expanded id="referencing-specified-path-in-boilerplate"><template slot="header">
               <h2 id="referencing-specified-path-in-boilerplate">Referencing specified path in boilerplate<a class="fa fa-anchor" href="#referencing-specified-path-in-boilerplate" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel</strong></p>
-          <panel src="/test_site/testPanels/NestedPanel._include_.html" expanded id="outer-nested-panel"><template slot="_header">
+          <panel src="/test_site/testPanels/NestedPanel._include_.html" expanded id="outer-nested-panel"><template slot="header">
               <h2 id="outer-nested-panel">Outer nested panel<a class="fa fa-anchor" href="#outer-nested-panel" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel without src</strong></p>
-          <panel expanded id="outer-nested-panel-without-src"><template slot="_header">
+          <panel expanded id="outer-nested-panel-without-src"><template slot="header">
               <h2 id="outer-nested-panel-without-src">Outer nested panel without src<a class="fa fa-anchor" href="#outer-nested-panel-without-src" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content of outer nested panel</strong></p>
-            <panel expanded id="inner-panel-header-without-src"><template slot="_header">
+            <panel expanded id="inner-panel-header-without-src"><template slot="header">
                 <h2 id="inner-panel-header-without-src">Inner panel header without src<a class="fa fa-anchor" href="#inner-panel-header-without-src" onclick="event.stopPropagation()"></a></h2>
               </template>
               <p><strong>Panel content of inner nested panel</strong></p>
             </panel>
           </panel>
           <p><strong>Panel with src from another Markbind site</strong></p>
-          <panel src="/test_site/sub_site/index._include_.html" expanded id="panel-with-src-from-another-markbind-site-header"><template slot="_header">
+          <panel src="/test_site/sub_site/index._include_.html" expanded id="panel-with-src-from-another-markbind-site-header"><template slot="header">
               <h2 id="panel-with-src-from-another-markbind-site-header">Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
-          <panel src="/test_site/sub_site/testReuse._include_.html" expanded id="panel-with-src-from-another-markbind-site-header-2"><template slot="_header">
+          <panel src="/test_site/sub_site/testReuse._include_.html" expanded id="panel-with-src-from-another-markbind-site-header-2"><template slot="header">
               <h2 id="panel-with-src-from-another-markbind-site-header-2">Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header-2" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
         </div>
@@ -600,18 +600,18 @@
           <trigger for="modal-with-panel">trigger</trigger>
         </p>
         <b-modal id="modal-with-panel" hide-footer size modal-class="mb-zoom" ref="modal-with-panel"><template slot="modal-title">modal title with panel inside</template>
-          <panel expanded id="panel-inside-modal"><template slot="_header">
+          <panel expanded id="panel-inside-modal"><template slot="header">
               <h2 id="panel-inside-modal">Panel inside modal<a class="fa fa-anchor" href="#panel-inside-modal" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside modal</strong></p>
           </panel>
         </b-modal>
         <p><strong>Unexpanded panel</strong></p>
-        <panel id="unexpanded-panel-header"><template slot="_header">
+        <panel id="unexpanded-panel-header"><template slot="header">
             <h2 id="unexpanded-panel-header">Unexpanded panel header<a class="fa fa-anchor" href="#unexpanded-panel-header" onclick="event.stopPropagation()"></a></h2>
           </template>
           <p><strong>Panel content of unexpanded panel should not appear in search data</strong></p>
-          <panel expanded id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><template slot="_header">
+          <panel expanded id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><template slot="header">
               <h2 id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data">Panel header inside unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside unexpanded panel should not appear in search data</strong></p>

--- a/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
@@ -37,12 +37,12 @@
         <h4 id="should-have-anchor-4">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
         <h5 id="should-have-anchor-5">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
         <h6 id="should-have-anchor-6">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
-        <panel id="should-have-anchor-7"><template slot="_header">
+        <panel id="should-have-anchor-7"><template slot="header">
             <h4 id="should-have-anchor-7">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-7" onclick="event.stopPropagation()"></a></h4>
           </template>
           Lorem ipsum
         </panel>
-        <panel><template slot="_header">
+        <panel><template slot="header">
             <p>Collapsed</p>
           </template>
           <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
@@ -53,7 +53,7 @@
           <h5 id="should-not-have-anchor-5">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
           <h6 id="should-not-have-anchor-6">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
         </panel>
-        <panel expanded><template slot="_header">
+        <panel expanded><template slot="header">
             <p>Expanded</p>
           </template>
           <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
@@ -74,12 +74,12 @@
           <h4 id="should-have-anchor-17">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-17" onclick="event.stopPropagation()"></a></h4>
           <h5 id="should-have-anchor-18">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-18" onclick="event.stopPropagation()"></a></h5>
           <h6 id="should-have-anchor-19">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-19" onclick="event.stopPropagation()"></a></h6>
-          <panel id="should-have-anchor-20"><template slot="_header">
+          <panel id="should-have-anchor-20"><template slot="header">
               <h4 id="should-have-anchor-20">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-20" onclick="event.stopPropagation()"></a></h4>
             </template>
             Lorem ipsum
           </panel>
-          <panel><template slot="_header">
+          <panel><template slot="header">
               <p>Collapsed</p>
             </template>
             <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
@@ -90,7 +90,7 @@
             <h5 id="should-not-have-anchor-11">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-11" onclick="event.stopPropagation()"></a></h5>
             <h6 id="should-not-have-anchor-12">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-12" onclick="event.stopPropagation()"></a></h6>
           </panel>
-          <panel expanded><template slot="_header">
+          <panel expanded><template slot="header">
               <p>Expanded</p>
             </template>
             <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>

--- a/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
@@ -1,3 +1,3 @@
-<panel src="/test_site/testPanels/NormalPanelContent._include_.html" expanded id="nested-panel"><template slot="_header">
+<panel src="/test_site/testPanels/NormalPanelContent._include_.html" expanded id="nested-panel"><template slot="header">
     <h2 id="nested-panel">Nested Panel<a class="fa fa-anchor" href="#nested-panel" onclick="event.stopPropagation()"></a></h2>
   </template></panel>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -50,12 +50,12 @@
         </b-modal>
         <trigger for="modal:trigger_id">Trigger should not have `algolia-no-index` class</trigger>
         <p><strong>Panels that are not expanded should have algolia-no-index class</strong></p>
-        <panel class="algolia-no-index"><template slot="_header">
+        <panel class="algolia-no-index"><template slot="header">
             <p>Panel</p>
           </template>
           Content
         </panel>
-        <panel expanded><template slot="_header">
+        <panel expanded><template slot="header">
             <p>Panel</p>
           </template>
           Content

--- a/packages/cli/test/functional/test_site_expressive_layout/expected/index.html
+++ b/packages/cli/test/functional/test_site_expressive_layout/expected/index.html
@@ -31,7 +31,7 @@
         <div></div>
         <p>Variable from layout</p>
         <p>This is an importedVar</p>
-        <panel type="success" minimized><template slot="_header">
+        <panel type="success" minimized><template slot="header">
             <p>Expanded panel</p>
           </template><template slot="_alt">
             <p>Minimized panel</p>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -183,13 +183,13 @@
         </box>
         <br>
         <h1 id="heading-3">Heading 3<a class="fa fa-anchor" href="#heading-3" onclick="event.stopPropagation()"></a></h1>
-        <panel type="info"><template slot="_header">
+        <panel type="info"><template slot="header">
             <p>Expandable panel</p>
           </template>
           Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.
         </panel>
         <br>
-        <panel type="success" minimized><template slot="_header">
+        <panel type="success" minimized><template slot="header">
             <p>Expanded panel</p>
           </template><template slot="_alt">
             <p>Minimized panel</p>
@@ -197,7 +197,7 @@
           ...
         </panel>
         <br>
-        <panel type="seamless"><template slot="_header">
+        <panel type="seamless"><template slot="header">
             <p>Expanded panel</p>
           </template><template slot="_alt">
             <p>Minimized panel</p>
@@ -206,7 +206,7 @@
         </panel>
         <br>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          <panel type="minimal" popup-url="https://markbind.org/userGuide/usingComponents.html#panels" no-switch><template slot="_header">
+          <panel type="minimal" popup-url="https://markbind.org/userGuide/usingComponents.html#panels" no-switch><template slot="header">
               <p><em><strong>Minimal panel <strong>-&gt;</strong></strong></em></p>
             </template><template slot="_alt">
               <p>Minimal panel</p>

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -315,7 +315,7 @@ class Page {
       }
 
       // Check if heading / panel is under a panel's header slots, which is handled specially below.
-      const slotParents = $(elem).parentsUntil(context).filter('[slot="header"], [slot="_header"]').not(elem);
+      const slotParents = $(elem).parentsUntil(context).filter('[slot="header"]').not(elem);
       const panelSlotParents = slotParents.parent('panel');
       if (panelSlotParents.length) {
         return;
@@ -323,8 +323,7 @@ class Page {
 
       if (elem.name === 'panel') {
         // Recurse only on the slot which has priority
-        let headings = $(elem).children('[slot="header"]');
-        headings = headings.length ? headings : $(elem).children('[slot="_header"]');
+        const headings = $(elem).children('[slot="header"]');
         if (!headings.length) return;
 
         this._collectNavigableHeadings($, headings.first(), pageNavSelector);
@@ -363,12 +362,6 @@ class Page {
         if (slotHeader.length) {
           this.collectHeadingsAndKeywordsInContent(slotHeader.html(),
                                                    lastHeading, excludeHeadings, sourceTraversalStack);
-        } else {
-          const headerAttr = $(panel).children('[slot="_header"]');
-          if (headerAttr.length) {
-            this.collectHeadingsAndKeywordsInContent(headerAttr.html(),
-                                                     lastHeading, excludeHeadings, sourceTraversalStack);
-          }
         }
       })
       .each((index, panel) => {
@@ -380,12 +373,8 @@ class Page {
         const slotHeadings = $(panel).children('[slot="header"]').find(':header');
         if (slotHeadings.length) {
           closestHeading = slotHeadings.first();
-        } else {
-          const attributeHeadings = $(panel).children('[slot="_header"]').find(':header');
-          if (attributeHeadings.length) {
-            closestHeading = attributeHeadings.first();
-          }
         }
+
         if (panel.attribs.src) {
           const src = panel.attribs.src.split('#')[0];
           const buildInnerDir = path.dirname(this.pageConfig.sourcePath);

--- a/packages/core/src/parsers/ComponentParser.js
+++ b/packages/core/src/parsers/ComponentParser.js
@@ -106,18 +106,7 @@ class ComponentParser {
 
   static _parsePanelAttributes(node) {
     ComponentParser._parseAttributeWithoutOverride(node, 'alt', false, '_alt');
-
-    const slotChildren = node.children && node.children.filter(child => _.has(child.attribs, 'slot'));
-    const hasAltSlot = slotChildren && slotChildren.some(child => child.attribs.slot === '_alt');
-    const hasHeaderSlot = slotChildren && slotChildren.some(child => child.attribs.slot === 'header');
-
-    // If both are present, the header attribute has no effect, and we can simply remove it.
-    if (hasAltSlot && hasHeaderSlot) {
-      delete node.attribs.header;
-      return;
-    }
-
-    ComponentParser._parseAttributeWithoutOverride(node, 'header', false, '_header');
+    ComponentParser._parseAttributeWithoutOverride(node, 'header', false);
   }
 
   /**
@@ -155,11 +144,9 @@ class ComponentParser {
   static _assignPanelId(node) {
     const slotChildren = node.children && node.children.filter(child => _.has(child.attribs, 'slot'));
     const headerSlot = slotChildren.find(child => child.attribs.slot === 'header');
-    const headerAttributeSlot = slotChildren.find(child => child.attribs.slot === '_header');
 
-    const slotElement = headerSlot || headerAttributeSlot;
-    if (slotElement) {
-      const header = ComponentParser._findHeaderElement(slotElement);
+    if (headerSlot) {
+      const header = ComponentParser._findHeaderElement(headerSlot);
       if (!header) {
         return;
       }

--- a/packages/core/test/unit/ComponentParser.data.js
+++ b/packages/core/test/unit/ComponentParser.data.js
@@ -11,7 +11,7 @@ module.exports.PARSE_PANEL_ATTRIBUTES = `
 `;
 
 module.exports.PARSE_PANEL_ATTRIBUTES_EXPECTED = `
-<panel><template slot="_header"><h1>Lorem ipsum</h1>
+<panel><template slot="header"><h1>Lorem ipsum</h1>
 </template><template slot="_alt"><p><em>emphasized alt</em></p>
 </template>
   Header and alt attributes should be parsed and inserted under panel as internal slots and deleted.
@@ -42,32 +42,15 @@ module.exports.PARSE_PANEL_HEADER_NO_OVERRIDE_EXPECTED = `
 `;
 
 // Post Parse
-module.exports.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_ATTRIBUTE = `
-<panel><template slot="_header"><h1 id="lorem-ipsum">Lorem ipsum</h1>
-</template>
-  Header and alt attributes should be parsed and inserted under panel as internal slots and deleted.
-</panel>
-`;
-
-module.exports.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_ATTRIBUTE_EXPECTED = `
-<panel id="lorem-ipsum"><template slot="_header"><h1 id="lorem-ipsum">Lorem ipsum</h1>
-</template>
-  Header and alt attributes should be parsed and inserted under panel as internal slots and deleted.
-</panel>
-`;
 
 module.exports.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_SLOT = `
-<panel><template slot="_header"><h1 id="attribute-header">Attribute Header</h1>
-</template>
-<template slot="header"><h1 id="slot-header">Slot Header</h1></template>
+<panel><template slot="header"><h1 id="slot-header">Slot Header</h1></template>
   Header and alt attributes should be parsed and inserted under panel as internal slots and deleted.
 </panel>
 `;
 
 module.exports.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_SLOT_EXPECTED = `
-<panel id="slot-header"><template slot="_header"><h1 id="attribute-header">Attribute Header</h1>
-</template>
-<template slot="header"><h1 id="slot-header">Slot Header</h1></template>
+<panel id="slot-header"><template slot="header"><h1 id="slot-header">Slot Header</h1></template>
   Header and alt attributes should be parsed and inserted under panel as internal slots and deleted.
 </panel>
 `;

--- a/packages/core/test/unit/ComponentParser.test.js
+++ b/packages/core/test/unit/ComponentParser.test.js
@@ -112,9 +112,6 @@ test('parseComponent parses box attributes and inserts into dom as slots correct
 });
 
 test('postParseComponent assigns the correct header id to panels', () => {
-  parseAndVerifyTemplate(testData.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_ATTRIBUTE,
-                         testData.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_ATTRIBUTE_EXPECTED,
-                         true);
   parseAndVerifyTemplate(testData.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_SLOT,
                          testData.POST_PARSE_PANEL_ID_ASSIGNED_USING_HEADER_SLOT_EXPECTED,
                          true);

--- a/packages/vue-components/src/panels/MinimalPanel.vue
+++ b/packages/vue-components/src/panels/MinimalPanel.vue
@@ -3,9 +3,7 @@
     <div v-show="localMinimized" class="morph">
       <button class="morph-display-wrapper btn card-title morph-title" @click="open()">
         <slot name="_alt">
-          <slot name="_header">
-            <slot name="header"></slot>
-          </slot>
+          <slot name="header"></slot>
         </slot>
       </button>
     </div>
@@ -21,14 +19,12 @@
             ref="headerWrapper"
             :class="['card-title', 'card-title-transparent', { 'ellipses': !hasHeaderBool }]"
           >
-            <slot name="header">
-              <span class="card-title-inline"><slot name="_header"></slot></span>
-              <span
-                v-show="showDownSwitch"
-                aria-hidden="true"
-                class="minimal-button glyphicon glyphicon-menu-down minimal-menu-down"
-              ></span>
-            </slot>
+            <span class="card-title-inline"><slot name="header"></slot></span>
+            <span
+              v-show="showDownSwitch"
+              aria-hidden="true"
+              class="minimal-button glyphicon glyphicon-menu-down minimal-menu-down"
+            ></span>
           </span>
         </transition>
         <div :class="['button-wrapper', { 'button-wrapper-expanded': isHeaderAtBottom }]">

--- a/packages/vue-components/src/panels/NestedPanel.vue
+++ b/packages/vue-components/src/panels/NestedPanel.vue
@@ -3,9 +3,7 @@
     <div v-show="localMinimized" class="morph">
       <button :class="['morph-display-wrapper', 'btn', btnType, 'card-title']" @click="open()">
         <slot name="_alt">
-          <slot name="_header">
-            <slot name="header"></slot>
-          </slot>
+          <slot name="header"></slot>
         </slot>
       </button>
     </div>
@@ -20,12 +18,8 @@
             :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']"
           ></span>
         </div>
-        <div ref="headerWrapper" class="header-wrapper">
-          <slot name="header">
-            <div :class="['card-title', cardType, {'text-white':!isLightBg}]">
-              <slot name="_header"></slot>
-            </div>
-          </slot>
+        <div ref="headerWrapper" :class="['header-wrapper card-title', cardType, {'text-white':!isLightBg}]">
+          <slot name="header"></slot>
         </div>
         <div class="button-wrapper">
           <slot name="button">

--- a/packages/vue-components/src/panels/PanelBase.js
+++ b/packages/vue-components/src/panels/PanelBase.js
@@ -78,7 +78,7 @@ export default {
     },
     // Vue 2.0 coerce migration end
     hasHeaderBool() {
-      return this.$slots._header || this.$slots.header;
+      return this.$slots.header;
     },
     isExpandableCard() {
       return this.expandableBool;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: small code quality improvement

**What is the rationale for this request?**
small code quality improvement - reduce the number of code paths, especially in heading indexing

**What changes did you make? (Give an overview)**
Remove the internal panel `header` attribute -> `_header` slot transformation, and just use the `header` slot.
The `header` slot (if any) is still preserved if present, so the priority of attributes / slots remains the same

**Proposed commit message: (wrap lines at 72 characters)**
Remove internal panel _header slot