### PR TITLE
Ignore self-closing special tags for markdown-it

### DIFF
--- a/packages/core/src/lib/markdown-it/markdown-it-escape-special-tags.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-escape-special-tags.js
@@ -12,7 +12,20 @@ function escape_plugin(md, tagsToIgnore) {
   const specialTagsRegex = Array.from(tagsToIgnore)
     .concat(['script|pre|style|variable'])
     .join('|');
-  const startingSpecialTagRegex = new RegExp(`^<(${specialTagsRegex})(?=(\\s|>|$))`, 'i');
+
+  // attr_name, unquoted ... attribute patterns adapted from markdown-it/lib/common/html_re
+  // Construct self-closing negative lookahead for special tags,
+  // because if matched, the endingSpecialTagRegex will roll down to find a non-existent closing tag
+  const attr_name = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
+  const unquoted      = '[^"\'=<>`\\x00-\\x20]+';
+  const single_quoted = "'[^']*'";
+  const double_quoted = '"[^"]*"';
+  const attr_value  = '(?:' + unquoted + '|' + single_quoted + '|' + double_quoted + ')';
+  const attribute   = '(?:\\s+' + attr_name + '(?:\\s*=\\s*' + attr_value + ')?)';
+  const selfClosingNegativeLookahead = `(?!${attribute}*\\s*\/>)`;
+
+  const startingSpecialTagRegex = new RegExp(
+    `^<(${specialTagsRegex})${selfClosingNegativeLookahead}(?=(\\s|>|$))`, 'i');
   const endingSpecialTagRegex = new RegExp(`<\\/(${specialTagsRegex})>`, 'i');
 
   const HTML_SEQUENCES = [


### PR DESCRIPTION

**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Follow up to #1101 
Surfaced in #1403 

**Overview of changes:**
- Add negative lookahead to starting pattern for special tag patch for markdown-it

**Anything you'd like to highlight / discuss:**
This was not apparent before as the only special tag in our tests is `<puml>`.
These are processed before markdown-it ever touches them, resulting in false positives.


**Testing instructions:**

Tested on https://regexr.com/, then #1403 

**Proposed commit message: (wrap lines at 72 characters)**
Ignore self-closing special tags for markdown-it

The markdown-it patch for special tags does not blacklist self-closed
special tags from the starting regex pattern. Thus, the starting regex
pattern incorrectly matches such a self-closing special tag, and the
ending regex pattern incorrectly seeks for a corresponding closing
special tag until EOF.

This is not apparent in the functional tests which have such tags
(`<puml>`), because puml tags are processed before markdown.

Let's add a negative lookahead to the starting pattern to blacklist
such tags.

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features (architectural restructure in #1403 surfaces this with our existing tests)
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
