### PR TITLE
Fix include panel processor tests

### DIFF
--- a/packages/core/test/unit/html/includePanelProcessor.test.js
+++ b/packages/core/test/unit/html/includePanelProcessor.test.js
@@ -8,7 +8,6 @@ afterEach(() => fs.vol.reset());
 
 test('includeFile replaces <include> with <div>', async () => {
   const indexPath = path.resolve('index.md');
-  const includePath = path.resolve('include.md');
 
   const index = [
     '# Index',
@@ -28,13 +27,8 @@ test('includeFile replaces <include> with <div>', async () => {
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div>'
-    + `<div data-included-from="${includePath}">`,
-    '',
-    '# Include',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div><h1 id="include"><span id="include" class="anchor"></span>Include</h1></div>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -62,13 +56,8 @@ test('includeFile replaces <include src="exist.md" optional> with <div>', async 
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div>'
-    + '<div>',
-    '',
-    '# Exist',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div><h1 id="exist"><span id="exist" class="anchor"></span>Exist</h1></div>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -93,9 +82,8 @@ test('includeFile replaces <include src="doesNotExist.md" optional> with empty <
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<include src="/doesNotExist.md" optional></include>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -126,13 +114,8 @@ test('includeFile replaces <include src="include.md#exists"> with <div>', async 
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div>'
-    + '<div>',
-    '',
-    'existing segment',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div>existing segment</div>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -163,10 +146,8 @@ test('includeFile replaces <include src="include.md#exists" inline> with inline 
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<span>'
-    + '<span>existing segment</span></span>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<span>existing segment</span>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -197,13 +178,8 @@ test('includeFile replaces <include src="include.md#exists" trim> with trimmed c
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div>'
-    + '<div>',
-    '',
-    'existing segment',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div>existing segment</div>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -221,7 +197,7 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
 
   const include = ['# Include'].join('\n');
 
-  const expectedErrorMessage = `No such segment 'doesNotExist' in file: ${includePath}`
+  const expectedErrorMessage = `No such segment '#doesNotExist' in file: ${includePath}`
     + `\nMissing reference in ${indexPath}`;
 
   const json = {
@@ -235,9 +211,8 @@ test('includeFile replaces <include src="include.md#doesNotExist"> with error <d
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    `<div style="color: red">${expectedErrorMessage}</div>`,
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    `<div style="color: red"><div style="color: red">${expectedErrorMessage}</div></div>`,
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -268,13 +243,8 @@ test('includeFile replaces <include src="include.md#exists" optional> with <div>
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    '<div>'
-    + '<div>',
-    '',
-    'existing segment',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div>existing segment</div>',
   ].join('\n');
 
   expect(result).toEqual(expected);
@@ -282,7 +252,6 @@ test('includeFile replaces <include src="include.md#exists" optional> with <div>
 
 test('includeFile replaces <include src="include.md#doesNotExist" optional> with empty <div>', async () => {
   const indexPath = path.resolve('index.md');
-  const includePath = path.resolve('include.md');
 
   const index = [
     '# Index',
@@ -303,13 +272,8 @@ test('includeFile replaces <include src="include.md#doesNotExist" optional> with
   const result = await nodeProcessor.process(indexPath, index);
 
   const expected = [
-    '# Index',
-    `<div cwf="${indexPath}">`
-    + `<div data-included-from="${includePath}" cwf="${includePath}">`,
-    '',
-    '',
-    '</div></div>',
-    '',
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div></div>',
   ].join('\n');
 
   expect(result).toEqual(expected);

--- a/packages/core/test/unit/utils/utils.js
+++ b/packages/core/test/unit/utils/utils.js
@@ -39,6 +39,7 @@ function getNewNodeProcessor(pluginManager) {
     headerIdMap: {},
     ignore: [],
     addressablePagesSource: [],
+    intrasiteLinkValidation: { enabled: false },
   };
 
   return new NodeProcessor(fileConfig, new PageSources(),


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Code maintenance

Found while doing #720. Turns out the test suite for `<include />` didn't get detected by Jest, and after that was resolved, most of the tests were failing due to the diffs in how the processed include is represented.

**Overview of changes:**
- Renamed `includePanelProcessorTest.js` to `includePanelProcessor.test.js`
- Added `intrasiteLinkValidation.enable` property in `getNewNodeProcessor` in order for the tests to run
- Fixed expected HTML of tests in the `<include />` tests.

**Anything you'd like to highlight / discuss:**
- Figuring out the expected HTML reveals quite some quirks of the include processing. Like on line 215 there are supposedly two identically styled `<div>`s back to back. Unless I'm mistaken this might probably be redundant. Though it's very minor, but maybe we'll get back around to trimming these sometime for conciseness or even for (minor) optimization should the need for reparsing (e.g. `cheerio.load`) arises.

**Testing instructions:**

**Proposed commit message: (wrap lines at 72 characters)**
Fix include panel processor tests

---

**Checklist:** :ballot_box_with_check:

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
