### PR TITLE
Render markdown before finding hash content

### DIFF
--- a/docs/userGuide/plugins/tags.mbdf
+++ b/docs/userGuide/plugins/tags.mbdf
@@ -144,6 +144,7 @@ Using `-` at the start of a tag hides all tags matching the expression. This is 
 This only works because tags are processed left to right, so all `language--*` tags are hidden before `language--C#`. Tags in `site.json` are processed after tags in `<frontmatter>`.
 
 <span id="short" class="d-none">
+
 ```html
 # Print 'Hello world'
 

--- a/docs/userGuide/syntax/boxes.mbdf
+++ b/docs/userGuide/syntax/boxes.mbdf
@@ -198,6 +198,7 @@ no-icon | `Boolean` | `false` | Removes icon, except if icon is displayed via `i
 
 
 <span id="short" class="d-none">
+
 ```html
 <box type="warning">
   warning

--- a/docs/userGuide/syntax/code.mbdf
+++ b/docs/userGuide/syntax/code.mbdf
@@ -22,6 +22,7 @@ To enable syntax coloring, specify a language next to the backticks before the f
 <div id="main-example">
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```xml
 <foo>
   <bar type="name">goo</bar>
@@ -36,6 +37,7 @@ Line numbers are provided by default. To hide line numbers, add the class `no-li
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```xml {.no-line-numbers}
 <foo>
   <bar type="name">goo</bar>
@@ -48,6 +50,7 @@ You can have your line numbers start with a value other than `1` with the `start
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```js {start-from=6}
 function add(a, b) {
     return a + b;
@@ -79,6 +82,7 @@ For ranges, you only need to use line-slices on either ends.
 <include src="codeAndOutputCode.md" boilerplate >
 
 <variable name="code">
+
 ```java {highlight-lines="1,3[:],6-8,10[:]-12"}
 import java.util.List;
 
@@ -104,6 +108,7 @@ To add a heading, add the attribute `heading` with the heading text as the value
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```xml {heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>
@@ -116,6 +121,7 @@ Headings support inline Markdown, except for `Inline Code` and %%Dim%% text styl
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```{heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, :+1: :exclamation: :x: :construction:<br>We support page breaks"}
 <foo></foo>
 ```
@@ -127,6 +133,7 @@ You can also use multiple features together, as shown below.
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
+
 ```xml {highlight-lines="2" heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>
@@ -150,6 +157,7 @@ or the java code `public static void main(String[] args)`{.java}.
 </include>
 
 <span id="short" class="d-none">
+
 ````
 ```xml
 <foo>

--- a/docs/userGuide/syntax/diagrams.mbdf
+++ b/docs/userGuide/syntax/diagrams.mbdf
@@ -16,6 +16,7 @@ must be installed to use this feature**
 <div id="main-example">
 <include src="outputBox.md" boilerplate>
 <span id="code">
+
 ```
 <puml width=300>
 @startuml

--- a/docs/userGuide/syntax/headings.mbdf
+++ b/docs/userGuide/syntax/headings.mbdf
@@ -19,6 +19,7 @@ If the heading text is `Foo Bar (Goo)`, the ID of the generated anchor will be `
 <small>Alternative syntax, more info: https://www.markdownguide.org/basic-syntax#headings
 
 <span id="short" class="d-none">
+
 ```markdown
 ### Heading level 3
 ...

--- a/docs/userGuide/syntax/horizontalrules.mbdf
+++ b/docs/userGuide/syntax/horizontalrules.mbdf
@@ -12,6 +12,7 @@ ______________
 </include>
 
 <span id="short" class="d-none">
+
 ```markdown
 *****
 -----

--- a/docs/userGuide/syntax/images.mbdf
+++ b/docs/userGuide/syntax/images.mbdf
@@ -13,6 +13,7 @@
 
 
 <span id="short" class="d-none">
+
 ```markdown
 ![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
 ```

--- a/docs/userGuide/syntax/textStyles.mbdf
+++ b/docs/userGuide/syntax/textStyles.mbdf
@@ -34,6 +34,7 @@ Syntax added by MarkBind:
 <small>Alternative syntax: https://www.markdownguide.org/basic-syntax#emphasis</small>
 
 <span id="short" class="d-none">
+
 ```markdown
 **Bold**, _Italic_, ___Bold and Italic___, `Inline Code`
 ~~Strike through~~, ****Super Bold****, ++Underline++, ==Highlight==, %%Dim%%, Super^script^, Sub~script~

--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -316,11 +316,9 @@
               resolved or clarified as necessary.</p>
           </div>
           <p><strong>Include segment</strong></p>
-          <div>
-            <p>Requirements gathering, requirements elicitation, requirements analysis,
-              requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-              of understanding what a software product should do.</p>
-          </div>
+          <div>Requirements gathering, requirements elicitation, requirements analysis,
+            requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+            of understanding what a software product should do.</div>
           <p><strong>Boilerplate include</strong></p>
           <div name="Boilerplate Referencing">
             <panel src="/test_site/requirements/UserStories._include_.html" no-close><template slot="header">
@@ -406,7 +404,8 @@
               <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
             </div>
           </div>
-          <div> <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
+          <div>
+            <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png">
             <pic src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></pic>
           </div>
           <p><strong>Include nested sub-site directly</strong></p>
@@ -439,23 +438,19 @@
             </div>
           </box>
           <p><strong>Include a file using baseUrl</strong>
-          <div>
-            <p>As we establish requirements, they should be recorded in some way for future reference,
-              usually called a requirement specification. Furthermore, it is advisable to show these requirements to stakeholders,
-              and refine requirements based on their feedback. The next phase is to convert requirements into a product
-              specification that specifies how the product will address the requirements.</p>
-          </div>
+          <div>As we establish requirements, they should be recorded in some way for future reference,
+            usually called a requirement specification. Furthermore, it is advisable to show these requirements to stakeholders,
+            and refine requirements based on their feedback. The next phase is to convert requirements into a product
+            specification that specifies how the product will address the requirements. </div>
           <panel src="/test_site/requirements/SpecifyingRequirements._include_.html#preview" type="minimal" fragment="preview"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
           <p><strong>Include a file in a sub-folder that uses baseUrl</strong>
           <div>
-            <div>
-              <p>Requirements gathering, requirements elicitation, requirements analysis,
-                requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-                of understanding what a software product should do.</p>
-            </div>
+            <div>Requirements gathering, requirements elicitation, requirements analysis,
+              requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+              of understanding what a software product should do.</div>
           </div>
           <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
@@ -463,11 +458,9 @@
           </p>
           <p><strong>Include a file in a sub-folder that uses baseUrl using baseUrl</strong>
           <div>
-            <div>
-              <p>Requirements gathering, requirements elicitation, requirements analysis,
-                requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-                of understanding what a software product should do.</p>
-            </div>
+            <div>Requirements gathering, requirements elicitation, requirements analysis,
+              requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+              of understanding what a software product should do.</div>
           </div>
           <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
@@ -475,7 +468,8 @@
           </p>
           <p><strong>Include a file in a sub-site that uses baseUrl</strong>
           <div>
-            <div><img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+            <div>
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
           <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
@@ -483,14 +477,16 @@
           </p>
           <p><strong>Include a file in a sub-site that uses baseUrl using baseUrl</strong>
           <div>
-            <div><img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+            <div>
+              <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
           <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
           <p><strong>Trimmed include</strong></p>
-          <p><strong><span>Fragment with leading spaces and newline</span></strong></p>
+          <p><strong><span><br>
+                Fragment with leading spaces and newline</span></strong></p>
           <p><strong>Trimmed include fragment</strong></p>
           <p><strong>Before | <span>Fragment with leading spaces and newline</span> | After</strong></p>
           <p><strong>Include with custom variables</strong></p>

--- a/packages/cli/test/functional/test_site/expected/requirements/testBaseUrlInIncludeSrc._include_.html
+++ b/packages/cli/test/functional/test_site/expected/requirements/testBaseUrlInIncludeSrc._include_.html
@@ -1,5 +1,3 @@
-<div>
-  <p>Requirements gathering, requirements elicitation, requirements analysis,
-    requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-    of understanding what a software product should do.</p>
-</div>
+<div>Requirements gathering, requirements elicitation, requirements analysis,
+  requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+  of understanding what a software product should do.</div>

--- a/packages/cli/test/functional/test_site/expected/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html
@@ -1,1 +1,2 @@
-<div><img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
+<div>
+  <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>

--- a/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
@@ -181,20 +181,16 @@
         <p><strong>Multiple inclusions of a modal should be supported</strong></p>
         <div>
           <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template slot="modal-title">Establishing Requirements</template>
-            <div>
-              <p>Requirements gathering, requirements elicitation, requirements analysis,
-                requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-                of understanding what a software product should do.</p>
-            </div>
+            <div>Requirements gathering, requirements elicitation, requirements analysis,
+              requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+              of understanding what a software product should do.</div>
           </b-modal>
         </div>
         <div>
           <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template slot="modal-title">Establishing Requirements</template>
-            <div>
-              <p>Requirements gathering, requirements elicitation, requirements analysis,
-                requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
-                of understanding what a software product should do.</p>
-            </div>
+            <div>Requirements gathering, requirements elicitation, requirements analysis,
+              requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
+              of understanding what a software product should do.</div>
           </b-modal>
         </div>
         <i class="fa fa-arrow-circle-up fa-lg" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i>

--- a/packages/core/src/html/includePanelProcessor.js
+++ b/packages/core/src/html/includePanelProcessor.js
@@ -202,10 +202,15 @@ function processInclude(node, context, pageSources, variableProcessor, renderMd,
     childContext,
   } = variableProcessor.renderIncludeFile(actualFilePath, pageSources, node, context, filePath);
 
+  let actualContent = nunjucksProcessed;
+  if (utils.isMarkdownFileExt(utils.getExt(actualFilePath))) {
+    actualContent = isInline
+      ? renderMdInline(actualContent)
+      : renderMd(actualContent);
+  }
+
   // Process sources with or without hash, retrieving and appending
   // the appropriate children to a wrapped include element
-
-  let actualContent = nunjucksProcessed;
   if (hash) {
     const $ = cheerio.load(actualContent);
     actualContent = $(hash).html();
@@ -225,12 +230,6 @@ function processInclude(node, context, pageSources, variableProcessor, renderMd,
 
   if (isTrim) {
     actualContent = actualContent.trim();
-  }
-
-  if (utils.isMarkdownFileExt(utils.getExt(actualFilePath))) {
-    actualContent = isInline
-      ? renderMdInline(actualContent)
-      : renderMd(actualContent);
   }
 
   const $includeEl = cheerio(node);


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Follow up to #1403, fixing one more instance where html is processed before markdown

Also fixes not being able to `<include src="xx#hash" />` is `#hash` was defined using markdown-it-attributes (e.g. `**segment**{id="hash"}`)

**Overview of changes:**
For `<include>`s with hashes, shift the markdown rendering from post-hash-search to pre-hash-search.

**Anything you'd like to highlight / discuss:**
- Some corrections had to be made to non commonmark compliant markdown in the docs with this change
- Some `<p>` elements are unwrapped in the expected test sites; These occur because we are now retrieving the hash-content post-markdown-rendering of the included source file

**Testing instructions:**
na

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
