### PR TITLE
Fix intralink validation for pages on windows

### DIFF
--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -528,7 +528,7 @@ class Site {
     this.addressablePages = Object.values(filteredPages);
     this.addressablePagesSource.length = 0;
     this.addressablePages.forEach((page) => {
-      this.addressablePagesSource.push(FsUtil.removeExtension(page.src));
+      this.addressablePagesSource.push(FsUtil.removeExtensionPosix(page.src));
     });
 
     return Promise.resolve();

--- a/packages/core/src/parsers/linkProcessor.js
+++ b/packages/core/src/parsers/linkProcessor.js
@@ -3,6 +3,7 @@ const lodashHas = require('lodash/has');
 const url = require('url');
 const ignore = require('ignore');
 const utils = require('../utils');
+const fsUtils = require('../utils/fsUtil');
 const logger = require('../utils/logger');
 
 const defaultTagLinkMap = {
@@ -82,10 +83,7 @@ function isValidPageSource(resourcePath, config) {
   const relativeResourcePath = resourcePath.startsWith('/')
     ? resourcePath.substring(1)
     : resourcePath;
-  const parsedPath = path.parse(relativeResourcePath);
-  const relativeResourcePathWithNoExt = parsedPath.dir
-    ? `${parsedPath.dir}/${parsedPath.name}`
-    : parsedPath.name;
+  const relativeResourcePathWithNoExt = fsUtils.removeExtensionPosix(relativeResourcePath);
   const isPageSrc = config.addressablePagesSource.includes(relativeResourcePathWithNoExt);
   return isPageSrc;
 }

--- a/packages/core/src/utils/fsUtil.js
+++ b/packages/core/src/utils/fsUtil.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
+const ensurePosix = require('ensure-posix-path');
 
 module.exports = {
   isInRoot: (root, fileName) => {
@@ -25,6 +26,11 @@ module.exports = {
     path.dirname(filePathWithExt),
     path.basename(filePathWithExt, path.extname(filePathWithExt)),
   ),
+
+  removeExtensionPosix: filePathWithExt => ensurePosix(path.join(
+    path.dirname(filePathWithExt),
+    path.basename(filePathWithExt, path.extname(filePathWithExt)),
+  )),
 
   copySyncWithOptions: function copySyncWithOptions(src, dest, options) {
     const files = fs.readdirSync(src);

--- a/packages/core/test/unit/LinkProcessor.test.js
+++ b/packages/core/test/unit/LinkProcessor.test.js
@@ -4,14 +4,13 @@ const linkProcessor = require('../../src/parsers/linkProcessor');
 
 jest.mock('fs');
 
+// Assets
 const json = {
-  './index.html': '1',
-  './userGuide/index.html': '2',
-  './userGuide/raw.html': '3',
-  './images/logo.png': '4',
-  './css/main.css': '5',
-  './devGuide/index.html': '6',
-  './rawFile': '7',
+  './userGuide/raw.html': '1',
+  './images/logo.png': '2',
+  './css/main.css': '3',
+  './devGuide/index.html': '4',
+  './rawFile': '5',
 };
 
 fs.vol.fromJSON(json, './src');
@@ -29,6 +28,7 @@ const mockConfig = {
     '.git/*', '*.pptx',
     'CNAME',
   ],
+  // Pages
   addressablePagesSource: [
     'index',
     'userGuide/index',


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Quick follow up to #1382 

Fixes intralink page checks failing on windows due to using posix implementation of file extension removal in `linkProcessor` only

**Overview of changes:**
- Normalize the page directory `addressablePageSource` to posix paths as well
- Extract the common method used in both methods to `fsUtil`
- Modified the unit tests to prevent false positives - the pages were validated as assets

**Anything you'd like to highlight / discuss:**
na

**Testing instructions:**
na
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix intralink validation for pages on windows

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
