### PR TITLE
Fix external dependency generation resolving

### DIFF
--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -754,7 +754,7 @@ class Site {
         }
 
         this.toRebuild.delete(normalizedUrl);
-        pageToRebuild.generate(new Set())
+        pageToRebuild.generate({})
           .then(() => this.writeSiteData())
           .then(() => {
             const endTime = new Date();
@@ -1043,7 +1043,7 @@ class Site {
    * @return {Promise} that resolves once all pages have generated
    */
   static generatePagesThrottled(pages) {
-    const builtFiles = new Set();
+    const builtFiles = {};
 
     const progressBar = new ProgressBar(`[:bar] :current / ${pages.length} pages built`,
                                         { total: pages.length });
@@ -1110,7 +1110,7 @@ class Site {
       return Promise.reject(new Error(`${this.onePagePath} is not specified in the site configuration.`));
     }
 
-    return landingPage.generate(new Set());
+    return landingPage.generate({});
   }
 
   regenerateAffectedPages(filePaths) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix: regression from #1364 


**What is the rationale for this request?**
Quick follow up to #1364, fixing an exposed race condition

**What changes did you make? (Give an overview)**
If an external dependency generation is in progress, resolve other generations (of the same dependency) only when the first (and only) external dependency generation has resolved.

**Proposed commit message: (wrap lines at 72 characters)**
Fix external dependency generation resolving

External dependencies are not regenerated if the same dependency is
being (or has finished) generated.
In such cases, the generation promise short circuits and immediately
resolves, without waiting for the same existing dependency to finish
generating.

This causes heading and keyword collection in Page to fail, which
relies on all its dependencies to have generated.
Let's return the same existing generation promise in such cases instead.