### PR TITLE
Generate heading anchors without fixed headers

### DIFF
--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -52,7 +52,7 @@
         <div class="border-right-grey nav-inner position-sticky slim-scroll">
           <ul class="site-nav-list site-nav-list-root">
             <li class="site-nav-custom-list-item site-nav-list-item-0">
-              <h2 id="navigation">Navigation<a class="fa fa-anchor" href="#navigation" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="navigation"><span id="navigation" class="anchor"></span>Navigation<a class="fa fa-anchor" href="#navigation" onclick="event.stopPropagation()"></a></h2>
             </li>
             <li>
               <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/test_site/index.html" class="current">Home 🏠</a></div>
@@ -61,7 +61,7 @@
               <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><a href="/test_site/bugs/index.html">Open Bugs 🐛</a></div>
             </li>
             <li class="site-nav-custom-list-item site-nav-list-item-0">
-              <h3 id="testing-site-nav">Testing Site-Nav<a class="fa fa-anchor" href="#testing-site-nav" onclick="event.stopPropagation()"></a></h3>
+              <h3 id="testing-site-nav"><span id="testing-site-nav" class="anchor"></span>Testing Site-Nav<a class="fa fa-anchor" href="#testing-site-nav" onclick="event.stopPropagation()"></a></h3>
             </li>
             <li>
               <div class="site-nav-default-list-item site-nav-list-item-0" onclick="handleSiteNavClick(this)"><strong>Dropdown </strong> <span aria-hidden="true" class="glyphicon glyphicon-search"></span> title ✏️
@@ -220,50 +220,50 @@
           </div>
           <p>Variables for includes should not be recognised as page variables, hence, there should be no text between <strong>this</strong></p>
           <p>and <strong>this</strong>.</p>
-          <h1 id="heading-with-multiple-keywords">Heading with multiple keywords<a class="fa fa-anchor" href="#heading-with-multiple-keywords" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="heading-with-multiple-keywords"><span id="heading-with-multiple-keywords" class="anchor"></span>Heading with multiple keywords<a class="fa fa-anchor" href="#heading-with-multiple-keywords" onclick="event.stopPropagation()"></a></h1>
           <p><span class="keyword">keyword 1</span>
             <span class="keyword">keyword 2</span></p>
-          <h1 id="heading-with-keyword-in-panel">Heading with keyword in panel<a class="fa fa-anchor" href="#heading-with-keyword-in-panel" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="heading-with-keyword-in-panel"><span id="heading-with-keyword-in-panel" class="anchor"></span>Heading with keyword in panel<a class="fa fa-anchor" href="#heading-with-keyword-in-panel" onclick="event.stopPropagation()"></a></h1>
           <panel expanded><template slot="header">
               <p>Panel with keyword</p>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Panel with heading with keyword</strong></p>
           <panel expanded id="panel-with-heading"><template slot="header">
-              <h1 id="panel-with-heading">Panel with heading<a class="fa fa-anchor" href="#panel-with-heading" onclick="event.stopPropagation()"></a></h1>
+              <h1 id="panel-with-heading"><span id="panel-with-heading" class="anchor"></span>Panel with heading<a class="fa fa-anchor" href="#panel-with-heading" onclick="event.stopPropagation()"></a></h1>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Expanded panel without heading with keyword</strong></p>
           <panel expanded id="panel-without-heading-with-keyword"><template slot="header">
-              <h1 id="panel-without-heading-with-keyword">Panel without heading with keyword<a class="fa fa-anchor" href="#panel-without-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
+              <h1 id="panel-without-heading-with-keyword"><span id="panel-without-heading-with-keyword" class="anchor"></span>Panel without heading with keyword<a class="fa fa-anchor" href="#panel-without-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
             </template>
-            <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading">Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading" onclick="event.stopPropagation()"></a></h1>
+            <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading"><span id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading" class="anchor"></span>Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading" onclick="event.stopPropagation()"></a></h1>
             <p><span class="keyword">panel keyword</span></p>
           </panel>
           <p></p>
           <p><strong>Unexpanded panel with heading with keyword</strong>
             <panel id="panel-with-heading-with-keyword"><template slot="header">
-                <h1 id="panel-with-heading-with-keyword">Panel with heading with keyword<a class="fa fa-anchor" href="#panel-with-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
+                <h1 id="panel-with-heading-with-keyword"><span id="panel-with-heading-with-keyword" class="anchor"></span>Panel with heading with keyword<a class="fa fa-anchor" href="#panel-with-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
               </template></panel>
           </p>
-          <h1 id="keyword-should-be-tagged-to-the-panel-heading-not-this-heading">Keyword should be tagged to the panel heading, not this heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-the-panel-heading-not-this-heading" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="keyword-should-be-tagged-to-the-panel-heading-not-this-heading"><span id="keyword-should-be-tagged-to-the-panel-heading-not-this-heading" class="anchor"></span>Keyword should be tagged to the panel heading, not this heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-the-panel-heading-not-this-heading" onclick="event.stopPropagation()"></a></h1>
           <p><span class="keyword">panel keyword</span></p>
-          <h1 id="heading-with-included-keyword">Heading with included keyword<a class="fa fa-anchor" href="#heading-with-included-keyword" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="heading-with-included-keyword"><span id="heading-with-included-keyword" class="anchor"></span>Heading with included keyword<a class="fa fa-anchor" href="#heading-with-included-keyword" onclick="event.stopPropagation()"></a></h1>
           <div>
             <p><span class="keyword">included keyword</span></p>
           </div>
           <div>
-            <h1 id="included-heading">Included Heading<a class="fa fa-anchor" href="#included-heading" onclick="event.stopPropagation()"></a></h1>
+            <h1 id="included-heading"><span id="included-heading" class="anchor"></span>Included Heading<a class="fa fa-anchor" href="#included-heading" onclick="event.stopPropagation()"></a></h1>
           </div>
           <span class="keyword">Keyword with included heading</span>
-          <h1 id="heading-with-nested-keyword">Heading with nested keyword<a class="fa fa-anchor" href="#heading-with-nested-keyword" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="heading-with-nested-keyword"><span id="heading-with-nested-keyword" class="anchor"></span>Heading with nested keyword<a class="fa fa-anchor" href="#heading-with-nested-keyword" onclick="event.stopPropagation()"></a></h1>
           <div>
             <div>
               <div>
                 <span class="keyword">nested keyword</span></div>
             </div>
           </div>
-          <h1 id="heading-with-hidden-keyword">Heading with hidden keyword<a class="fa fa-anchor" href="#heading-with-hidden-keyword" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="heading-with-hidden-keyword"><span id="heading-with-hidden-keyword" class="anchor"></span>Heading with hidden keyword<a class="fa fa-anchor" href="#heading-with-hidden-keyword" onclick="event.stopPropagation()"></a></h1>
           <p><span class="keyword d-none">invisible keyword</span></p>
           <div>
             <p><strong>Div with frontmatter shown tag</strong></p>
@@ -305,22 +305,22 @@
           </div>
           <p><strong>Normal include</strong></p>
           <div>
-            <h3 id="establishing-requirements">Establishing Requirements<a class="fa fa-anchor" href="#establishing-requirements" onclick="event.stopPropagation()"></a></h3>
+            <h3 id="establishing-requirements"><span id="establishing-requirements" class="anchor"></span>Establishing Requirements<a class="fa fa-anchor" href="#establishing-requirements" onclick="event.stopPropagation()"></a></h3>
             <p>
               <seg id="preview">Requirements gathering, requirements elicitation, requirements analysis,
                 requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
                 of understanding what a software product should do.</seg>
             </p>
             <p>There are many techniques used during a requirements gathering. The following are some of the techniques.</p>
-            <h4 id="brainstorming">Brainstorming<a class="fa fa-anchor" href="#brainstorming" onclick="event.stopPropagation()"></a></h4>
+            <h4 id="brainstorming"><span id="brainstorming" class="anchor"></span>Brainstorming<a class="fa fa-anchor" href="#brainstorming" onclick="event.stopPropagation()"></a></h4>
             <p>Brainstorming is a group activity designed to generate a large number of diverse and creative ideas for the solution
               of a problem. In a brainstorming session there are no &quot;bad&quot; ideas.
               The aim is to generate ideas; not to validate them. Brainstorming encourages you to &quot;think outside the box&quot; and
               put &quot;crazy&quot; ideas on the table without fear of rejection.</p>
-            <h4 id="user-surveys">User surveys<a class="fa fa-anchor" href="#user-surveys" onclick="event.stopPropagation()"></a></h4>
+            <h4 id="user-surveys"><span id="user-surveys" class="anchor"></span>User surveys<a class="fa fa-anchor" href="#user-surveys" onclick="event.stopPropagation()"></a></h4>
             <p>Carefully designed questionnaires can be used to solicit responses and opinions from a large number of users regarding
               any current system or a new innovation.</p>
-            <h4 id="focus-groups">Focus groups<a class="fa fa-anchor" href="#focus-groups" onclick="event.stopPropagation()"></a></h4>
+            <h4 id="focus-groups"><span id="focus-groups" class="anchor"></span>Focus groups<a class="fa fa-anchor" href="#focus-groups" onclick="event.stopPropagation()"></a></h4>
             <p>Focus groups are a kind of informal interview within an interactive group setting.
               A <span data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content">e.g. potential users, beta testers</span>group of people</span>
               are asked about their understanding of a specific issue or a process.
@@ -342,7 +342,7 @@
             </p>
           </div>
           <div name="Referencing specified path in boilerplate">
-            <h1 id="path-within-the-boilerplate-folder-is-separately-specified">Path within the boilerplate folder is separately specified<a class="fa fa-anchor" href="#path-within-the-boilerplate-folder-is-separately-specified" onclick="event.stopPropagation()"></a></h1>
+            <h1 id="path-within-the-boilerplate-folder-is-separately-specified"><span id="path-within-the-boilerplate-folder-is-separately-specified" class="anchor"></span>Path within the boilerplate folder is separately specified<a class="fa fa-anchor" href="#path-within-the-boilerplate-folder-is-separately-specified" onclick="event.stopPropagation()"></a></h1>
             <p>Like static include, pages within the site should be able to use files located in folders within boilerplate.</p>
             <p>Also, the boilerplate file name (e.g. <code v-pre>inside.md</code>) and the file that it is supposed to act as (<code v-pre>notInside.md</code>) can be different.</p>
             <p>This file should behaves as if it is in the <code v-pre>requirements</code> folder:</p>
@@ -379,7 +379,7 @@
           <p><strong>Include from another Markbind site</strong></p>
           <div>
             <p>This is a page from another Markbind site.</p>
-            <h2 id="feature-list">Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
+            <h2 id="feature-list"><span id="feature-list" class="anchor"></span>Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
             <p>It is a list of features (or functionalities) grouped according to some criteria such as priority
               (e.g. must-have, nice-to-have, etc. ), order of delivery, object or process related
               (e.g. order-related, invoice-related, etc.).
@@ -551,7 +551,7 @@
             </span></panel>
           <p><strong>Panel without src</strong></p>
           <panel expanded id="panel-without-src-header"><template slot="header">
-              <h2 id="panel-without-src-header">Panel without src header<a class="fa fa-anchor" href="#panel-without-src-header" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-without-src-header"><span id="panel-without-src-header" class="anchor"></span>Panel without src header<a class="fa fa-anchor" href="#panel-without-src-header" onclick="event.stopPropagation()"></a></h2>
             </template>
             <div>
               <p><strong>Panel without src content heading</strong></p>
@@ -559,40 +559,40 @@
           </panel>
           <p><strong>Panel with normal src</strong></p>
           <panel src="/test_site/testPanels/PanelNormalSource._include_.html" expanded id="panel-with-normal-src-header"><template slot="header">
-              <h2 id="panel-with-normal-src-header">Panel with normal src header<a class="fa fa-anchor" href="#panel-with-normal-src-header" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-with-normal-src-header"><span id="panel-with-normal-src-header" class="anchor"></span>Panel with normal src header<a class="fa fa-anchor" href="#panel-with-normal-src-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with src from a page segment</strong></p>
           <panel src="/test_site/testPanels/PanelSourceContainsSegment._include_.html#segment" expanded fragment="segment" id="panel-with-src-from-a-page-segment-header"><template slot="header">
-              <h2 id="panel-with-src-from-a-page-segment-header">Panel with src from a page segment header<a class="fa fa-anchor" href="#panel-with-src-from-a-page-segment-header" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-with-src-from-a-page-segment-header"><span id="panel-with-src-from-a-page-segment-header" class="anchor"></span>Panel with src from a page segment header<a class="fa fa-anchor" href="#panel-with-src-from-a-page-segment-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with boilerplate</strong></p>
           <panel src="/test_site/testPanels/boilerTestPanel._include_.html" expanded id="boilerplate-referencing"><template slot="header">
-              <h2 id="boilerplate-referencing">Boilerplate referencing<a class="fa fa-anchor" href="#boilerplate-referencing" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="boilerplate-referencing"><span id="boilerplate-referencing" class="anchor"></span>Boilerplate referencing<a class="fa fa-anchor" href="#boilerplate-referencing" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <panel src="/test_site/testPanels/notInside._include_.html" expanded id="referencing-specified-path-in-boilerplate"><template slot="header">
-              <h2 id="referencing-specified-path-in-boilerplate">Referencing specified path in boilerplate<a class="fa fa-anchor" href="#referencing-specified-path-in-boilerplate" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="referencing-specified-path-in-boilerplate"><span id="referencing-specified-path-in-boilerplate" class="anchor"></span>Referencing specified path in boilerplate<a class="fa fa-anchor" href="#referencing-specified-path-in-boilerplate" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel</strong></p>
           <panel src="/test_site/testPanels/NestedPanel._include_.html" expanded id="outer-nested-panel"><template slot="header">
-              <h2 id="outer-nested-panel">Outer nested panel<a class="fa fa-anchor" href="#outer-nested-panel" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="outer-nested-panel"><span id="outer-nested-panel" class="anchor"></span>Outer nested panel<a class="fa fa-anchor" href="#outer-nested-panel" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel without src</strong></p>
           <panel expanded id="outer-nested-panel-without-src"><template slot="header">
-              <h2 id="outer-nested-panel-without-src">Outer nested panel without src<a class="fa fa-anchor" href="#outer-nested-panel-without-src" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="outer-nested-panel-without-src"><span id="outer-nested-panel-without-src" class="anchor"></span>Outer nested panel without src<a class="fa fa-anchor" href="#outer-nested-panel-without-src" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content of outer nested panel</strong></p>
             <panel expanded id="inner-panel-header-without-src"><template slot="header">
-                <h2 id="inner-panel-header-without-src">Inner panel header without src<a class="fa fa-anchor" href="#inner-panel-header-without-src" onclick="event.stopPropagation()"></a></h2>
+                <h2 id="inner-panel-header-without-src"><span id="inner-panel-header-without-src" class="anchor"></span>Inner panel header without src<a class="fa fa-anchor" href="#inner-panel-header-without-src" onclick="event.stopPropagation()"></a></h2>
               </template>
               <p><strong>Panel content of inner nested panel</strong></p>
             </panel>
           </panel>
           <p><strong>Panel with src from another Markbind site</strong></p>
           <panel src="/test_site/sub_site/index._include_.html" expanded id="panel-with-src-from-another-markbind-site-header"><template slot="header">
-              <h2 id="panel-with-src-from-another-markbind-site-header">Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-with-src-from-another-markbind-site-header"><span id="panel-with-src-from-another-markbind-site-header" class="anchor"></span>Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <panel src="/test_site/sub_site/testReuse._include_.html" expanded id="panel-with-src-from-another-markbind-site-header-2"><template slot="header">
-              <h2 id="panel-with-src-from-another-markbind-site-header-2">Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header-2" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-with-src-from-another-markbind-site-header-2"><span id="panel-with-src-from-another-markbind-site-header-2" class="anchor"></span>Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header-2" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
         </div>
         <p><strong>Modal with panel inside</strong></p>
@@ -601,25 +601,25 @@
         </p>
         <b-modal id="modal-with-panel" hide-footer size modal-class="mb-zoom" ref="modal-with-panel"><template slot="modal-title">modal title with panel inside</template>
           <panel expanded id="panel-inside-modal"><template slot="header">
-              <h2 id="panel-inside-modal">Panel inside modal<a class="fa fa-anchor" href="#panel-inside-modal" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-inside-modal"><span id="panel-inside-modal" class="anchor"></span>Panel inside modal<a class="fa fa-anchor" href="#panel-inside-modal" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside modal</strong></p>
           </panel>
         </b-modal>
         <p><strong>Unexpanded panel</strong></p>
         <panel id="unexpanded-panel-header"><template slot="header">
-            <h2 id="unexpanded-panel-header">Unexpanded panel header<a class="fa fa-anchor" href="#unexpanded-panel-header" onclick="event.stopPropagation()"></a></h2>
+            <h2 id="unexpanded-panel-header"><span id="unexpanded-panel-header" class="anchor"></span>Unexpanded panel header<a class="fa fa-anchor" href="#unexpanded-panel-header" onclick="event.stopPropagation()"></a></h2>
           </template>
           <p><strong>Panel content of unexpanded panel should not appear in search data</strong></p>
           <panel expanded id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><template slot="header">
-              <h2 id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data">Panel header inside unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" onclick="event.stopPropagation()"></a></h2>
+              <h2 id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><span id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" class="anchor"></span>Panel header inside unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside unexpanded panel should not appear in search data</strong></p>
           </panel>
         </panel>
         <p><strong>Test plugin in markbind/plugins</strong></p>
         <div id="test-markbind-plugin">
-          <h1 id="markbind-plugin-pre-render">Markbind Plugin Pre-render<a class="fa fa-anchor" href="#markbind-plugin-pre-render" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="markbind-plugin-pre-render"><span id="markbind-plugin-pre-render" class="anchor"></span>Markbind Plugin Pre-render<a class="fa fa-anchor" href="#markbind-plugin-pre-render" onclick="event.stopPropagation()"></a></h1>
           <p>Node Modules Plugin Post-render</p>
         </div>
         <p><strong>Test search indexing</strong></p>
@@ -663,8 +663,8 @@
             <pic src="/test_site/diagrams/object.png"></pic>
           </p>
         </div>
-        <h2 class="no-index" id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed">Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed<a class="fa fa-anchor" href="#level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed" onclick="event.stopPropagation()"></a></h2>
-        <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed">Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed<a class="fa fa-anchor" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed" onclick="event.stopPropagation()"></a></h6>
+        <h2 class="no-index" id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed"><span id="level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed" class="anchor"></span>Level 2 header (inside headingSearchIndex) with no-index attribute should not be indexed<a class="fa fa-anchor" href="#level-2-header-inside-headingsearchindex-with-no-index-attribute-should-not-be-indexed" onclick="event.stopPropagation()"></a></h2>
+        <h6 class="always-index" id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed"><span id="level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed" class="anchor"></span>Level 6 header (outside headingSearchIndex) with always-index attribute should be indexed<a class="fa fa-anchor" href="#level-6-header-outside-headingsearchindex-with-always-index-attribute-should-be-indexed" onclick="event.stopPropagation()"></a></h6>
         <p><strong>Test nunjucks raw tags</strong></p>
         <div v-pre>{{ variable interpolation syntax can be used with v-pre }}</div>
         <div v-pre>{{ nonExistentVariable }}</div>
@@ -762,7 +762,7 @@
       </nav>
     </div>
     <footer>
-      <h1 id="heading-in-footer-should-not-be-indexed">Heading in footer should not be indexed<a class="fa fa-anchor" href="#heading-in-footer-should-not-be-indexed" onclick="event.stopPropagation()"></a></h1>
+      <h1 id="heading-in-footer-should-not-be-indexed"><span id="heading-in-footer-should-not-be-indexed" class="anchor"></span>Heading in footer should not be indexed<a class="fa fa-anchor" href="#heading-in-footer-should-not-be-indexed" onclick="event.stopPropagation()"></a></h1>
       <div class="text-center">
         This is a dynamic height footer that supports markdown <span>😄</span>!
       </div>

--- a/packages/cli/test/functional/test_site/expected/requirements/SpecifyingRequirements._include_.html
+++ b/packages/cli/test/functional/test_site/expected/requirements/SpecifyingRequirements._include_.html
@@ -1,4 +1,4 @@
-<h1 id="specifying-requirements">Specifying requirements<a class="fa fa-anchor" href="#specifying-requirements" onclick="event.stopPropagation()"></a></h1>
+<h1 id="specifying-requirements"><span id="specifying-requirements" class="anchor"></span>Specifying requirements<a class="fa fa-anchor" href="#specifying-requirements" onclick="event.stopPropagation()"></a></h1>
 <p>
   <seg id="preview">As we establish requirements, they should be recorded in some way for future reference,
     usually called a requirement specification. Furthermore, it is advisable to show these requirements to stakeholders,
@@ -7,12 +7,12 @@
 </p>
 <p>Given next are some tools and techniques that can be used to specify requirements.
   Note that they can also be used for establishing requirements too.</p>
-<h2 id="textual-descriptions-unstructured-prose">Textual descriptions (unstructured prose)<a class="fa fa-anchor" href="#textual-descriptions-unstructured-prose" onclick="event.stopPropagation()"></a></h2>
+<h2 id="textual-descriptions-unstructured-prose"><span id="textual-descriptions-unstructured-prose" class="anchor"></span>Textual descriptions (unstructured prose)<a class="fa fa-anchor" href="#textual-descriptions-unstructured-prose" onclick="event.stopPropagation()"></a></h2>
 <p>This is the most straight forward way of describing requirements.
   A textual description can be used to give a quick overview of the domain/system that is understandable to both
   the users and the development team. Textual descriptions are especially useful when describing the vision of a product.
   However, lengthy textual descriptions are hard to follow.</p>
-<h2 id="feature-list">Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
+<h2 id="feature-list"><span id="feature-list" class="anchor"></span>Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
 <p>It is a list of features (or functionalities) grouped according to some criteria such as priority
   (e.g. must-have, nice-to-have, etc. ), order of delivery, object or process related
   (e.g. order-related, invoice-related, etc.).

--- a/packages/cli/test/functional/test_site/expected/sub_site/index._include_.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/index._include_.html
@@ -1,5 +1,5 @@
 <p>This is a page from another Markbind site.</p>
-<h2 id="feature-list">Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
+<h2 id="feature-list"><span id="feature-list" class="anchor"></span>Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
 <p>It is a list of features (or functionalities) grouped according to some criteria such as priority
   (e.g. must-have, nice-to-have, etc. ), order of delivery, object or process related
   (e.g. order-related, invoice-related, etc.).

--- a/packages/cli/test/functional/test_site/expected/sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/index.html
@@ -31,7 +31,7 @@
     <div id="flex-body">
       <div id="content-wrapper">
         <p>This is a page from another Markbind site.</p>
-        <h2 id="feature-list">Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="feature-list"><span id="feature-list" class="anchor"></span>Feature list<a class="fa fa-anchor" href="#feature-list" onclick="event.stopPropagation()"></a></h2>
         <p>It is a list of features (or functionalities) grouped according to some criteria such as priority
           (e.g. must-have, nice-to-have, etc. ), order of delivery, object or process related
           (e.g. order-related, invoice-related, etc.).

--- a/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
@@ -30,15 +30,15 @@
   <div id="app">
     <div id="flex-body">
       <div id="content-wrapper">
-        <h1 id="root-file">Root file<a class="fa fa-anchor" href="#root-file" onclick="event.stopPropagation()"></a></h1>
-        <h1 id="should-have-anchor">should have anchor<a class="fa fa-anchor" href="#should-have-anchor" onclick="event.stopPropagation()"></a></h1>
-        <h2 id="should-have-anchor-2">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-2" onclick="event.stopPropagation()"></a></h2>
-        <h3 id="should-have-anchor-3">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-3" onclick="event.stopPropagation()"></a></h3>
-        <h4 id="should-have-anchor-4">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
-        <h5 id="should-have-anchor-5">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
-        <h6 id="should-have-anchor-6">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
+        <h1 id="root-file"><span id="root-file" class="anchor"></span>Root file<a class="fa fa-anchor" href="#root-file" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="should-have-anchor"><span id="should-have-anchor" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor" onclick="event.stopPropagation()"></a></h1>
+        <h2 id="should-have-anchor-2"><span id="should-have-anchor-2" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-2" onclick="event.stopPropagation()"></a></h2>
+        <h3 id="should-have-anchor-3"><span id="should-have-anchor-3" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-3" onclick="event.stopPropagation()"></a></h3>
+        <h4 id="should-have-anchor-4"><span id="should-have-anchor-4" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
+        <h5 id="should-have-anchor-5"><span id="should-have-anchor-5" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
+        <h6 id="should-have-anchor-6"><span id="should-have-anchor-6" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
         <panel id="should-have-anchor-7"><template slot="header">
-            <h4 id="should-have-anchor-7">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-7" onclick="event.stopPropagation()"></a></h4>
+            <h4 id="should-have-anchor-7"><span id="should-have-anchor-7" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-7" onclick="event.stopPropagation()"></a></h4>
           </template>
           Lorem ipsum
         </panel>
@@ -46,36 +46,36 @@
             <p>Collapsed</p>
           </template>
           <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
-          <h1 id="should-not-have-anchor">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor" onclick="event.stopPropagation()"></a></h1>
-          <h2 id="should-not-have-anchor-2">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-2" onclick="event.stopPropagation()"></a></h2>
-          <h3 id="should-not-have-anchor-3">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-3" onclick="event.stopPropagation()"></a></h3>
-          <h4 id="should-not-have-anchor-4">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
-          <h5 id="should-not-have-anchor-5">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
-          <h6 id="should-not-have-anchor-6">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
+          <h1 id="should-not-have-anchor"><span id="should-not-have-anchor" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor" onclick="event.stopPropagation()"></a></h1>
+          <h2 id="should-not-have-anchor-2"><span id="should-not-have-anchor-2" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-2" onclick="event.stopPropagation()"></a></h2>
+          <h3 id="should-not-have-anchor-3"><span id="should-not-have-anchor-3" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-3" onclick="event.stopPropagation()"></a></h3>
+          <h4 id="should-not-have-anchor-4"><span id="should-not-have-anchor-4" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
+          <h5 id="should-not-have-anchor-5"><span id="should-not-have-anchor-5" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
+          <h6 id="should-not-have-anchor-6"><span id="should-not-have-anchor-6" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
         </panel>
         <panel expanded><template slot="header">
             <p>Expanded</p>
           </template>
           <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
-          <h1 id="should-have-anchor-8">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-8" onclick="event.stopPropagation()"></a></h1>
-          <h2 id="should-have-anchor-9">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-9" onclick="event.stopPropagation()"></a></h2>
-          <h3 id="should-have-anchor-10">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-10" onclick="event.stopPropagation()"></a></h3>
-          <h4 id="should-have-anchor-11">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-11" onclick="event.stopPropagation()"></a></h4>
-          <h5 id="should-have-anchor-12">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-12" onclick="event.stopPropagation()"></a></h5>
-          <h6 id="should-have-anchor-13">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-13" onclick="event.stopPropagation()"></a></h6>
+          <h1 id="should-have-anchor-8"><span id="should-have-anchor-8" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-8" onclick="event.stopPropagation()"></a></h1>
+          <h2 id="should-have-anchor-9"><span id="should-have-anchor-9" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-9" onclick="event.stopPropagation()"></a></h2>
+          <h3 id="should-have-anchor-10"><span id="should-have-anchor-10" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-10" onclick="event.stopPropagation()"></a></h3>
+          <h4 id="should-have-anchor-11"><span id="should-have-anchor-11" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-11" onclick="event.stopPropagation()"></a></h4>
+          <h5 id="should-have-anchor-12"><span id="should-have-anchor-12" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-12" onclick="event.stopPropagation()"></a></h5>
+          <h6 id="should-have-anchor-13"><span id="should-have-anchor-13" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-13" onclick="event.stopPropagation()"></a></h6>
         </panel>
         <hr>
         <div>
-          <h1 id="included-file">Included File<a class="fa fa-anchor" href="#included-file" onclick="event.stopPropagation()"></a></h1>
+          <h1 id="included-file"><span id="included-file" class="anchor"></span>Included File<a class="fa fa-anchor" href="#included-file" onclick="event.stopPropagation()"></a></h1>
           <br>
-          <h1 id="should-have-anchor-14">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-14" onclick="event.stopPropagation()"></a></h1>
-          <h2 id="should-have-anchor-15">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-15" onclick="event.stopPropagation()"></a></h2>
-          <h3 id="should-have-anchor-16">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-16" onclick="event.stopPropagation()"></a></h3>
-          <h4 id="should-have-anchor-17">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-17" onclick="event.stopPropagation()"></a></h4>
-          <h5 id="should-have-anchor-18">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-18" onclick="event.stopPropagation()"></a></h5>
-          <h6 id="should-have-anchor-19">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-19" onclick="event.stopPropagation()"></a></h6>
+          <h1 id="should-have-anchor-14"><span id="should-have-anchor-14" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-14" onclick="event.stopPropagation()"></a></h1>
+          <h2 id="should-have-anchor-15"><span id="should-have-anchor-15" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-15" onclick="event.stopPropagation()"></a></h2>
+          <h3 id="should-have-anchor-16"><span id="should-have-anchor-16" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-16" onclick="event.stopPropagation()"></a></h3>
+          <h4 id="should-have-anchor-17"><span id="should-have-anchor-17" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-17" onclick="event.stopPropagation()"></a></h4>
+          <h5 id="should-have-anchor-18"><span id="should-have-anchor-18" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-18" onclick="event.stopPropagation()"></a></h5>
+          <h6 id="should-have-anchor-19"><span id="should-have-anchor-19" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-19" onclick="event.stopPropagation()"></a></h6>
           <panel id="should-have-anchor-20"><template slot="header">
-              <h4 id="should-have-anchor-20">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-20" onclick="event.stopPropagation()"></a></h4>
+              <h4 id="should-have-anchor-20"><span id="should-have-anchor-20" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-20" onclick="event.stopPropagation()"></a></h4>
             </template>
             Lorem ipsum
           </panel>
@@ -83,23 +83,23 @@
               <p>Collapsed</p>
             </template>
             <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
-            <h1 id="should-not-have-anchor-7">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-7" onclick="event.stopPropagation()"></a></h1>
-            <h2 id="should-not-have-anchor-8">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-8" onclick="event.stopPropagation()"></a></h2>
-            <h3 id="should-not-have-anchor-9">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-9" onclick="event.stopPropagation()"></a></h3>
-            <h4 id="should-not-have-anchor-10">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-10" onclick="event.stopPropagation()"></a></h4>
-            <h5 id="should-not-have-anchor-11">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-11" onclick="event.stopPropagation()"></a></h5>
-            <h6 id="should-not-have-anchor-12">should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-12" onclick="event.stopPropagation()"></a></h6>
+            <h1 id="should-not-have-anchor-7"><span id="should-not-have-anchor-7" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-7" onclick="event.stopPropagation()"></a></h1>
+            <h2 id="should-not-have-anchor-8"><span id="should-not-have-anchor-8" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-8" onclick="event.stopPropagation()"></a></h2>
+            <h3 id="should-not-have-anchor-9"><span id="should-not-have-anchor-9" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-9" onclick="event.stopPropagation()"></a></h3>
+            <h4 id="should-not-have-anchor-10"><span id="should-not-have-anchor-10" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-10" onclick="event.stopPropagation()"></a></h4>
+            <h5 id="should-not-have-anchor-11"><span id="should-not-have-anchor-11" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-11" onclick="event.stopPropagation()"></a></h5>
+            <h6 id="should-not-have-anchor-12"><span id="should-not-have-anchor-12" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-12" onclick="event.stopPropagation()"></a></h6>
           </panel>
           <panel expanded><template slot="header">
               <p>Expanded</p>
             </template>
             <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
-            <h1 id="should-have-anchor-21">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-21" onclick="event.stopPropagation()"></a></h1>
-            <h2 id="should-have-anchor-22">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-22" onclick="event.stopPropagation()"></a></h2>
-            <h3 id="should-have-anchor-23">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-23" onclick="event.stopPropagation()"></a></h3>
-            <h4 id="should-have-anchor-24">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-24" onclick="event.stopPropagation()"></a></h4>
-            <h5 id="should-have-anchor-25">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-25" onclick="event.stopPropagation()"></a></h5>
-            <h6 id="should-have-anchor-26">should have anchor<a class="fa fa-anchor" href="#should-have-anchor-26" onclick="event.stopPropagation()"></a></h6>
+            <h1 id="should-have-anchor-21"><span id="should-have-anchor-21" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-21" onclick="event.stopPropagation()"></a></h1>
+            <h2 id="should-have-anchor-22"><span id="should-have-anchor-22" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-22" onclick="event.stopPropagation()"></a></h2>
+            <h3 id="should-have-anchor-23"><span id="should-have-anchor-23" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-23" onclick="event.stopPropagation()"></a></h3>
+            <h4 id="should-have-anchor-24"><span id="should-have-anchor-24" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-24" onclick="event.stopPropagation()"></a></h4>
+            <h5 id="should-have-anchor-25"><span id="should-have-anchor-25" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-25" onclick="event.stopPropagation()"></a></h5>
+            <h6 id="should-have-anchor-26"><span id="should-have-anchor-26" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-26" onclick="event.stopPropagation()"></a></h6>
           </panel>
         </div>
         <p><i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>

--- a/packages/cli/test/functional/test_site/expected/testDates.html
+++ b/packages/cli/test/functional/test_site/expected/testDates.html
@@ -30,7 +30,7 @@
   <div id="app">
     <div id="flex-body">
       <div id="content-wrapper">
-        <h2 id="dates">Dates<a class="fa fa-anchor" href="#dates" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="dates"><span id="dates" class="anchor"></span>Dates<a class="fa fa-anchor" href="#dates" onclick="event.stopPropagation()"></a></h2>
         <div></div>
         <p>Mon 12 Aug should be Mon 12 Aug</p>
         <p>12 08 2019 should be 12 08 2019</p>

--- a/packages/cli/test/functional/test_site/expected/testImportVariables._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testImportVariables._include_.html
@@ -4,11 +4,11 @@
 <p>Test import variables from src specified via variable:
   This variable comes from <a href="http://variablesToImport.md">variablesToImport.md</a></p>
 <p>Test import variables that itself imports other variables:</p>
-<h2 id="trying-to-access-a-page-variable">Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
+<h2 id="trying-to-access-a-page-variable"><span id="trying-to-access-a-page-variable" class="anchor"></span>Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
 <p>There should be something red below:</p>
 <div style="color:red">This is a page variable from variablestoimport.md</div>
 Something should have appeared above in red.
-<h2 id="trying-to-access-an-imported-variable-via-namespace">Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
+<h2 id="trying-to-access-an-imported-variable-via-namespace"><span id="trying-to-access-an-imported-variable-via-namespace" class="anchor"></span>Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
 <p>There should be something blue below:</p>
 <div style="color:blue">This is a deeply imported variable</div>
 Something should have appeared above in blue.

--- a/packages/cli/test/functional/test_site/expected/testImportVariables.html
+++ b/packages/cli/test/functional/test_site/expected/testImportVariables.html
@@ -36,11 +36,11 @@
         <p>Test import variables from src specified via variable:
           This variable comes from <a href="http://variablesToImport.md">variablesToImport.md</a></p>
         <p>Test import variables that itself imports other variables:</p>
-        <h2 id="trying-to-access-a-page-variable">Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="trying-to-access-a-page-variable"><span id="trying-to-access-a-page-variable" class="anchor"></span>Trying to access a page variable:<a class="fa fa-anchor" href="#trying-to-access-a-page-variable" onclick="event.stopPropagation()"></a></h2>
         <p>There should be something red below:</p>
         <div style="color:red">This is a page variable from variablestoimport.md</div>
         Something should have appeared above in red.
-        <h2 id="trying-to-access-an-imported-variable-via-namespace">Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="trying-to-access-an-imported-variable-via-namespace"><span id="trying-to-access-an-imported-variable-via-namespace" class="anchor"></span>Trying to access an imported variable via namespace:<a class="fa fa-anchor" href="#trying-to-access-an-imported-variable-via-namespace" onclick="event.stopPropagation()"></a></h2>
         <p>There should be something blue below:</p>
         <div style="color:blue">This is a deeply imported variable</div>
         Something should have appeared above in blue.

--- a/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
@@ -1,3 +1,3 @@
 <panel src="/test_site/testPanels/NormalPanelContent._include_.html" expanded id="nested-panel"><template slot="header">
-    <h2 id="nested-panel">Nested Panel<a class="fa fa-anchor" href="#nested-panel" onclick="event.stopPropagation()"></a></h2>
+    <h2 id="nested-panel"><span id="nested-panel" class="anchor"></span>Nested Panel<a class="fa fa-anchor" href="#nested-panel" onclick="event.stopPropagation()"></a></h2>
   </template></panel>

--- a/packages/cli/test/functional/test_site/expected/testPanels/NormalPanelContent._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/NormalPanelContent._include_.html
@@ -1,1 +1,1 @@
-<h3 id="normal-panel-content-heading">Normal panel content heading<a class="fa fa-anchor" href="#normal-panel-content-heading" onclick="event.stopPropagation()"></a></h3>
+<h3 id="normal-panel-content-heading"><span id="normal-panel-content-heading" class="anchor"></span>Normal panel content heading<a class="fa fa-anchor" href="#normal-panel-content-heading" onclick="event.stopPropagation()"></a></h3>

--- a/packages/cli/test/functional/test_site/expected/testPanels/PanelNormalSource._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/PanelNormalSource._include_.html
@@ -1,1 +1,1 @@
-<h3 id="panel-normal-source-content-headings">Panel normal source content headings<a class="fa fa-anchor" href="#panel-normal-source-content-headings" onclick="event.stopPropagation()"></a></h3>
+<h3 id="panel-normal-source-content-headings"><span id="panel-normal-source-content-headings" class="anchor"></span>Panel normal source content headings<a class="fa fa-anchor" href="#panel-normal-source-content-headings" onclick="event.stopPropagation()"></a></h3>

--- a/packages/cli/test/functional/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/PanelSourceContainsSegment._include_.html
@@ -1,4 +1,4 @@
 <div id="segment">
-  <h3 id="panel-source-segment-content-headings">Panel source segment content headings<a class="fa fa-anchor" href="#panel-source-segment-content-headings" onclick="event.stopPropagation()"></a></h3>
+  <h3 id="panel-source-segment-content-headings"><span id="panel-source-segment-content-headings" class="anchor"></span>Panel source segment content headings<a class="fa fa-anchor" href="#panel-source-segment-content-headings" onclick="event.stopPropagation()"></a></h3>
 </div>
-<h3 id="this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data">This heading is not src of any panel, so it should not be in the search data<a class="fa fa-anchor" href="#this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data" onclick="event.stopPropagation()"></a></h3>
+<h3 id="this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data"><span id="this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data" class="anchor"></span>This heading is not src of any panel, so it should not be in the search data<a class="fa fa-anchor" href="#this-heading-is-not-src-of-any-panel-so-it-should-not-be-in-the-search-data" onclick="event.stopPropagation()"></a></h3>

--- a/packages/cli/test/functional/test_site/expected/testPanels/boilerTestPanel._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/boilerTestPanel._include_.html
@@ -1,1 +1,1 @@
-<h3 id="boilerplate-test-for-panel-heading">boilerplate test for panel heading<a class="fa fa-anchor" href="#boilerplate-test-for-panel-heading" onclick="event.stopPropagation()"></a></h3>
+<h3 id="boilerplate-test-for-panel-heading"><span id="boilerplate-test-for-panel-heading" class="anchor"></span>boilerplate test for panel heading<a class="fa fa-anchor" href="#boilerplate-test-for-panel-heading" onclick="event.stopPropagation()"></a></h3>

--- a/packages/cli/test/functional/test_site/expected/testPanels/notInside._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/notInside._include_.html
@@ -1,1 +1,1 @@
-<h3 id="heading-in-panel-boilerplate">heading in panel boilerplate<a class="fa fa-anchor" href="#heading-in-panel-boilerplate" onclick="event.stopPropagation()"></a></h3>
+<h3 id="heading-in-panel-boilerplate"><span id="heading-in-panel-boilerplate" class="anchor"></span>heading in panel boilerplate<a class="fa fa-anchor" href="#heading-in-panel-boilerplate" onclick="event.stopPropagation()"></a></h3>

--- a/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
+++ b/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
@@ -30,7 +30,7 @@
   <div id="app">
     <div id="flex-body">
       <div id="content-wrapper">
-        <h1 id="569-stray-space-after-tooltip">569: Stray space after tooltip<a class="fa fa-anchor" href="#569-stray-space-after-tooltip" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="569-stray-space-after-tooltip"><span id="569-stray-space-after-tooltip" class="anchor"></span>569: Stray space after tooltip<a class="fa fa-anchor" href="#569-stray-space-after-tooltip" onclick="event.stopPropagation()"></a></h1>
         <pre><code class="hljs" v-pre><span>&lt;tooltip&gt;tooltip&lt;/tooltip&gt;, test
 </span><span>
 </span><span>&lt;trigger&gt;trigger&lt;/trigger&gt;, test

--- a/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
+++ b/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
@@ -31,7 +31,7 @@
     <div id="flex-body">
       <div id="content-wrapper">
         <div></div>
-        <h1 id="content-fragment"><span>content fragment</span><a class="fa fa-anchor" href="#content-fragment" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="content-fragment"><span id="content-fragment" class="anchor"></span><span>content fragment</span><a class="fa fa-anchor" href="#content-fragment" onclick="event.stopPropagation()"></a></h1>
         <p><i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>
       </div>
 

--- a/packages/cli/test/functional/test_site/expected/test_md_fragment.html
+++ b/packages/cli/test/functional/test_site/expected/test_md_fragment.html
@@ -30,7 +30,7 @@
   <div id="app">
     <div id="flex-body">
       <div id="content-wrapper">
-        <h1 id="some-heading">Some heading<a class="fa fa-anchor" href="#some-heading" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="some-heading"><span id="some-heading" class="anchor"></span>Some heading<a class="fa fa-anchor" href="#some-heading" onclick="event.stopPropagation()"></a></h1>
         <p>The <strong>quick</strong> brown fox jumps <em>over</em> the lazy dog.
           <i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>
       </div>

--- a/packages/cli/test/functional/test_site_convert/expected/Page-1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Page-1.html
@@ -48,7 +48,7 @@
       </nav>
 
       <div id="content-wrapper">
-        <h1 id="page-1">Page 1<a class="fa fa-anchor" href="#page-1" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="page-1"><span id="page-1" class="anchor"></span>Page 1<a class="fa fa-anchor" href="#page-1" onclick="event.stopPropagation()"></a></h1>
         <p><i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>
       </div>
 

--- a/packages/cli/test/functional/test_site_convert/expected/about.html
+++ b/packages/cli/test/functional/test_site_convert/expected/about.html
@@ -48,7 +48,7 @@
       </nav>
 
       <div id="content-wrapper">
-        <h1 id="about">About<a class="fa fa-anchor" href="#about" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="about"><span id="about" class="anchor"></span>About<a class="fa fa-anchor" href="#about" onclick="event.stopPropagation()"></a></h1>
         <p>Welcome to your <strong>About Us</strong> page.</p>
         <p><i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>
       </div>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
@@ -74,7 +74,7 @@
 
       <div id="content-wrapper">
         <br>
-        <h1 id="topic-1">Topic 1<a class="fa fa-anchor" href="#topic-1" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="topic-1"><span id="topic-1" class="anchor"></span>Topic 1<a class="fa fa-anchor" href="#topic-1" onclick="event.stopPropagation()"></a></h1>
         <blockquote>
           <p>More content to be added</p>
         </blockquote>

--- a/packages/cli/test/functional/test_site_expressive_layout/expected/index.html
+++ b/packages/cli/test/functional/test_site_expressive_layout/expected/index.html
@@ -41,7 +41,7 @@
         <div></div>
         <hr>
         <p><em>Content above the horizontal line belongs to the layout file</em></p>
-        <h1 id="welcome-to-markbind">Welcome to Markbind<a class="fa fa-anchor" href="#welcome-to-markbind" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="welcome-to-markbind"><span id="welcome-to-markbind" class="anchor"></span>Welcome to Markbind<a class="fa fa-anchor" href="#welcome-to-markbind" onclick="event.stopPropagation()"></a></h1>
         <p>This is a minimalistic template. To learn more about authoring contents in Markbind, visit the <a href="https://markbind.org/userGuide/authoringContents.html">User Guide</a>.</p>
         <p>Variable from page</p>
         <p><strong>Test that {% raw %} and {% endraw %} tags work in the content file inserted into the layout</strong></p>

--- a/packages/cli/test/functional/test_site_special_tags/expected/index.html
+++ b/packages/cli/test/functional/test_site_special_tags/expected/index.html
@@ -27,8 +27,8 @@
   <div id="app">
     <div id="flex-body">
       <div id="content-wrapper">
-        <h1 id="functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags">Functional test for htmlparser2 and markdown-it patches for special tags<a class="fa fa-anchor" href="#functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags" onclick="event.stopPropagation()"></a></h1>
-        <h2 id="so-far-as-to-comply-with-the-commonmark-spec">So far as to comply with the commonmark spec<a class="fa fa-anchor" href="#so-far-as-to-comply-with-the-commonmark-spec" onclick="event.stopPropagation()"></a></h2>
+        <h1 id="functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags"><span id="functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags" class="anchor"></span>Functional test for htmlparser2 and markdown-it patches for special tags<a class="fa fa-anchor" href="#functional-test-for-htmlparser2-and-markdown-it-patches-for-special-tags" onclick="event.stopPropagation()"></a></h1>
+        <h2 id="so-far-as-to-comply-with-the-commonmark-spec"><span id="so-far-as-to-comply-with-the-commonmark-spec" class="anchor"></span>So far as to comply with the commonmark spec<a class="fa fa-anchor" href="#so-far-as-to-comply-with-the-commonmark-spec" onclick="event.stopPropagation()"></a></h2>
         <p>There should be no text between this and the next <code v-pre>&lt;hr&gt;</code> tag in the browser, since it is a <code v-pre>&lt;script&gt;</code> tag.<br>
           There should be an alert with the value of 2 as well.</p>
         <script>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -74,7 +74,7 @@
 
       <div id="content-wrapper">
         <br>
-        <h1 id="topic-1">Topic 1<a class="fa fa-anchor" href="#topic-1" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="topic-1"><span id="topic-1" class="anchor"></span>Topic 1<a class="fa fa-anchor" href="#topic-1" onclick="event.stopPropagation()"></a></h1>
         <blockquote>
           <p>More content to be added</p>
         </blockquote>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -76,11 +76,11 @@
         <br>
         <div class="jumbotron jumbotron-fluid bg-primary text-white">
           <div class="container">
-            <h1 class="display-4 no-index" id="landing-page-title">Landing Page Title<a class="fa fa-anchor" href="#landing-page-title" onclick="event.stopPropagation()"></a></h1>
+            <h1 class="display-4 no-index" id="landing-page-title"><span id="landing-page-title" class="anchor"></span>Landing Page Title<a class="fa fa-anchor" href="#landing-page-title" onclick="event.stopPropagation()"></a></h1>
             <p class="lead">A tagline can go here</p>
           </div>
         </div>
-        <h1 id="heading-1">Heading 1<a class="fa fa-anchor" href="#heading-1" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="heading-1"><span id="heading-1" class="anchor"></span>Heading 1<a class="fa fa-anchor" href="#heading-1" onclick="event.stopPropagation()"></a></h1>
         <p>Some text some text some text some text some text some text some text. <strong>Some text some text some text some text some text <mark>some text</mark> some text</strong>. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.</p>
         <p><strong>A block quote:</strong></p>
         <blockquote>
@@ -102,7 +102,7 @@
 </span><span>  <span class="hljs-tag">&lt;<span class="hljs-name">bar</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"name"</span>&gt;</span>goo<span class="hljs-tag">&lt;/<span class="hljs-name">bar</span>&gt;</span>
 </span><span><span class="hljs-tag">&lt;/<span class="hljs-name">foo</span>&gt;</span>
 </span></code></pre>
-        <h2 id="sub-heading-1-1">Sub Heading 1.1<a class="fa fa-anchor" href="#sub-heading-1-1" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="sub-heading-1-1"><span id="sub-heading-1-1" class="anchor"></span>Sub Heading 1.1<a class="fa fa-anchor" href="#sub-heading-1-1" onclick="event.stopPropagation()"></a></h2>
         <p>A <span effect="scale" placement="top" trigger="hover" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content">❗️ some <strong>important explanation</strong></span>tooltip</span>, a <trigger for="modal:modalinfo" trigger="click">modal</trigger>, a <a href="https://markbind.org/">link</a>, a <span class="badge badge-danger">badge</span>, another <span class="badge badge-warning">badge</span>.</p>
         <b-modal id="modal:modalinfo" hide-footer size modal-class="mb-zoom" ref="modal:modalinfo"><template slot="modal-title">Modal Title</template>
           Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.
@@ -134,7 +134,7 @@
             </tbody>
           </table>
         </div>
-        <h2 id="sub-heading-1-2">Sub Heading 1.2<a class="fa fa-anchor" href="#sub-heading-1-2" onclick="event.stopPropagation()"></a></h2>
+        <h2 id="sub-heading-1-2"><span id="sub-heading-1-2" class="anchor"></span>Sub Heading 1.2<a class="fa fa-anchor" href="#sub-heading-1-2" onclick="event.stopPropagation()"></a></h2>
         <p><strong>Media embeds:</strong></p>
         <div class="block-embed block-embed-service-youtube"><iframe type="text/html" src="//www.youtube.com/embed/v40b3ExbM0c" frameborder="0" width="640" height="390" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
         <p><strong>Tabs:</strong></p>
@@ -155,7 +155,7 @@
           </tab-group>
         </tabs>
         <br>
-        <h1 id="heading-2">Heading 2<a class="fa fa-anchor" href="#heading-2" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="heading-2"><span id="heading-2" class="anchor"></span>Heading 2<a class="fa fa-anchor" href="#heading-2" onclick="event.stopPropagation()"></a></h1>
         <p><strong>Some boxes:</strong></p>
         <box>
           default
@@ -182,7 +182,7 @@
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </box>
         <br>
-        <h1 id="heading-3">Heading 3<a class="fa fa-anchor" href="#heading-3" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="heading-3"><span id="heading-3" class="anchor"></span>Heading 3<a class="fa fa-anchor" href="#heading-3" onclick="event.stopPropagation()"></a></h1>
         <panel type="info"><template slot="header">
             <p>Expandable panel</p>
           </template>

--- a/packages/cli/test/functional/test_site_templates/test_minimal/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_minimal/expected/index.html
@@ -32,7 +32,7 @@
       </nav>
 
       <div id="content-wrapper">
-        <h1 id="welcome-to-markbind">Welcome to Markbind<a class="fa fa-anchor" href="#welcome-to-markbind" onclick="event.stopPropagation()"></a></h1>
+        <h1 id="welcome-to-markbind"><span id="welcome-to-markbind" class="anchor"></span>Welcome to Markbind<a class="fa fa-anchor" href="#welcome-to-markbind" onclick="event.stopPropagation()"></a></h1>
         <p>This is a minimalistic template. To learn more about authoring contents in Markbind, visit the <a href="https://markbind.org/userGuide/authoringContents.html">User Guide</a>.</p>
         <p><i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i></p>
       </div>

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -23,6 +23,12 @@ function insertCss(cssCode) {
 }
 
 function setupAnchorsForFixedNavbar() {
+  jQuery(':header').each((index, heading) => {
+    if (heading.id) {
+      jQuery(heading).removeAttr('id'); // to avoid duplicated id problem
+    }
+  });
+
   const headerSelector = jQuery('header[fixed]');
   const isFixed = headerSelector.length !== 0;
   if (!isFixed) {
@@ -45,11 +51,6 @@ function setupAnchorsForFixedNavbar() {
         margin-top: calc(-${headerHeight}px - ${bufferHeight}rem);
         height: calc(${headerHeight}px + ${bufferHeight}rem);
       }`);
-  jQuery('h1, h2, h3, h4, h5, h6, .header-wrapper').each((index, heading) => {
-    if (heading.id) {
-      jQuery(heading).removeAttr('id'); // to avoid duplicated id problem
-    }
-  });
 }
 
 function updateSearchData(vm) {

--- a/packages/core/src/parsers/ComponentParser.js
+++ b/packages/core/src/parsers/ComponentParser.js
@@ -594,8 +594,8 @@ class ComponentParser {
     ComponentParser.postParseComponents(node);
 
     // If a fixed header is applied to the page, generate dummy spans as anchor points
-    if (this.config.fixedHeader && isHeadingTag && node.attribs.id) {
-      cheerio(node).append(cheerio.parseHTML(`<span id="${node.attribs.id}" class="anchor"></span>`));
+    if (isHeadingTag && node.attribs.id) {
+      cheerio(node).prepend(`<span id="${node.attribs.id}" class="anchor"></span>`);
     }
 
     return node;

--- a/packages/core/test/unit/ComponentParser.test.js
+++ b/packages/core/test/unit/ComponentParser.test.js
@@ -146,7 +146,7 @@ test('renderFile converts markdown headers to <h1> with an id', async () => {
   const result = await componentParser.render(indexPath, index);
 
   const expected = [
-    '<h1 id="index">Index</h1>',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
     '',
   ].join('\n');
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, please explain: code maintanence

**What is the rationale for this request?**
Since the styles that elavate the dummy heading anchors are not inserted at runtime if the header is fixed, lets generate these anchors anyway when there are no fixed headers at compile time

This removes the need to pass the `fixedHeader` variable around

**What changes did you make? (Give an overview)**
- always generate the dummy span anchors
- remove duplicated ids at runtime correspondingly even when there is no fixed header


**Proposed commit message: (wrap lines at 72 characters)**
Generate heading anchors without fixed headers

Empty heading anchors are generated for headings when the header is
fixed.

Since the position for these anchors are set at runtime only if there
is a fixed header, let's always generate these anchors instead,
resulting in one less instance variable needed.