### PR TITLE
UG: Remove Markdown styling on plaintext codeblocks

### DIFF
--- a/docs/userGuide/syntax/blockquotes.mbdf
+++ b/docs/userGuide/syntax/blockquotes.mbdf
@@ -32,7 +32,7 @@ Nested blockquote
 
 <span id="short" class="d-none">
 
-```markdown
+```
 > Blockquote, first paragraph
 >
 > Second paragraph

--- a/docs/userGuide/syntax/blockquotes.mbdf
+++ b/docs/userGuide/syntax/blockquotes.mbdf
@@ -1,7 +1,6 @@
 ## Blockquotes
 
 <include src="codeAndOutput.md" boilerplate >
-<variable name="highlightStyle">markdown</variable>
 <variable name="code">
 Normal text
 > Blockquote, first paragraph


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [x] Bug fix

Resolves #670 

**Overview of changes:**
- Removed `markdown` syntax-highlight specification on some codeblocks that should actually be plaintext, in order not to be stylised unexpectedly (e.g. italics). 

**Anything you'd like to highlight / discuss:**
- I haven't seen any other codeblocks in the syntax UG that needs to be made plain text as well, but if I missed anything please let me know!

**Testing instructions:**

**Proposed commit message: (wrap lines at 72 characters)**
UG: Remove Markdown styling on plaintext codeblocks

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
