### PR TITLE
Lazy-loading: Add support for index.mbd as default

### DIFF
--- a/docs/userGuide/cliCommands.md
+++ b/docs/userGuide/cliCommands.md
@@ -81,7 +81,7 @@ Usage: markbind <command>
 **Options** :fas-cogs:
 
 * `-o <file>`, `--one-page <file>`<br>
- Serves only a single page from your website **initially**. If `<file>` is not specified, it defaults to `index.md/mbf/mbdf`.<br>
+ Serves only a single page from your website **initially**. If `<file>` is not specified, it defaults to `index.md/mbd`.<br>
   * Thereafter, when changes to source files have been made, only the page being viewed will be rebuilt if it was affected.<br>
   * Navigating to a new page will build the new page, if it has not been built before, or there were some changes to source files that affected it before navigating to it.<br>
   * {{ icon_example }} `--one-page guide/index.md`

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -16,6 +16,7 @@ const fsUtil = require('@markbind/core/src/utils/fsUtil');
 const utils = require('@markbind/core/src/utils');
 const {
   INDEX_MARKDOWN_FILE,
+  INDEX_MARKBIND_FILE,
   LAZY_LOADING_SITE_FILE_NAME,
 } = require('@markbind/core/src/Site/constants');
 
@@ -120,7 +121,13 @@ program
     const logsFolder = path.join(rootFolder, '_markbind/logs');
     const outputFolder = path.join(rootFolder, '_site');
 
-    let onePagePath = options.onePage === true ? INDEX_MARKDOWN_FILE : options.onePage;
+    const defaultFiles = [INDEX_MARKDOWN_FILE, INDEX_MARKBIND_FILE];
+    const presentDefaultFile = defaultFiles.find(utils.fileExists);
+    if (options.onePage === true && !presentDefaultFile) {
+      handleError(new Error('Oops! It seems that you didn\'t have the default file index.md|mbd.'));
+      process.exit();
+    }
+    let onePagePath = options.onePage === true ? presentDefaultFile : options.onePage;
     onePagePath = onePagePath ? utils.ensurePosix(onePagePath) : onePagePath;
 
     const site = new Site(rootFolder, outputFolder, onePagePath,

--- a/packages/core/src/Site/constants.js
+++ b/packages/core/src/Site/constants.js
@@ -11,6 +11,7 @@ module.exports = {
   FAVICON_DEFAULT_PATH: 'favicon.ico',
   FOOTER_PATH: '_markbind/footers/footer.md',
   INDEX_MARKDOWN_FILE: 'index.md',
+  INDEX_MARKBIND_FILE: 'index.mbd',
   MARKBIND_DEFAULT_PLUGIN_DIRECTORY: path.join(__dirname, '../plugins/default'),
   MARKBIND_PLUGIN_DIRECTORY: path.join(__dirname, '../plugins'),
   MARKBIND_PLUGIN_PREFIX: 'markbind-plugin-',


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

Fixes #1295 

**Overview of changes:**
- Added `index.mbd` as one of the default files for lazy-loading (alongside `index.md`)
- When author tries to run `markbind serve -o` without specifying initial file, MarkBind will try to find the default files first in the directory (in the order of `index.md`, `index.mbd`) and select the first one that it found.

**Anything you'd like to highlight / discuss:**
- I tried to do some validation here, if author didn't specify which file to lazy-load, and the directory does not have all the default files, it should not proceed. I don't know if it's proper way of handling it, since I don't really see a lot of examples where there is a validation error.
- I see from the user guide that when author didn't specify the file to lazy-load, the default files are `index.md|mbd|mbdf`. Should I add the support for `mbdf` default file too in this PR?

**Testing instructions:**
From `markbind init`, rename `index.md` to `index.mdb` and try `markbind serve -o`.

To try the validation: remove the index file altogether.

**Proposed commit message: (wrap lines at 72 characters)**
Lazy loading: Add support for index.mbd as default file

---

**Checklist:** :ballot_box_with_check:

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
