### PR TITLE
Make dotted/dashed lines for triggers more visible

### DIFF
--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -368,12 +368,12 @@ li.footnote-item:target {
 
 /* styles for triggers, popovers, tooltips */
 .trigger {
-    border-bottom: 1px dotted currentColor;
+    border-bottom: 3px dotted currentColor;
 }
 
 .trigger-click {
     cursor: pointer;
-    border-bottom: 1px dashed currentColor;
+    border-bottom: 3px dashed currentColor;
 }
 
 .trigger-click:focus {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->


<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

Closes #1357 

**What changes did you make? (Give an overview)**

In `markbind.css`, `3px` below is changed from `1px` before

```
.trigger {
    border-bottom: 3px dotted currentColor;
}

.trigger-click {
    cursor: pointer;
    border-bottom: 3px dashed currentColor;
}
```

**Is there anything you'd like reviewers to focus on?**

If we're following the vue-strap convention, I suppose I don't need to minify the `.css` file for this PR?

**Proposed commit message: (wrap lines at 72 characters)**

Increased trigger underline visibility