### PR TITLE
Development mode: Change console log level to debug

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -107,6 +107,10 @@ program
   .option('-s, --site-config <file>', 'specify the site config file (default: site.json)')
   .option('-d, --dev', 'development mode, enabling live & hot reload for frontend source files.')
   .action((userSpecifiedRoot, options) => {
+    if (options.dev) {
+      logger.useDebugConsole();
+    }
+
     let rootFolder;
     try {
       rootFolder = cliUtil.findRootFolder(userSpecifiedRoot, options.siteConfig);

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -14,6 +14,10 @@ const consoleTransport = new (winston.transports.Console)({
   showLevel: true,
 });
 
+function useDebugConsole() {
+  consoleTransport.level = 'debug';
+}
+
 const dailyRotateFileTransport = new DailyRotateFile({
   datePattern: 'YYYY-MM-DD',
   dirname: '_markbind/logs',
@@ -43,4 +47,5 @@ module.exports = {
   /* eslint-disable no-console */
   log: console.log,
   logo: () => console.log(chalk.cyan(figlet.textSync('MarkBind', { horizontalLayout: 'full' }))),
+  useDebugConsole,
 };


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

As mentioned on #970, with the addition of debug-level logs, we need a way to run MarkBind with the debug-level logs printed out to console too, instead of just to the log files. 

**Overview of changes:**
Added a function to switch console transport's log level to be `debug`, and called when `--dev` is specified.

**Anything you'd like to highlight / discuss:**
NA

**Testing instructions:**
From the default MarkBind project created by `markbind init`, run `markbind serve -d` . Then, remove one of the files in the `contents` folder. There will be a debug-level log "Assets removed" displayed on console.

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Development mode: Change console log level to debug

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
