### PR TITLE
Move heading and keyword collection into Page

### DIFF
--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -927,6 +927,7 @@ class Page {
         return Promise.all(resolvingFiles);
       })
       .then(() => {
+        this.collectHeadingsAndKeywords();
         this.collectIncludedFiles(pageSources.getDynamicIncludeSrc());
         this.collectIncludedFiles(pageSources.getStaticIncludeSrc());
         this.collectIncludedFiles(pageSources.getMissingIncludeSrc());


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: code maintainence

**What is the rationale for this request?**
- Less code
- Let a `Page` index its own content, not defer it to `Site` unnecessarily which leaks responsibilities

**What changes did you make? (Give an overview)**
Move the `page.collectHeadingsAndKeywords()` call into `Page`


**Proposed commit message: (wrap lines at 72 characters)**
Move heading and keyword collection into Page