### PR TITLE
Support deploying via Github Actions using deploy --ci command

### DIFF
--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -90,6 +90,11 @@ jobs:
       - run: markbind deploy --ci
 ```
 
+<box type="info">
+
+The sample `deploy.yml` workflow above uses the [default Github Token secret](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) that is generated automatically for each Github Actions workflow. You may also use a Github Personal Access Token in place of the default Github Token. For steps on setting up your Github Personal Access Token, you may refer to the [setup instructions for Travis CI](#configuring-your-repository-in-travis-ci). 
+</box>
+
 Once you have created the file, commit and push the file to your repo. Github Actions should start to build and deploy your markbind site. You can verify this by visiting `www.github.com/<org|username>/<repo>/actions`. 
 
 For more information on customizing your workflow file to fit your specific needs, you may refer to the [Github Action Docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -65,11 +65,36 @@ You can override the default deployment settings %%(e.g., repo/branch to deploy)
 ### Deploying to GitHub Pages via CI Tools
 **You can setup CI Tools to automatically build and deploy your site on GitHub Pages every time your GitHub repo is updated.**
 
-<box type="important" light>
+<panel header="#### Deploying via Github Actions" type="seamless" expanded>
 
-Markbind currently supports deploying to Github Pages via [Travis CI](https://www.travis-ci.com/) or [AppVeyor CI](https://www.appveyor.com/).
-</box>
+To instruct [Github Actions](https://docs.github.com/en/actions) to build and deploy the site when you push to the repository, add a Github Actions workflow file in your project repo at the location `<PROJECT_ROOT>/.github/workflows/deploy.yml`  A sample workflow file is provided below:
+```
+name: Deploy Markbind Site
+on:
+  push:
+    branches: master
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: test
+    env:
+      GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10'
+      - run: npm i -g markbind-cli
+      - run: markbuild build
+      - run: markbind deploy --ci
+```
+
+Once you have created the file, commit and push the file to your repo. Github Actions should start to build and deploy your markbind site. You can verify this by visiting `www.github.com/<org|username>/<repo>/actions`. 
+
+For more information on customizing your workflow file to fit your specific needs, you may refer to the [Github Action Docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+
+</panel>
 
 <panel header="#### Deploying via Travis CI" type="seamless" expanded>
 

--- a/docs/userGuide/deployingTheSite.md
+++ b/docs/userGuide/deployingTheSite.md
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: '10'
       - run: npm i -g markbind-cli
-      - run: markbuild build
+      - run: markbind build
       - run: markbind deploy --ci
 ```
 

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1174,6 +1174,17 @@ class Site {
           name: 'AppVeyorBot',
           email: 'deploy@appveyor.com',
         };
+      } else if (process.env.GITHUB_ACTIONS) {
+        if (options.repo) {
+          repoSlug = Site.extractRepoSlug(options.repo);
+        } else {
+          repoSlug = process.env.GITHUB_REPOSITORY;
+        }
+
+        options.user = {
+          name: 'Github',
+          email: 'noreply@github.com',
+        };
       } else {
         throw new Error('-c/--ci should only be run in CI environments.');
       }

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1182,8 +1182,8 @@ class Site {
         }
 
         options.user = {
-          name: 'Github',
-          email: 'noreply@github.com',
+          name: 'github-actions',
+          email: 'github-actions@github.com',
         };
       } else {
         throw new Error('-c/--ci should only be run in CI environments.');

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1189,7 +1189,7 @@ class Site {
         throw new Error('-c/--ci should only be run in CI environments.');
       }
 
-      options.repo = `https://${githubToken}@github.com/${repoSlug}.git`;
+      options.repo = `https://x-access-token:${githubToken}@github.com/${repoSlug}.git`;
     }
 
     publish(basePath, options);

--- a/packages/core/test/unit/Site.test.js
+++ b/packages/core/test/unit/Site.test.js
@@ -282,11 +282,13 @@ describe('Site deploy with various CI environments', () => {
 
   beforeEach(() => {
     // Delete all environment variables that affect tests
-    delete process.env.TRAVIS;
     delete process.env.GITHUB_TOKEN;
+    delete process.env.TRAVIS;
     delete process.env.TRAVIS_REPO_SLUG;
     delete process.env.APPVEYOR;
     delete process.env.APPVEYOR_REPO_NAME;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_REPOSITORY;
   });
 
   afterAll(() => {
@@ -297,6 +299,7 @@ describe('Site deploy with various CI environments', () => {
   test.each([
     ['TRAVIS', 'TRAVIS_REPO_SLUG', { name: 'Deployment Bot', email: 'deploy@travis-ci.org' }],
     ['APPVEYOR', 'APPVEYOR_REPO_NAME', { name: 'AppVeyorBot', email: 'deploy@appveyor.com' }],
+    ['GITHUB_ACTIONS', 'GITHUB_REPOSITORY', { name: 'github-actions', email: 'github-actions@github.com' }],
   ])('Site deploy -c/--ci deploys with default settings',
      async (ciIdentifier, repoSlugIdentifier, deployBotUser) => {
        process.env[ciIdentifier] = true;
@@ -319,6 +322,7 @@ describe('Site deploy with various CI environments', () => {
   test.each([
     ['TRAVIS', 'TRAVIS_REPO_SLUG'],
     ['APPVEYOR', 'APPVEYOR_REPO_NAME'],
+    ['GITHUB_ACTIONS', 'GITHUB_REPOSITORY'],
   ])('Site deploy -c/--ci deploys with custom GitHub repo',
      async (ciIdentifier, repoSlugIdentifier) => {
        process.env[ciIdentifier] = true;
@@ -342,6 +346,7 @@ describe('Site deploy with various CI environments', () => {
   test.each([
     ['TRAVIS', 'TRAVIS_REPO_SLUG'],
     ['APPVEYOR', 'APPVEYOR_REPO_NAME'],
+    ['GITHUB_ACTIONS', 'GITHUB_REPOSITORY'],
   ])('Site deploy -c/--ci deploys to correct repo when .git is in repo name',
      async (ciIdentifier, repoSlugIdentifier) => {
        process.env[ciIdentifier] = true;
@@ -378,6 +383,7 @@ describe('Site deploy with various CI environments', () => {
   test.each([
     ['TRAVIS'],
     ['APPVEYOR'],
+    ['GITHUB_ACTIONS'],
   ])('Site deploy -c/--ci should not deploy without authentication token', async (ciIdentifier) => {
     process.env[ciIdentifier] = true;
 
@@ -396,6 +402,7 @@ describe('Site deploy with various CI environments', () => {
   test.each([
     ['TRAVIS'],
     ['APPVEYOR'],
+    ['GITHUB_ACTIONS'],
   ])('Site deploy -c/--ci should not deploy if custom repository is not on GitHub', async (ciIdentifier) => {
     process.env[ciIdentifier] = true;
     process.env.GITHUB_TOKEN = 'githubToken';

--- a/packages/core/test/unit/Site.test.js
+++ b/packages/core/test/unit/Site.test.js
@@ -315,7 +315,8 @@ describe('Site deploy with various CI environments', () => {
        const site = new Site('./', '_site');
        await site.deploy(true);
        expect(ghpages.options.repo)
-         .toEqual(`https://${process.env.GITHUB_TOKEN}@github.com/${process.env[repoSlugIdentifier]}.git`);
+         // eslint-disable-next-line max-len
+         .toEqual(`https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/${process.env[repoSlugIdentifier]}.git`);
        expect(ghpages.options.user).toEqual(deployBotUser);
      });
 
@@ -340,7 +341,7 @@ describe('Site deploy with various CI environments', () => {
        const site = new Site('./', '_site');
        await site.deploy(true);
        expect(ghpages.options.repo)
-         .toEqual(`https://${process.env.GITHUB_TOKEN}@github.com/USER/REPO.git`);
+         .toEqual(`https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/USER/REPO.git`);
      });
 
   test.each([
@@ -362,7 +363,8 @@ describe('Site deploy with various CI environments', () => {
        const site = new Site('./', '_site');
        await site.deploy(true);
        expect(ghpages.options.repo)
-         .toEqual(`https://${process.env.GITHUB_TOKEN}@github.com/${process.env[repoSlugIdentifier]}.git`);
+         // eslint-disable-next-line max-len
+         .toEqual(`https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/${process.env[repoSlugIdentifier]}.git`);
      });
 
   test('Site deploy -c/--ci should not deploy if not in CI environment', async () => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Related to #1432 
<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Add logic for detecting Github Action CI environment as well as Repo Slug using environmental variables (`process.env.GITHUB_ACTIONS` and `process.env.GITHUB_REPOSITORY` respectively). 

**Anything you'd like to highlight / discuss:**
- Similar to deploying via Travis / Appveyor, the user has to generate a github personal access token with **repo** permissions and add a custom environmental variable. For Travis/Appveyor, the default name for such token in the userGuide is `GITHUB_TOKEN`. However, github [does not allow custom environmental variables with the `GITHUB_` prefix](https://docs.github.com/en/actions/reference/environment-variables#naming-conventions-for-environment-variables). Would it be better, for consistency, to update the default name for the token to just `TOKEN`? Or would it be better to create a special naming instruction for deploying via github actions?

**Testing instructions:**
Add to `.github/workflows/deploy.yml`:
```
name: Deploy
on:
  push:
    branches: master

jobs:
  build:
    runs-on: ubuntu-latest
    name: test
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-node@v2
        with:
          node-version: '10'
      - run: cd ../ && git clone -b fix-1432-gh-action-2 https://github.com/raysonkoh/markbind.git
      - run: cd ../markbind/packages/cli && npm link
      - run: cd ../markbind && npm run setup
      - run: markbind build
      - run: markbind deploy --ci
```
For regression testing:
**Appveyor**: Add to `appveyor.yml`
```
environment:
  nodejs_version: '10'

branches:
  only:
    - master

install:
  - ps: Install-Product node $env:nodejs_version
  - cd ../
  - git clone -b fix-1432-gh-action-2 https://github.com/raysonkoh/markbind.git
  - cd markbind/packages/cli 
  - npm link 
  - cd ../../ 
  - npm run setup 
  - cd %APPVEYOR_BUILD_FOLDER%
  - markbind build
  - markbind deploy --ci

test: off

build: off
```
**Travis CI**: Add to `.travis.yml`
```
language: node_js
node_js:
  - 10
install:
  - cd ../ 
  - git clone -b fix-1432-gh-action-2 https://github.com/raysonkoh/markbind.git 
  - cd markbind/packages/cli 
  - npm link 
  - cd ../../ 
  - npm run setup 
  - cd $TRAVIS_BUILD_DIR
script: markbind build
deploy:
  provider: script
  script: markbind deploy --ci
  skip_cleanup: true
  on:
    branch: master
```

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Support deploying via Github Actions using deploy --ci command

A Github Personal Access Token must be supplied as a
custom environmental variable in order to successfully deploy the
site via Travis CI and Appveyor.

For Github Actions, a default Github Token is
automatically generated for each Github Action job. The default Github
Token has sufficient write permissions to the repo, and so it
can be used in place of the Github Personal Access Token. To
incorporate the default Github Token, the deploy url has to use the
full url syntax of username:password. 

Let's update the deploy url to use x-access-token as the username, as
per the official Github documentation.
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
