### PR TITLE
Add a per-link attribute for disabling intralink validation

### DIFF
--- a/docs/userGuide/syntax/links.mbdf
+++ b/docs/userGuide/syntax/links.mbdf
@@ -104,6 +104,23 @@ Within `index.md`, we can also display the image using
 </box>
 
 </div>
+
+****Link validation****
+
+<div class="indented">
+
+Links will be validated when generating a site and a warning will be displayed in the console for every link that is invalid.
+
+<box type="warning">
+
+If you wish to disable validation for a specific link, you may use the `no-validation` attribute.
+
+{{ icon_example }}
+`Click [here](index.md){no-validation}`
+
+</box>
+
+</div>
 </div>
 
 <span id="short" class="d-none">

--- a/packages/core/src/html/linkProcessor.js
+++ b/packages/core/src/html/linkProcessor.js
@@ -125,7 +125,7 @@ function isValidFileAsset(resourcePath, config) {
 
 /**
  * Serves as an internal intra-link validator. Checks if the intra-links are valid.
- * If the intra-links are suspected to not be valid and they do not have the no-validation
+ * If the intra-links are suspected to be invalid and they do not have the no-validation
  * attribute, a warning message will be logged.
  *
  * @param {Object<any, any>} node from the dom traversal

--- a/packages/core/src/html/linkProcessor.js
+++ b/packages/core/src/html/linkProcessor.js
@@ -125,7 +125,8 @@ function isValidFileAsset(resourcePath, config) {
 
 /**
  * Serves as an internal intra-link validator. Checks if the intra-links are valid.
- * If the intra-links are not suspected to not be valid, a warning message will be logged.
+ * If the intra-links are suspected to not be valid and they do not have the no-intralink-validation
+ * attribute, a warning message will be logged.
  *
  * @param {Object<any, any>} node from the dom traversal
  * @param {string} cwf as flagged from {@link NodePreprocessor}
@@ -133,6 +134,13 @@ function isValidFileAsset(resourcePath, config) {
  * @returns {string} these string return values are for unit testing purposes only
  */
 function validateIntraLink(node, cwf, config) {
+  if (node.attribs) {
+    const hasIntralinkValidationDisabled = lodashHas(node.attribs, 'no-intralink-validation');
+    if (hasIntralinkValidationDisabled) {
+      return 'Intralink validation disabled';
+    }
+  }
+
   let resourcePath = getDefaultTagsResourcePath(node);
   if (!resourcePath || utils.isUrl(resourcePath) || resourcePath.startsWith('#')) {
     return 'Not Intralink';

--- a/packages/core/src/html/linkProcessor.js
+++ b/packages/core/src/html/linkProcessor.js
@@ -125,7 +125,7 @@ function isValidFileAsset(resourcePath, config) {
 
 /**
  * Serves as an internal intra-link validator. Checks if the intra-links are valid.
- * If the intra-links are suspected to not be valid and they do not have the no-intralink-validation
+ * If the intra-links are suspected to not be valid and they do not have the no-validation
  * attribute, a warning message will be logged.
  *
  * @param {Object<any, any>} node from the dom traversal
@@ -135,7 +135,7 @@ function isValidFileAsset(resourcePath, config) {
  */
 function validateIntraLink(node, cwf, config) {
   if (node.attribs) {
-    const hasIntralinkValidationDisabled = lodashHas(node.attribs, 'no-intralink-validation');
+    const hasIntralinkValidationDisabled = lodashHas(node.attribs, 'no-validation');
     if (hasIntralinkValidationDisabled) {
       return 'Intralink validation disabled';
     }

--- a/packages/core/test/unit/html/linkProcessor.test.js
+++ b/packages/core/test/unit/html/linkProcessor.test.js
@@ -173,3 +173,12 @@ test('Test invalid link for non-existent file asset (css)', () => {
 
   expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
 });
+
+test('Test link for disabled intralink validation', () => {
+  const mockLink = '<a href="https://markbind.org" no-intralink-validation>Test</a>';
+  const mockNode = cheerio.parseHTML(mockLink)[0];
+
+  const EXPECTED_RESULT = 'Intralink validation disabled';
+
+  expect(linkProcessor.validateIntraLink(mockNode, mockCwf, mockConfig)).toEqual(EXPECTED_RESULT);
+});

--- a/packages/core/test/unit/html/linkProcessor.test.js
+++ b/packages/core/test/unit/html/linkProcessor.test.js
@@ -175,7 +175,7 @@ test('Test invalid link for non-existent file asset (css)', () => {
 });
 
 test('Test link for disabled intralink validation', () => {
-  const mockLink = '<a href="https://markbind.org" no-intralink-validation>Test</a>';
+  const mockLink = '<a href="https://markbind.org" no-validation>Test</a>';
   const mockNode = cheerio.parseHTML(mockLink)[0];
 
   const EXPECTED_RESULT = 'Intralink validation disabled';


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #1387. Related #1418. Add no-validation attribute to link and the link will not be validated. A test was added in linkProcessor.test.js

**Anything you'd like to highlight / discuss:**
Code quality and implementation.

**Testing instructions:**
npm run test
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
linkProcessor: add attribute to disable intralink validation

There are no known methods to disable intralink validation per-link.

There were dummy links in the user guide that failed the intralink
 validation and printed warnings in the console.

Let's add a no-validation attribute to disable intralink
 validation for such cases in the future.
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
