### PR TITLE
Whitelist <markdown> and <md> as special tags

### DIFF
--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -180,6 +180,22 @@
       <div id="content-wrapper" class="fixed-header-padding">
 
         <div class="website-content">
+          <p><strong>Test <code class="hljs inline no-lang" v-pre>&lt;markdown&gt;</code> and <code class="hljs inline no-lang" v-pre>&lt;md&gt;</code> elements</strong></p>
+          <div>
+            <p>This should be wrapped in a <code class="hljs inline no-lang" v-pre>&lt;p&gt;</code> tag as it uses the block-level markdown renderer</p>
+          </div>
+          <span>This should not be wrapped in a <code class="hljs inline no-lang" v-pre>&lt;p&gt;</code> tag as it uses the inline markdown renderer</span>
+          <div class="mt-2">
+            <pre><code class="hljs" v-pre><span>&lt;markdown&gt; elements allow block-level markdown without needing a leading newline.
+</span><span>Hence, this html should be parsed and output as is, without any parsing errors.
+</span><span>&lt;/invalidhtml&gt;
+</span></code></pre>
+          </div>
+          <span>
+            <code class="hljs inline no-lang" v-pre>&lt;md&gt;</code> elements allow block-level markdown without needing a leading newline.
+            Hence, this html should be parsed and output as is, without any parsing errors.
+            <code class="hljs inline no-lang" v-pre>&lt;/invalid&gt;</code>.
+          </span>
           <p><strong>Test footnotes</strong></p>
           <div>
             <p><strong>Normal footnotes:</strong>

--- a/packages/cli/test/functional/test_site/index.md
+++ b/packages/cli/test/functional/test_site/index.md
@@ -10,6 +10,27 @@ tags: ["tag-frontmatter-shown", "tag-included-file", "+tag-exp*", "-tag-exp-hidd
 
 <div class="website-content">
 
+**Test `<markdown>` and `<md>` elements**
+
+<markdown>This should be wrapped in a `<p>` tag as it uses the block-level markdown renderer</markdown>
+
+<md>This should not be wrapped in a `<p>` tag as it uses the inline markdown renderer</md>
+
+<markdown class="mt-2">
+```
+<markdown> elements allow block-level markdown without needing a leading newline.
+Hence, this html should be parsed and output as is, without any parsing errors.
+</invalidhtml>
+```
+</markdown>
+
+<md>
+`<md>` elements allow block-level markdown without needing a leading newline.
+Hence, this html should be parsed and output as is, without any parsing errors.
+`</invalid>`.
+</md>
+
+
 **Test footnotes**
 
 <include src="testFootnotes.md" />

--- a/packages/core/src/lib/markdown-it/markdown-it-escape-special-tags.js
+++ b/packages/core/src/lib/markdown-it/markdown-it-escape-special-tags.js
@@ -10,7 +10,7 @@ function escape_plugin(md, tagsToIgnore) {
   const HTML_OPEN_CLOSE_TAG_RE = require('markdown-it/lib/common/html_re').HTML_OPEN_CLOSE_TAG_RE;
 
   const specialTagsRegex = Array.from(tagsToIgnore)
-    .concat(['script|pre|style|variable|site-nav'])
+    .concat(['script|pre|style|variable|site-nav|markdown|md'])
     .join('|');
 
   // attr_name, unquoted ... attribute patterns adapted from markdown-it/lib/common/html_re

--- a/packages/core/src/patches/htmlparser2.js
+++ b/packages/core/src/patches/htmlparser2.js
@@ -142,6 +142,8 @@ const DEFAULT_SPECIAL_TAGS = [
 	'script',
 	'style',
 	'variable',
+	'markdown',
+	'md',
 ];
 
 function whitespace(c) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Final (hopefully) follow up to #1403 in preparation for markdown-htmlparser patch removal

**Overview of changes:**
- Whitelist said tags as special tags, hence htmlparser parses its content as text for rendering later, allowing fancy markdown syntax inside
- Add 'invalid html tests'
   - these are first tested with the htmlparser-markdown patch removed with expected failure, then the tags are whitelisted and retested. the htmlparser patch is also reintroduced, for removal in another pr

**Anything you'd like to highlight / discuss:**
na

**Testing instructions:**
na

**Proposed commit message: (wrap lines at 72 characters)**
Whitelist <markdown> and <md> as special tags

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
