### PR TITLE
Add {% ext %} nunjucks extension

### DIFF
--- a/docs/userGuide/syntax/extra/scoreboard.json
+++ b/docs/userGuide/syntax/extra/scoreboard.json
@@ -1,0 +1,20 @@
+{
+  "lastUpdated": "21 November, 2020",
+  "students": [
+    {
+      "number": "A1234567X",
+      "score": 87,
+      "rank": 1
+    },
+    {
+      "number": "A1234123U",
+      "score": 60,
+      "rank": 3
+    },
+    {
+      "number": "A9876543L",
+      "score": 76,
+      "rank": 2
+    }
+  ]
+}

--- a/docs/userGuide/syntax/variables.mbdf
+++ b/docs/userGuide/syntax/variables.mbdf
@@ -159,7 +159,42 @@ In this case, all the variables in `title.md` are not accessible, as they are ov
 
 </box>
 
-### Defining variables with JSON
+### Importing variables from other external file formats
+
+You can also sources variables from external files using MarkBind's {%raw%}`{% ext varName = "filepathToFile/file.json" %}`{%endraw%} nunjucks extension.
+This is useful if you have external datasets you want to display in your site!
+
+Only `.json` files are supported for now.
+
+<include src="codeAndOutputSeparate.md" boilerplate>
+<variable name="highlightStyle">html</variable>
+<variable name="code">
+{% raw %}
+{% ext studentScoreboard = "userGuide/syntax/extra/scoreboard.json" %}
+
+Student Number | Score | Rank
+:----- | :-------: | ----
+{% for student in studentScoreboard.students -%}
+{{ student.number }} | {{ student.score }} | {{ student.rank }}
+{% endfor %}
+
+<small>Last updated at {{ studentScoreboard.lastUpdated }}</small>
+{% endraw %}
+</variable>
+<variable name="output">
+{% ext studentScoreboard = "userGuide/syntax/extra/scoreboard.json" %}
+
+Student Number | Score | Rank
+:----- | :-------: | ----
+{% for student in studentScoreboard.students -%}
+{{ student.number }} | {{ student.score }} / 100 | {{ student.rank }}
+{% endfor %}
+
+<small>Last updated at {{ studentScoreboard.lastUpdated }}</small>
+</variable>
+</include>
+
+<panel type="seamless" header="##### Old syntax (deprecated)">
 
 You could also have your variables defined in a JSON file to define multiple variables in a more concise manner.
 
@@ -188,7 +223,7 @@ locally scoped variables in `index.md`:
 
 In this case, json variables referenced within `index.md` would be a page variable accessible within the page `index.md`.
 
-
+</panel>
 
 ### Tips and Tricks for variables
 

--- a/docs/userGuide/syntax/variables.mbdf
+++ b/docs/userGuide/syntax/variables.mbdf
@@ -159,17 +159,23 @@ In this case, all the variables in `title.md` are not accessible, as they are ov
 
 </box>
 
-### Importing variables from other external file formats
+#### Importing variables from other external file formats
 
-You can also sources variables from external files using MarkBind's {%raw%}`{% ext varName = "filepathToFile/file.json" %}`{%endraw%} nunjucks extension.
+You can also source variables from external files using MarkBind's {%raw%}`{% ext varName = "filepathToFile" %}`{%endraw%} Nunjucks extension.
 This is useful if you have external datasets you want to display in your site!
 
-Only `.json` files are supported for now.
+To do so, assign a root variable name (`varName`) to the file path from the <tooltip content="similar to how you assign filepaths for other Nunjucks tags">root directory of the site</tooltip>. You may then access the file's variables using dot `varName.xx` or array `varName[i]` syntax, depending on the file's contents.
 
-<include src="codeAndOutputSeparate.md" boilerplate>
-<variable name="highlightStyle">html</variable>
-<variable name="code">
+
+
+{{ icon_example }}
+
+%%CODE:%%
+
+<div class="indented">
+
 {% raw %}
+```html {heading="Displaying a student scoreboard stored as JSON"}
 {% ext studentScoreboard = "userGuide/syntax/extra/scoreboard.json" %}
 
 Student Number | Score | Rank
@@ -179,9 +185,25 @@ Student Number | Score | Rank
 {% endfor %}
 
 <small>Last updated at {{ studentScoreboard.lastUpdated }}</small>
+```
 {% endraw %}
-</variable>
-<variable name="output">
+
+<panel type="minimal" header="Json file used in example">
+
+```json {heading="Json File"}
+{% include "userGuide/syntax/extra/scoreboard.json" %}
+```
+
+</panel>
+<br>
+
+</div>
+
+%%OUTPUT:%%
+<div class="indented">
+
+<box border-left-color="grey" background-color="white">
+
 {% ext studentScoreboard = "userGuide/syntax/extra/scoreboard.json" %}
 
 Student Number | Score | Rank
@@ -191,8 +213,13 @@ Student Number | Score | Rank
 {% endfor %}
 
 <small>Last updated at {{ studentScoreboard.lastUpdated }}</small>
-</variable>
-</include>
+</box>
+</div>
+
+<box type="info" seamless>
+
+Only `.json` files are supported for now.
+</box>
 
 <panel type="seamless" header="##### Old syntax (deprecated)">
 

--- a/packages/cli/test/functional/test_site/_markbind/variable.json
+++ b/packages/cli/test/functional/test_site/_markbind/variable.json
@@ -2,5 +2,12 @@
     "back": "back </div>",
     "front": "<div> front",
     "jsonVar1": "Json Variable can be referenced",
-    "jsonVar2": "Referencing jsonVar1: {{ jsonVar1 }}"
+    "jsonVar2": "Referencing jsonVar1: {{ jsonVar1 }}",
+    "arrayVar": [
+        "arrayVarItem1",
+        "arrayVarItem2"
+    ],
+    "nestedVar": {
+        "nestedVarKey": "nestedVarValue"
+    }
 }

--- a/packages/cli/test/functional/test_site/expected/_markbind/variable.json
+++ b/packages/cli/test/functional/test_site/expected/_markbind/variable.json
@@ -2,5 +2,12 @@
     "back": "back </div>",
     "front": "<div> front",
     "jsonVar1": "Json Variable can be referenced",
-    "jsonVar2": "Referencing jsonVar1: {{ jsonVar1 }}"
+    "jsonVar2": "Referencing jsonVar1: {{ jsonVar1 }}",
+    "arrayVar": [
+        "arrayVarItem1",
+        "arrayVarItem2"
+    ],
+    "nestedVar": {
+        "nestedVarKey": "nestedVarValue"
+    }
 }

--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -175,6 +175,11 @@
               Here is an inline note.<trigger for="pop:footnote3"><sup class="footnote-ref"><a aria-describedby="footnote-label" href="#fn3" id="fnref3">[3]</a></sup></trigger>
             </p>
           </div>
+          <p><strong>Nunjucks SetExt</strong></p>
+          <div> front back </div>
+          <p>arrayVarItem1</p>
+          <p>arrayVarItem2</p>
+          <p>nestedVarValue</p>
           <p><strong>Json Variable</strong></p>
           <div> front back </div>
           <p>Json Variable can be referenced Referencing jsonVar1: Json Variable can be referenced</p>

--- a/packages/cli/test/functional/test_site/index.md
+++ b/packages/cli/test/functional/test_site/index.md
@@ -18,6 +18,18 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 <include src="testFootnotes.md" />
 
+**Nunjucks SetExt**
+
+{% ext externalVar = "_markbind/variable.json" %}
+
+{{ externalVar.front }} {{ externalVar.back }}
+
+{% for val in externalVar.arrayVar %}
+{{ val }}
+{% endfor %}
+
+{{ externalVar.nestedVar.nestedVarKey }}
+
 **Json Variable**
 
 {{ front }} {{ back }}

--- a/packages/core/src/lib/nunjucks-extensions/index.js
+++ b/packages/core/src/lib/nunjucks-extensions/index.js
@@ -1,0 +1,7 @@
+const { filter } = require('./nunjucks-date');
+const { SetExternalExtension } = require('./set-external');
+
+module.exports = {
+  dateFilter: filter,
+  SetExternalExtension,
+};

--- a/packages/core/src/lib/nunjucks-extensions/set-external.js
+++ b/packages/core/src/lib/nunjucks-extensions/set-external.js
@@ -1,0 +1,69 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+const { Parser } = require('nunjucks/src/parser');
+const { lex } = require('nunjucks/src/lexer');
+
+const _ = {};
+_.isArray = require('lodash/isArray');
+_.isObject = require('lodash/isObject');
+_.isString = require('lodash/isString');
+
+const logger = require('../../utils/logger');
+
+/**
+ * Nunjucks extension for sourcing in variables from external sources.
+ * Supports only .json sources for now.
+ */
+class SetExternalExtension {
+  constructor(rootPath, env) {
+    this.tags = ['ext'];
+    this.rootPath = rootPath;
+    this.env = env;
+  }
+
+  emitLoad(fullPath) {
+    // Emit the nunjucks load event for the listener in {@link VariableRenderer}
+    this.env.emit('load', '', { path: fullPath });
+  }
+
+  parse(parser, nodes, lexer) {
+    // get the tag token
+    const setExtTagToken = parser.nextToken();
+
+    // parse the args and move after the block end. passing true
+    // as the second arg is required if there are no parentheses
+    const args = parser.parseSignature(null, true);
+    parser.advanceAfterBlockEnd(setExtTagToken.value);
+    const firstChild = args.children[0];
+
+    const buffer = [];
+    if (firstChild instanceof nodes.KeywordArgs) {
+      firstChild.children.forEach((pair) => {
+        const variableName = pair.key.value;
+        const resourcePath = pair.value.value;
+
+        if (resourcePath.endsWith('.json')) {
+          const fullResourcePath = path.resolve(this.rootPath, resourcePath);
+          const resourceRaw = fs.readFileSync(fullResourcePath);
+          buffer.push(`{% set ${variableName} = ${resourceRaw} %}`);
+          this.emitLoad(fullResourcePath);
+        }
+      });
+    } else {
+      logger.error(`Invalid {% ext %} tag at line ${setExtTagToken.lineno}.`);
+      return new nodes.NodeList(setExtTagToken.lineno, setExtTagToken.colno, []);
+    }
+
+    const newParser = new Parser(lex(buffer.join('\n'), lexer.opts));
+    if (parser.extensions !== undefined) {
+      newParser.extensions = parser.extensions;
+    }
+
+    return newParser.parse();
+  }
+}
+
+module.exports = {
+  SetExternalExtension,
+};

--- a/packages/core/src/variables/VariableRenderer.js
+++ b/packages/core/src/variables/VariableRenderer.js
@@ -1,8 +1,12 @@
-require('../patches/nunjucks'); // load our patch first
+require('../patches/nunjucks'); // load patch first
 const nunjucks = require('nunjucks');
-const { filter: dateFilter } = require('../lib/nunjucks-extensions/nunjucks-date');
+const {
+  dateFilter,
+  SetExternalExtension,
+} = require('../lib/nunjucks-extensions');
 
-const unescapedEnv = nunjucks.configure({ autoescape: false }).addFilter('date', dateFilter);
+const unescapedEnv = nunjucks.configure({ autoescape: false })
+  .addFilter('date', dateFilter);
 
 const START_ESCAPE_STR = '{% raw %}';
 const END_ESCAPE_STR = '{% endraw %}';
@@ -69,7 +73,9 @@ class VariableRenderer {
      */
     this.pageSources = undefined;
 
-    this.nj = nunjucks.configure(siteRootPath, { autoescape: false }).addFilter('date', dateFilter);
+    this.nj = nunjucks.configure(siteRootPath, { autoescape: false });
+    this.nj.addFilter('date', dateFilter);
+    this.nj.addExtension('SetExternalExtension', new SetExternalExtension(siteRootPath, this.nj));
     this.nj.on('load', (name, source) => {
       this.pageSources.staticIncludeSrc.push({ to: source.path });
     });


### PR DESCRIPTION


**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

Part of #1353 

**Overview of changes:**
- Add {% ext %} nunjucks extension replacing `<variable type="json" ... >`
- Update docs (and deprecate old syntax)

**Anything you'd like to highlight / discuss:**

**Testing instructions:**


**Proposed commit message: (wrap lines at 72 characters)**
Add {% ext %} nunjucks extension

MarkBind page variables requires processing html before nunjucks and
markdown syntax.
This poses several architectural issues (#1353) of simplicity,
performance, and extensibility of markdown syntax.

As another step in removing this prerequisite, let's reimplement
external json variables using a nunjucks extension.

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
