### PR TITLE
Incorrect octicon name crashes live preview

### DIFF
--- a/packages/core/src/lib/markdown-it/markdown-it-icons.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-icons.js
@@ -1,22 +1,30 @@
 const octicons = require('@primer/octicons');
+const _ = require('lodash');
 
 module.exports = require('markdown-it-regexp')(
-    /:(fa[brs]|glyphicon|octicon|octiconlight)-([a-z-]+)~?([a-z-]+)?:/,
-    (match, _) => {
-        let iconFontType = match[1];
-        let iconFontName = match[2];
-        let iconClass = match[3];
+  /:(fa[brs]|glyphicon|octicon|octiconlight)-([a-z-]+)~?([a-z-]+)?:/,
+  (match, _) => {
+    let iconFontType = match[1];
+    let iconFontName = match[2];
+    let iconClass = match[3];
 
-        if (iconFontType === 'glyphicon') {
-            return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
-        } else if (iconFontType === 'octicon') {
-            return iconClass ? octicons[iconFontName].toSVG({"class": iconClass})
-                             : octicons[iconFontName].toSVG();
-        } else if (iconFontType === 'octiconlight') {
-            return iconClass ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
-                             : octicons[iconFontName].toSVG({"style": "color: #fff;"});
-        } else { // If icon is a Font Awesome icon
-            return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
-        }
+    // ensure octicons exist
+    if (iconFontType === 'octicon' || iconFontType === 'octiconlight') {
+      if (!octicons.hasOwnProperty(iconFontName)) {
+        return `<span aria-hidden="true"></span>`;
+      }
     }
+
+    if (iconFontType === 'glyphicon') {
+      return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
+    } else if (iconFontType === 'octicon') {
+      return iconClass ? octicons[iconFontName].toSVG({"class": iconClass})
+        : octicons[iconFontName].toSVG();
+    } else if (iconFontType === 'octiconlight') {
+      return iconClass ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
+        : octicons[iconFontName].toSVG({"style": "color: #fff;"});
+    } else { // If icon is a Font Awesome icon
+      return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
+    }
+  }
 );

--- a/packages/core/src/lib/markdown-it/markdown-it-icons.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-icons.js
@@ -1,30 +1,22 @@
 const octicons = require('@primer/octicons');
-const _ = require('lodash');
 
 module.exports = require('markdown-it-regexp')(
-  /:(fa[brs]|glyphicon|octicon|octiconlight)-([a-z-]+)~?([a-z-]+)?:/,
-  (match, _) => {
-    let iconFontType = match[1];
-    let iconFontName = match[2];
-    let iconClass = match[3];
+    /:(fa[brs]|glyphicon|octicon|octiconlight)-([a-z-]+)~?([a-z-]+)?:/,
+    (match, _) => {
+        let iconFontType = match[1];
+        let iconFontName = match[2];
+        let iconClass = match[3];
 
-    // ensure octicons exist
-    if (iconFontType === 'octicon' || iconFontType === 'octiconlight') {
-      if (!octicons.hasOwnProperty(iconFontName)) {
-        return `<span aria-hidden="true"></span>`;
-      }
+        if (iconFontType === 'glyphicon') {
+            return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
+        } else if (iconFontType === 'octicon') {
+            return iconClass ? octicons[iconFontName].toSVG({"class": iconClass})
+                             : octicons[iconFontName].toSVG();
+        } else if (iconFontType === 'octiconlight') {
+            return iconClass ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
+                             : octicons[iconFontName].toSVG({"style": "color: #fff;"});
+        } else { // If icon is a Font Awesome icon
+            return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
+        }
     }
-
-    if (iconFontType === 'glyphicon') {
-      return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
-    } else if (iconFontType === 'octicon') {
-      return iconClass ? octicons[iconFontName].toSVG({"class": iconClass})
-        : octicons[iconFontName].toSVG();
-    } else if (iconFontType === 'octiconlight') {
-      return iconClass ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
-        : octicons[iconFontName].toSVG({"style": "color: #fff;"});
-    } else { // If icon is a Font Awesome icon
-      return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
-    }
-  }
 );

--- a/packages/core/src/lib/markdown-it/markdown-it-icons.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-icons.js
@@ -7,21 +7,26 @@ module.exports = require('markdown-it-regexp')(
         let iconFontName = match[2];
         let iconClass = match[3];
 
-        // ensure octicons exist
-        if (iconFontType === 'octicon' || iconFontType === 'octiconlight') {
-            if (!octicons.hasOwnProperty(iconFontName)) {
-              return `<span aria-hidden="true"></span>`;
-            }
-        }
-
         if (iconFontType === 'glyphicon') {
             return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
         } else if (iconFontType === 'octicon') {
-            return iconClass ? octicons[iconFontName].toSVG({"class": iconClass})
-                             : octicons[iconFontName].toSVG();
+            let icon = iconClass
+                ? octicons[iconFontName].toSVG({"class": iconClass})
+                : octicons[iconFontName].toSVG();
+            // ensure octicons are valid
+            if (!octicons.hasOwnProperty(iconFontName)) {
+                icon = `<span aria-hidden="true"></span>`;
+            }
+            return icon;
         } else if (iconFontType === 'octiconlight') {
-            return iconClass ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
-                             : octicons[iconFontName].toSVG({"style": "color: #fff;"});
+            let icon = iconClass
+                ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
+                : octicons[iconFontName].toSVG({"style": "color: #fff;"});
+            // ensure octicons are valid
+            if (!octicons.hasOwnProperty(iconFontName)) {
+                icon = `<span aria-hidden="true"></span>`;
+            }
+            return icon;
         } else { // If icon is a Font Awesome icon
             return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
         }

--- a/packages/core/src/lib/markdown-it/markdown-it-icons.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-icons.js
@@ -7,6 +7,13 @@ module.exports = require('markdown-it-regexp')(
         let iconFontName = match[2];
         let iconClass = match[3];
 
+        // ensure octicons exist
+        if (iconFontType === 'octicon' || iconFontType === 'octiconlight') {
+            if (!octicons.hasOwnProperty(iconFontName)) {
+              return `<span aria-hidden="true"></span>`;
+            }
+        }
+
         if (iconFontType === 'glyphicon') {
             return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
         } else if (iconFontType === 'octicon') {

--- a/packages/core/src/lib/markdown-it/markdown-it-icons.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-icons.js
@@ -10,23 +10,21 @@ module.exports = require('markdown-it-regexp')(
         if (iconFontType === 'glyphicon') {
             return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
         } else if (iconFontType === 'octicon') {
-            let icon = iconClass
+            // ensure octicons are valid
+            if (!octicons.hasOwnProperty(iconFontName)) {
+                return `<span aria-hidden="true"></span>`;
+            }
+            return iconClass
                 ? octicons[iconFontName].toSVG({"class": iconClass})
                 : octicons[iconFontName].toSVG();
+        } else if (iconFontType === 'octiconlight') {
             // ensure octicons are valid
             if (!octicons.hasOwnProperty(iconFontName)) {
-                icon = `<span aria-hidden="true"></span>`;
+               return `<span aria-hidden="true"></span>`;
             }
-            return icon;
-        } else if (iconFontType === 'octiconlight') {
-            let icon = iconClass
+            return iconClass
                 ? octicons[iconFontName].toSVG({"style": "color: #fff;", "class": iconClass})
                 : octicons[iconFontName].toSVG({"style": "color: #fff;"});
-            // ensure octicons are valid
-            if (!octicons.hasOwnProperty(iconFontName)) {
-                icon = `<span aria-hidden="true"></span>`;
-            }
-            return icon;
         } else { // If icon is a Font Awesome icon
             return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Resolves #1266 

Currently, if a user tries to use an invalid octicon, the live server crashes. On the other hand, this does not happen with glyphicons since usage of empty glyphicons just results in an empty `<span glyphicon glyphicon-invalid></span>`.
![image](https://user-images.githubusercontent.com/38814428/96361237-a4856f80-1156-11eb-8485-a7d6f46a4011.png)

**What changes did you make? (Give an overview)**
Added an existence check for the octicon the user wants to use, returning an empty `<span>` otherwise.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
    // ensure octicons exist
    if (iconFontType === 'octicon' || iconFontType === 'octiconlight') {
      if (!octicons.hasOwnProperty(iconFontName)) {
        return `<span aria-hidden="true"></span>`;
      }
    }
```

**Is there anything you'd like reviewers to focus on?**
https://primer.style/octicons/packages/javascript
It is possible for us to use the octicons API to adjust the height/width of the glyphicons we need. This would be much less of a hassle that currently having to create a new class just to resize the icon. Perhaps we could consider adding in this functionality?
![image](https://user-images.githubusercontent.com/38814428/96361141-d34f1600-1155-11eb-9131-cffce1cc65bf.png)

**Testing instructions:**
Try serving a webpage with invalid octicon.

**Proposed commit message: (wrap lines at 72 characters)**
add validity check for octicons

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
