### PR TITLE
Fix bootswatch theme path resolving

### DIFF
--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -75,7 +75,7 @@ const {
 } = require('./constants');
 
 function getBootswatchThemePath(theme) {
-  return path.join(__dirname, '..', 'node_modules', 'bootswatch', 'dist', theme, 'bootstrap.min.css');
+  return require.resolve(`bootswatch/dist/${theme}/bootstrap.min.css`);
 }
 
 const SUPPORTED_THEMES_PATHS = {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes #1394

**Overview of changes:**
Fixes a regression likely from the shift to lerna as a package manager.

The old path resolving manually seeks out the resource path via `path.join(__dirname, ...` which fails due to the vastly different package structure.

Let's use node's `require.resolve` method instead which is more robust.

**Anything you'd like to highlight / discuss:**


**Testing instructions:**

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix bootswatch theme path resolving
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:
- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
