### PR TITLE
Intralink validator

### DIFF
--- a/docs/devGuide/design.md
+++ b/docs/devGuide/design.md
@@ -61,6 +61,6 @@ Internal bundles are also present, generated from setup scripts, custom styleshe
 
 ### UI components library
 
-This package consists of a mix of [Bootstrap](getbootstrap.com/components/) and proprietary components rewritten in [Vue.js](vuejs.org) based on our needs for educational websites.
+This package consists of a mix of [Bootstrap](https://getbootstrap.com/components/) and proprietary components rewritten in [Vue.js](https://vuejs.org) based on our needs for educational websites.
 
 We forked it from the original [yuche/vue-strap](https://github.com/yuche/vue-strap) repo into the [MarkBind/vue-strap](https://github.com/MarkBind/vue-strap) repo, and then later merged it into the main [MarkBind/markbind](https://github.com/MarkBind/markbind) repo.

--- a/packages/core/src/Page/PageConfig.js
+++ b/packages/core/src/Page/PageConfig.js
@@ -109,6 +109,16 @@ class PageConfig {
      * @type {VariableProcessor}
      */
     this.variableProcessor = args.variableProcessor;
+    /**
+     * Array of file types to ignore
+     * @type {Array}
+     */
+    this.ignore = args.ignore;
+    /**
+     * Array of page source objects
+     * @type {Array}
+     */
+    this.addressablePagesSource = args.addressablePagesSource;
   }
 }
 

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -865,6 +865,9 @@ class Page {
       baseUrl: this.pageConfig.baseUrl,
       rootPath: this.pageConfig.rootPath,
       headerIdMap: this.headerIdMap,
+      ignore: this.pageConfig.ignore,
+      addressablePagesSource: this.pageConfig.addressablePagesSource,
+      pageSrc: this.pageConfig.src,
     };
     const pageSources = new PageSources();
     const componentPreprocessor = new ComponentPreprocessor(fileConfig, this.pageConfig.variableProcessor,

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -139,6 +139,7 @@ class Site {
 
     // Other properties
     this.addressablePages = [];
+    this.addressablePagesSource = [];
     this.baseUrlMap = new Set();
     this.forceReload = forceReload;
     this.plugins = {};
@@ -322,6 +323,8 @@ class Site {
       titlePrefix: this.siteConfig.titlePrefix,
       template: this.pageTemplate,
       variableProcessor: this.variableProcessor,
+      ignore: this.siteConfig.ignore,
+      addressablePagesSource: this.addressablePagesSource,
     });
     return new Page(pageConfig);
   }
@@ -523,6 +526,10 @@ class Site {
         : filteredPage;
     });
     this.addressablePages = Object.values(filteredPages);
+    this.addressablePagesSource.length = 0;
+    this.addressablePages.forEach((page) => {
+      this.addressablePagesSource.push(FsUtil.removeExtension(page.src));
+    });
 
     return Promise.resolve();
   }

--- a/packages/core/src/parsers/ComponentParser.js
+++ b/packages/core/src/parsers/ComponentParser.js
@@ -8,7 +8,7 @@ _.isArray = require('lodash/isArray');
 _.cloneDeep = require('lodash/cloneDeep');
 _.has = require('lodash/has');
 
-const { convertRelativeLinks, convertMdExtToHtmlExt } = require('./linkProcessor');
+const linkProcessor = require('./linkProcessor');
 
 const md = require('../lib/markdown-it');
 const utils = require('../utils');
@@ -547,8 +547,12 @@ class ComponentParser {
       context = _.cloneDeep(context);
       context.cwf = node.attribs['data-included-from'];
     }
-    convertRelativeLinks(node, context.cwf, this.config.rootPath, this.config.baseUrl);
-    convertMdExtToHtmlExt(node);
+
+    if (linkProcessor.hasTagLink(node)) {
+      linkProcessor.convertRelativeLinks(node, context.cwf, this.config.rootPath, this.config.baseUrl);
+      linkProcessor.convertMdAndMbdExtToHtmlExt(node);
+      linkProcessor.validateIntraLink(node, context.cwf, this.config);
+    }
 
     const isHeadingTag = (/^h[1-6]$/).test(node.name);
 

--- a/packages/core/src/parsers/linkProcessor.js
+++ b/packages/core/src/parsers/linkProcessor.js
@@ -47,11 +47,20 @@ function convertRelativeLinks(node, cwf, rootPath, baseUrl) {
 
 function convertMdExtToHtmlExt(node) {
   if (node.name === 'a' && node.attribs && node.attribs.href) {
+    const hasNoConvert = lodashHas(node.attribs, 'no-convert');
+    if (hasNoConvert) {
+      return;
+    }
     const { href } = node.attribs;
     const hasMdExtension = href.slice(-3) === '.md';
-    const hasNoConvert = lodashHas(node.attribs, 'no-convert');
-    if (hasMdExtension && !hasNoConvert) {
+    if (hasMdExtension) {
       const newHref = `${href.substring(0, href.length - 3)}.html`;
+      node.attribs.href = newHref;
+      return;
+    }
+    const hasMbdExtension = href.slice(-4) === '.mbd';
+    if (hasMbdExtension) {
+      const newHref = `${href.substring(0, href.length - 4)}.html`;
       node.attribs.href = newHref;
     }
   }

--- a/packages/core/src/preprocessors/ComponentPreprocessor.js
+++ b/packages/core/src/preprocessors/ComponentPreprocessor.js
@@ -303,6 +303,7 @@ class ComponentPreprocessor {
     // the file path of dynamic resources ( images, anchors, plugin sources, etc. ) later
     const wrapperType = isInline ? 'span' : 'div';
     const childrenHtml = `<${wrapperType} data-included-from="${filePath}">${actualContent}</${wrapperType}>`;
+
     element.children = cheerio.parseHTML(childrenHtml, true);
 
     if (element.children && element.children.length > 0) {

--- a/packages/core/test/unit/LinkProcessor.test.js
+++ b/packages/core/test/unit/LinkProcessor.test.js
@@ -1,0 +1,175 @@
+const cheerio = require('cheerio');
+const fs = require('fs-extra');
+const linkProcessor = require('../../src/parsers/linkProcessor');
+
+jest.mock('fs');
+
+const json = {
+  './index.html': '1',
+  './userGuide/index.html': '2',
+  './userGuide/raw.html': '3',
+  './images/logo.png': '4',
+  './css/main.css': '5',
+  './devGuide/index.html': '6',
+  './rawFile': '7',
+};
+
+fs.vol.fromJSON(json, './src');
+
+const mockCwf = 'Test';
+
+const mockConfig = {
+  rootPath: './src',
+  baseUrl: '',
+  ignore: [
+    '_markbind', '_site/*',
+    'lib/*', '*.json',
+    '*.md', '*.mbd',
+    '*.mbdf', '*.njk',
+    '.git/*', '*.pptx',
+    'CNAME',
+  ],
+  addressablePagesSource: [
+    'index',
+    'userGuide/index',
+  ],
+};
+
+test('Test invalid URL link ', () => {
+  const mockLink = '<a href="https://markbind.org">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Not Intralink';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid ".html" extension link ', () => {
+  // should be checked as page
+  const mockLink = '<a href="/index.html">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink with ".html" extension is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid raw (not page source) ".html" extension link ', () => {
+  // should be checked as file asset
+  const mockLink = '<a href="/userGuide/raw.html">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_ERR_RESULT = 'Intralink with ".html" extension is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_ERR_RESULT);
+});
+
+test('Test invalid, non-existent ".html" extension link ', () => {
+  // should be checked as page and file asset
+  const mockLink = '<a href="/missing.html">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_ERR_RESULT = 'Intralink with ".html" extension is neither a Page Source nor File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_ERR_RESULT);
+});
+
+test('Test valid link ending with /', () => {
+  // should be checked as page
+  const mockLink = '<a href="/userGuide/">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink ending with "/" is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid link ending with /', () => {
+  // should be checked as page and file asset
+  const mockLink = '<a href="/devGuide/">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink ending with "/" is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test invalid, non-existent link ending with /', () => {
+  // should be checked as page and file asset
+  const mockLink = '<a href="/missingGuide/">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink ending with "/" is neither a Page Source nor File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid link ending with no extension', () => {
+  // should be checked as page
+  const mockLink = '<a href="/userGuide">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink with no extension is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid link ending with no extension', () => {
+  // should be checked as page and file asset (implicit index resource path will be true)
+  const mockLink = '<a href="/devGuide">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink with no extension is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid link ending with no extension', () => {
+  // should be checked as file asset (raw file)
+  const mockLink = '<a href="/rawFile">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink with no extension is a valid Page Source or File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test invalid, non-existent link ending with no extension', () => {
+  // should be checked as page, file asset, and raw file asset
+  const mockLink = '<a href="/missingRawFile">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink with no extension is neither a Page Source nor File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid file asset links (png)', () => {
+  // should be checked as file asset
+  const mockLink = '<img src="/images/logo.png">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink is a valid File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test valid file asset links (css)', () => {
+  // should be checked as file asset
+  const mockLink = '<link rel="stylesheet" href="/css/main.css">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink is a valid File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});
+
+test('Test invalid link for non-existent file asset (css)', () => {
+  // should be checked as file asset
+  const mockLink = '<link rel="stylesheet" href="/css/missing.css">Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink is not a File Asset';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});


### PR DESCRIPTION
**What is the purpose of this pull request?**
- [x] Feature addition or enhancement

This PR resolves issue #824 by introducing a crawler that validates all intra-link during site generation.

This PR is a replacement of the PR #1375 as the branch from that PR would introduce a lot of merge conflict to the master branch. It was deemed that it would be easier to create another branch and make a new PR. 

All the conversations and reviews can be viewed on PR #1375.

**Overview of changes:**
Implemented a method to check for all intra links during parsing.

**Anything you'd like to highlight / discuss:**
Code quality and edge cases. 

**Testing instructions:**
`npm run test`

**Proposed commit message: (wrap lines at 72 characters)**
Implement broken intralink validator

Currently, users have to manually check if their intralinks are valid.
Let's create a crawler to validate intralinks automatically. 

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
