### PR TITLE
Remove MarkBind.afterSetup hook

### DIFF
--- a/packages/cli/test/functional/test_site/expected/bugs/index.html
+++ b/packages/cli/test/functional/test_site/expected/bugs/index.html
@@ -227,8 +227,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -792,8 +792,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/index.html
@@ -234,8 +234,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
@@ -226,8 +226,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
@@ -293,8 +293,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -266,8 +266,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
+++ b/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
@@ -324,8 +324,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testDates.html
+++ b/packages/cli/test/functional/test_site/expected/testDates.html
@@ -230,8 +230,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testExternalScripts.html
+++ b/packages/cli/test/functional/test_site/expected/testExternalScripts.html
@@ -235,8 +235,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
@@ -235,8 +235,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
@@ -227,8 +227,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testLayouts.html
+++ b/packages/cli/test/functional/test_site/expected/testLayouts.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
@@ -231,8 +231,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testPlantUML.html
+++ b/packages/cli/test/functional/test_site/expected/testPlantUML.html
@@ -232,8 +232,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
+++ b/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
@@ -226,8 +226,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testThumbnails.html
+++ b/packages/cli/test/functional/test_site/expected/testThumbnails.html
@@ -321,8 +321,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
+++ b/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
@@ -229,8 +229,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
+++ b/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
@@ -221,8 +221,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site/expected/test_md_fragment.html
+++ b/packages/cli/test/functional/test_site/expected/test_md_fragment.html
@@ -222,8 +222,5 @@
 
   gtag('config', 'TRACKING-ID');
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -141,19 +141,13 @@
 </script>
 <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script>
-  function initAlgolia() {
-    docsearch({
-      apiKey: "25626fae796133dc1e734c6bcaaeac3c",
-      indexName: "docsearch",
-      inputSelector: "#algolia-search-input",
-      algoliaOptions: {},
-      debug: false,
-    });
-  }
-  MarkBind.afterSetup(initAlgolia);
-</script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
+  docsearch({
+    apiKey: "25626fae796133dc1e734c6bcaaeac3c",
+    indexName: "docsearch",
+    inputSelector: "#algolia-search-input",
+    algoliaOptions: {},
+    debug: false,
+  });
 </script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/Home.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Home.html
@@ -75,8 +75,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/Page-1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Page-1.html
@@ -75,8 +75,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/_Footer.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Footer.html
@@ -75,8 +75,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
@@ -78,8 +78,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/about.html
+++ b/packages/cli/test/functional/test_site_convert/expected/about.html
@@ -76,8 +76,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
@@ -80,8 +80,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
@@ -78,8 +78,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
@@ -78,8 +78,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
@@ -78,8 +78,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_convert/expected/index.html
+++ b/packages/cli/test/functional/test_site_convert/expected/index.html
@@ -75,8 +75,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_special_tags/expected/index.html
+++ b/packages/cli/test/functional/test_site_special_tags/expected/index.html
@@ -111,8 +111,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -109,8 +109,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -107,8 +107,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -107,8 +107,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -107,8 +107,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -258,8 +258,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/cli/test/functional/test_site_templates/test_minimal/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_minimal/expected/index.html
@@ -41,8 +41,5 @@
 <script>
   MarkBind.setupWithSearch()
 </script>
-<script>
-  if (MarkBind.AfterSetup) MarkBind.AfterSetup()
-</script>
 
 </html>

--- a/packages/core/src/Page/page.njk
+++ b/packages/core/src/Page/page.njk
@@ -61,6 +61,4 @@
     {{ scripts }}
 {%- endfor %}
 {%- endif %}
-{#- todo deprecate MarkBind.AfterSetup() fully (#1306) -#}
-<script>if (MarkBind.AfterSetup) MarkBind.AfterSetup()</script>
 </html>

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -8,16 +8,13 @@ const {
 
 function buildAlgoliaInitScript(pluginContext) {
   return `<script>
-    function initAlgolia() {
-      docsearch({
-        apiKey: "${pluginContext.apiKey}",
-        indexName: "${pluginContext.indexName}",
-        inputSelector: "${ALGOLIA_INPUT_SELECTOR}",
-        algoliaOptions: ${JSON.stringify(pluginContext.algoliaOptions || {})},
-        debug: ${pluginContext.debug || false},
-      });
-    }
-    MarkBind.afterSetup(initAlgolia);
+    docsearch({
+      apiKey: "${pluginContext.apiKey}",
+      indexName: "${pluginContext.indexName}",
+      inputSelector: "${ALGOLIA_INPUT_SELECTOR}",
+      algoliaOptions: ${JSON.stringify(pluginContext.algoliaOptions || {})},
+      debug: ${pluginContext.debug || false},
+    });
   </script>`;
 }
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

Deprecated on the user side in #1306 
Original issue / pr pair: #577, #593
Made unnecessary by #621

**Overview of changes:**
- Removed `markbind.afterSetup` implementation and internal usage (algolia plugin)

**Anything you'd like to highlight / discuss:**
This was necessary as described in #577 as vue setup was performed after fetching search data before. This was changed in #621.

**Testing instructions:**
- Added `<searchbar placeholder="Search" algolia menu-align-right></searchbar>` to `test_site_algolia_plugin`
- Verified it still works internally

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Remove MarkBind.afterSetup hook

The afterSetup MarkBind hook was introduced to allow user scripts and
plugin scripts to deterministically execute post Vue setup, which may
not happen synchronously, as search data was fetched before doing so.

With search data retrieval moved to post Vue setup, this is no longer
necessary.

Let's remove the hook as such.

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
