### PR TITLE
Remove line numbers and fix formatting issues in user guide

### DIFF
--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -190,11 +190,11 @@ Here are the steps to set up Netlify to use a specific version of MarkBind.
 1. run `npm init` which will create `package.json` and `package.lock.json`
 1. run `npm install markbind-cli@1.6.3 --save` to install markbind as a dependency (using v1.6.3 as an example)
 1. create/update `.gitignore` file in the root directory and add:
-   ```
+   ```{.no-line-numbers}
    node_modules
    ```
 1. update `ignore` in site.json to include
-   ```
+   ```{.no-line-numbers}
    node_modules/*
    .gitignore
    ```

--- a/docs/userGuide/plugins/algolia.mbdf
+++ b/docs/userGuide/plugins/algolia.mbdf
@@ -11,8 +11,7 @@ indexName | `String` || The index name for your site's Algolia DocSearch setup
 algoliaOptions | `Object` | `{}` | A JSON object specifying [additional options for DocSearch](https://community.algolia.com/docsearch/behavior.html#algoliaoptions)
 debug | `Boolean` | `false` | Whether to turn on debug mode to allow inspection of CSS styles for the dropdown
 
-```js
-site.json
+```js {heading="site.json"}
 {
   ...
   "plugins": [

--- a/docs/userGuide/plugins/codeBlockCopyButtons.mbdf
+++ b/docs/userGuide/plugins/codeBlockCopyButtons.mbdf
@@ -4,8 +4,7 @@ This plugin adds a 'copy' button to fenced code blocks so that readers can copy 
 
 To enable it, simply add `codeBlockCopyButtons` to your site's plugins.
 
-```js
-site.json
+```js {heading="site.json"}
 {
   ...
   "plugins": [

--- a/docs/userGuide/plugins/googleAnalytics.mbdf
+++ b/docs/userGuide/plugins/googleAnalytics.mbdf
@@ -8,8 +8,7 @@ Name | Type | Default | Description
 ---- | ---- | ------- | ------
 trackingID | `String` || Tracking ID provided by Google. Follow this [guide](https://support.google.com/analytics/answer/1008080) to get your Tracking ID.
 
-```js
-site.json
+```js {heading="site.json"}
 {
   ...
   "plugins": [

--- a/docs/userGuide/reusingContents.md
+++ b/docs/userGuide/reusingContents.md
@@ -34,7 +34,7 @@
 <div class="indented">
 
 {{ icon_example }} Suppose you have a site `textbook` and you want to include some pages from it in another site `course`. Given below is how you can locate the sub-site `textbook` inside the root directory of the main-site `course` so that files from `textbook` can be reused in the `course` site.
-```
+```{.no-line-numbers}
 c:/course/
   ├── textbook/
   |      ├── index.md

--- a/docs/userGuide/reusingContents.md
+++ b/docs/userGuide/reusingContents.md
@@ -35,7 +35,7 @@
 
 {{ icon_example }} Suppose you have a site `textbook` and you want to include some pages from it in another site `course`. Given below is how you can locate the sub-site `textbook` inside the root directory of the main-site `course` so that files from `textbook` can be reused in the `course` site.
 ```{.no-line-numbers}
-c:/course/
+C:/course/
   ├── textbook/
   |      ├── index.md
   |      ├── overview.md

--- a/docs/userGuide/syntax/includes.mbdf
+++ b/docs/userGuide/syntax/includes.mbdf
@@ -84,7 +84,7 @@ The `<include>` mechanism can be used inside any MarkBind source file (even insi
 
 {{ icon_example }} Suppose you have a MarkBind project with the following file structure.
 ```{.no-line-numbers}
-c:/mySite/
+C:/mySite/
   ├── bookFiles/
   |      ├── book.md
   |      ├── chapter1.md
@@ -160,7 +160,7 @@ If the same variable is defined in a chain of `<include>`s (e.g. `a.md` includes
 
 {{ icon_example }} Suppose you have a MarkBind project with the following file structure.
 ```{.no-line-numbers}
-c:/mySite/
+C:/mySite/
   ├── chapter1/
   |      ├── chapter.md
   |      ├── text.md
@@ -205,7 +205,7 @@ To use a code fragment as a boilerplate file,
 
 {{ icon_example }} Here's how you can use a boilerplate file to avoid duplicating the `chapter.md`:
 ```{.no-line-numbers}
-c:/mySite/
+C:/mySite/
   ├── _markbind/boilerplates/
   |      └── chapter.md
   ├── chapter1/
@@ -242,7 +242,7 @@ If you have many boilerplate files, you can organize them into directories insid
 
 {{ icon_example }} Suppose the `chapter.md` is places in a `book` directory:
 ```{.no-line-numbers}
-c:/mySite/
+C:/mySite/
   └── _markbind/boilerplates/
          └── book/
                └── chapter.md

--- a/docs/userGuide/syntax/includes.mbdf
+++ b/docs/userGuide/syntax/includes.mbdf
@@ -83,7 +83,7 @@ The `<include>` mechanism can be used inside any MarkBind source file (even insi
 <div class="indented">
 
 {{ icon_example }} Suppose you have a MarkBind project with the following file structure.
-```
+```{.no-line-numbers}
 c:/mySite/
   ├── bookFiles/
   |      ├── book.md
@@ -159,7 +159,7 @@ If the same variable is defined in a chain of `<include>`s (e.g. `a.md` includes
 <div class="indented">
 
 {{ icon_example }} Suppose you have a MarkBind project with the following file structure.
-```
+```{.no-line-numbers}
 c:/mySite/
   ├── chapter1/
   |      ├── chapter.md
@@ -204,7 +204,7 @@ To use a code fragment as a boilerplate file,
 <div class="indented">
 
 {{ icon_example }} Here's how you can use a boilerplate file to avoid duplicating the `chapter.md`:
-```
+```{.no-line-numbers}
 c:/mySite/
   ├── _markbind/boilerplates/
   |      └── chapter.md
@@ -241,7 +241,7 @@ If you have many boilerplate files, you can organize them into directories insid
 <div class="indented">
 
 {{ icon_example }} Suppose the `chapter.md` is places in a `book` directory:
-```
+```{.no-line-numbers}
 c:/mySite/
   └── _markbind/boilerplates/
          └── book/

--- a/docs/userGuide/syntax/pageLayouts.mbdf
+++ b/docs/userGuide/syntax/pageLayouts.mbdf
@@ -19,7 +19,7 @@ To apply the layout, specify it as an attribute named `layout` in the `<frontmat
 <div class="indented">
 
 {{ icon_example }} Suppose you have a layout named `chapterLayout`.
-```
+```{.no-line-numbers}
 <root>/_markbind/layouts/
                   └── chapterLayout/
                         ├── header.md


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #1093.

**Anything you'd like to highlight / discuss:**
There are also some file names which are not moved to the code headers. This change updates the formatting of code blocks to have the file names as the code block header.

**Testing instructions:**
There are no special testing instructions.
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->
```
Remove line numbers and fix formatting issues in user guide

Some of the code blocks in the user guide contains redundant line
numbers. There are also some file names which are not moved to the
code headers and are listed as part of the code itself.

Let's remove the redundant line numbers and format code blocks
correctly to have the file names as part of the code headers.
```
---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
