### PR TITLE
Fix error when deploying

### DIFF
--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1313,16 +1313,17 @@ class Site {
       if (!remoteUrl) {
         return null;
       }
+      const parts = remoteUrl.split('/');
       if (remoteUrl.startsWith(HTTPS_PREAMBLE)) {
         // https://github.com/<name|org>/<repo>.git (HTTPS)
-        const parts = remoteUrl.split('/');
-        const repoName = parts[parts.length - 1].toLowerCase();
+        const repoNameWithExt = parts[parts.length - 1];
+        const repoName = repoNameWithExt.substring(0, repoNameWithExt.lastIndexOf('.'));
         const name = parts[parts.length - 2].toLowerCase();
         return `https://${name}.${GITHUB_IO_PART}/${repoName}`;
       } else if (remoteUrl.startsWith(SSH_PREAMBLE)) {
         // git@github.com:<name|org>/<repo>.git (SSH)
-        const parts = remoteUrl.split('/');
-        const repoName = parts[parts.length - 1].toLowerCase();
+        const repoNameWithExt = parts[parts.length - 1];
+        const repoName = repoNameWithExt.substring(0, repoNameWithExt.lastIndexOf('.'));
         const name = parts[0].substring(SSH_PREAMBLE.length);
         return `https://${name}.${GITHUB_IO_PART}/${repoName}`;
       }
@@ -1336,14 +1337,14 @@ class Site {
 
     return Promise.all(promises)
       .then((results) => {
-        const cname = results[0].trim();
-        const remoteUrl = results[1].trim();
+        const cname = results[0];
+        const remoteUrl = results[1];
         if (cname) {
-          return cname;
+          return cname.trim();
         } else if (repo) {
           return constructGhPagesUrl(repo);
         }
-        return constructGhPagesUrl(remoteUrl);
+        return constructGhPagesUrl(remoteUrl.trim());
       })
       .catch((err) => {
         logger.error(err);


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes #1354 , while addressing an incorrect implementation from #1329 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
To fix a bug #1354 caused when running `markbind deploy`.

Additionally, this PR fixes a prior issue from #1329 , where an incorrect URL would be displayed when no CNAME exists in the website being deployed (no custom URL is being used for gh-pages). In that case, the incorrect URL was being constructed 
from the repository name. 
(If I have a repository Orbital3 the old URL would be `https://kendrickang.github.io/orbital3.git/` when it should have been `https://kendrickang.github.io/Orbital3/`)

**What changes did you make? (Give an overview)**
The case that CNAME was undefined was not being handled. In that case, a gh-pages link should be reconstructed based on the repo name. This PR also addresses an further issue where the file extension `.git` was not being stripped from the generated URL.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
const cname = results[0];
const remoteUrl = results[1];
if (cname) {
   return cname.trim();
} else if (repo) {
  return constructGhPagesUrl(repo);
}
return constructGhPagesUrl(remoteUrl.trim());

// another separate snippet
const repoNameWithExt = parts[parts.length - 1];
const repoName = repoNameWithExt.substring(0, repoNameWithExt.lastIndexOf('.'));
```

**Is there anything you'd like reviewers to focus on?**


**Testing instructions:**
1. Generate any empty test site with a remote github repo (so gh-pages can be used).
2. Add the repo name to baseUrl in `site.json`
3. Run `markbind deploy` and verify correctness

**Proposed commit message: (wrap lines at 72 characters)**
Fix error when deploying and correct generated URL

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
