### PR TITLE
Update deprecated Vue slot syntax

### DIFF
--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -11,7 +11,7 @@
 Most component attributes allow a richer form of formatting using slots, denoted by an attribute<strong>^\[S\]^</strong> superscript in the respective components' tables.
 In other cases, when the option is of type "Slot", only the slot option is available.
 
-You can define such a slot within the component by adding a `slot="attribute name"` attribute to any element within the slot.
+You can define such a slot within the component by adding a `slot="attribute_name"` attribute to any element within the slot.
 
 {{ icon_example }}
 
@@ -36,6 +36,21 @@ You can define such a slot within the component by adding a `slot="attribute nam
 <variable name="highlightStyle">html</variable>
 </include>
 </div>
+
+<box type="tip">
+
+You may define a slot by using the shorthand notation `#attribute_name` as well! 
+
+```html
+  <panel>
+    <div #header>
+      Look at the slot shorthand notation directly above. 
+    </div>
+    Now you know how to use the shorthand notation!
+  </panel>
+```
+</box>
+
   
 <modal header="Richer formatting of attributes using slots" id="on-slots" large>
 <include src="advanced.md#slots" />

--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -11,14 +11,14 @@
 Most component attributes allow a richer form of formatting using slots, denoted by an attribute<strong>^\[S\]^</strong> superscript in the respective components' tables.
 In other cases, when the option is of type "Slot", only the slot option is available.
 
-You can define such a slot within the component by adding a `slot="attribute_name"` attribute to any element within the slot.
+You can define such a slot within the component by adding a `#attribute_name` attribute to any element within the slot.
 
 {{ icon_example }}
 
 <include src="codeAndOutput.md" boilerplate>
 <variable name="code">
 <panel expanded>
-  <p slot="header" class="card-title">
+  <p #header class="card-title">
     <i><strong>
       <span style="color:#FF0000;">R</span>
       <span style="color:#FF7F00;">A</span>
@@ -37,16 +37,16 @@ You can define such a slot within the component by adding a `slot="attribute_nam
 </include>
 </div>
 
-<box type="tip">
+<box type="info">
 
-You may define a slot by using the shorthand notation `#attribute_name` as well! 
+You may define a slot by using `slot="attribute_name"` as well. 
+However, we **++do not recommend++** using this syntax as it is deprecated and will be removed in the future. 
 
 ```html
   <panel>
-    <div #header>
-      Look at the slot shorthand notation directly above. 
+    <div slot="header">
+      Look at the slot syntax directly above. 
     </div>
-    Now you know how to use the shorthand notation!
   </panel>
 ```
 </box>

--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -11,7 +11,7 @@
 Most component attributes allow a richer form of formatting using slots, denoted by an attribute<strong>^\[S\]^</strong> superscript in the respective components' tables.
 In other cases, when the option is of type "Slot", only the slot option is available.
 
-You can define such a slot within the component by adding a `#attribute_name` attribute to any element within the slot.
+You can define such a slot within the component by adding a `#slot_name` attribute to any element within the slot.
 
 {{ icon_example }}
 

--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -39,7 +39,7 @@ You can define such a slot within the component by adding a `#attribute_name` at
 
 <box type="info">
 
-You may define a slot by using `slot="attribute_name"` as well. 
+You may define a slot by using `slot="slot_name"` as well. 
 However, we **++do not recommend++** using this syntax as it is deprecated and will be removed in the future. 
 
 ```html

--- a/packages/cli/test/functional/test_site/expected/bugs/index.html
+++ b/packages/cli/test/functional/test_site/expected/bugs/index.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">
@@ -231,17 +231,17 @@
           <p><span class="keyword">keyword 1</span>
             <span class="keyword">keyword 2</span></p>
           <h1 id="heading-with-keyword-in-panel"><span id="heading-with-keyword-in-panel" class="anchor"></span>Heading with keyword in panel<a class="fa fa-anchor" href="#heading-with-keyword-in-panel" onclick="event.stopPropagation()"></a></h1>
-          <panel expanded><template slot="header">
+          <panel expanded><template #header>
               <p>Panel with keyword</p>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Panel with heading with keyword</strong></p>
-          <panel expanded id="panel-with-heading"><template slot="header">
+          <panel expanded id="panel-with-heading"><template #header>
               <h1 id="panel-with-heading"><span id="panel-with-heading" class="anchor"></span>Panel with heading<a class="fa fa-anchor" href="#panel-with-heading" onclick="event.stopPropagation()"></a></h1>
             </template>
             <span class="keyword">panel keyword</span></panel>
           <p><strong>Expanded panel without heading with keyword</strong></p>
-          <panel expanded id="panel-without-heading-with-keyword"><template slot="header">
+          <panel expanded id="panel-without-heading-with-keyword"><template #header>
               <h1 id="panel-without-heading-with-keyword"><span id="panel-without-heading-with-keyword" class="anchor"></span>Panel without heading with keyword<a class="fa fa-anchor" href="#panel-without-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
             </template>
             <h1 id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading"><span id="keyword-should-be-tagged-to-this-heading-not-the-panel-heading" class="anchor"></span>Keyword should be tagged to this heading, not the panel heading<a class="fa fa-anchor" href="#keyword-should-be-tagged-to-this-heading-not-the-panel-heading" onclick="event.stopPropagation()"></a></h1>
@@ -249,7 +249,7 @@
           </panel>
           <p></p>
           <p><strong>Unexpanded panel with heading with keyword</strong>
-            <panel id="panel-with-heading-with-keyword"><template slot="header">
+            <panel id="panel-with-heading-with-keyword"><template #header>
                 <h1 id="panel-with-heading-with-keyword"><span id="panel-with-heading-with-keyword" class="anchor"></span>Panel with heading with keyword<a class="fa fa-anchor" href="#panel-with-heading-with-keyword" onclick="event.stopPropagation()"></a></h1>
               </template></panel>
           </p>
@@ -340,7 +340,7 @@
             of understanding what a software product should do.</div>
           <p><strong>Boilerplate include</strong></p>
           <div name="Boilerplate Referencing">
-            <panel src="/test_site/requirements/UserStories._include_.html" no-close><template slot="header">
+            <panel src="/test_site/requirements/UserStories._include_.html" no-close><template #header>
                 <p>Boilerplate Includes</p>
               </template></panel>
           </div>
@@ -349,7 +349,7 @@
             <p>Like static include, pages within the site should be able to use files located in folders within boilerplate.</p>
             <p>Also, the boilerplate file name (e.g. <code class="hljs inline no-lang" v-pre>inside.md</code>) and the file that it is supposed to act as (<code class="hljs inline no-lang" v-pre>notInside.md</code>) can be different.</p>
             <p>This file should behaves as if it is in the <code class="hljs inline no-lang" v-pre>requirements</code> folder:</p>
-            <panel src="/test_site/requirements/NonFunctionalRequirements._include_.html"><template slot="header">
+            <panel src="/test_site/requirements/NonFunctionalRequirements._include_.html"><template #header>
                 <p>Tested with the folllowing include</p>
               </template></panel>
           </div>
@@ -462,7 +462,7 @@
             usually called a requirement specification. Furthermore, it is advisable to show these requirements to stakeholders,
             and refine requirements based on their feedback. The next phase is to convert requirements into a product
             specification that specifies how the product will address the requirements. </div>
-          <panel src="/test_site/requirements/SpecifyingRequirements._include_.html#preview" type="minimal" fragment="preview"><template slot="header">
+          <panel src="/test_site/requirements/SpecifyingRequirements._include_.html#preview" type="minimal" fragment="preview"><template #header>
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
@@ -472,7 +472,7 @@
               requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
               of understanding what a software product should do.</div>
           </div>
-          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
+          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template #header>
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
@@ -482,7 +482,7 @@
               requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
               of understanding what a software product should do.</div>
           </div>
-          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template slot="header">
+          <panel src="/test_site/requirements/testBaseUrlInIncludeSrc._include_.html" type="minimal"><template #header>
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
@@ -491,7 +491,7 @@
             <div>
               <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
-          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
+          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template #header>
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
@@ -500,7 +500,7 @@
             <div>
               <img src="/test_site/sub_site/images/I'm not allowed to use my favorite tool.png"></div>
           </div>
-          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template slot="header">
+          <panel src="/test_site/sub_site/testBaseUrlInIncludeSrcSubSite._include_.html" type="minimal"><template #header>
               <p><strong>same test with panels</strong></p>
             </template></panel>
           </p>
@@ -561,7 +561,7 @@
               Heading
             </span></panel>
           <p><strong>Panel without src</strong></p>
-          <panel expanded id="panel-without-src-header"><template slot="header">
+          <panel expanded id="panel-without-src-header"><template #header>
               <h2 id="panel-without-src-header"><span id="panel-without-src-header" class="anchor"></span>Panel without src header<a class="fa fa-anchor" href="#panel-without-src-header" onclick="event.stopPropagation()"></a></h2>
             </template>
             <div>
@@ -569,40 +569,40 @@
             </div>
           </panel>
           <p><strong>Panel with normal src</strong></p>
-          <panel src="/test_site/testPanels/PanelNormalSource._include_.html" expanded id="panel-with-normal-src-header"><template slot="header">
+          <panel src="/test_site/testPanels/PanelNormalSource._include_.html" expanded id="panel-with-normal-src-header"><template #header>
               <h2 id="panel-with-normal-src-header"><span id="panel-with-normal-src-header" class="anchor"></span>Panel with normal src header<a class="fa fa-anchor" href="#panel-with-normal-src-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with src from a page segment</strong></p>
-          <panel src="/test_site/testPanels/PanelSourceContainsSegment._include_.html#segment" expanded fragment="segment" id="panel-with-src-from-a-page-segment-header"><template slot="header">
+          <panel src="/test_site/testPanels/PanelSourceContainsSegment._include_.html#segment" expanded fragment="segment" id="panel-with-src-from-a-page-segment-header"><template #header>
               <h2 id="panel-with-src-from-a-page-segment-header"><span id="panel-with-src-from-a-page-segment-header" class="anchor"></span>Panel with src from a page segment header<a class="fa fa-anchor" href="#panel-with-src-from-a-page-segment-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Panel with boilerplate</strong></p>
-          <panel src="/test_site/testPanels/boilerTestPanel._include_.html" expanded id="boilerplate-referencing"><template slot="header">
+          <panel src="/test_site/testPanels/boilerTestPanel._include_.html" expanded id="boilerplate-referencing"><template #header>
               <h2 id="boilerplate-referencing"><span id="boilerplate-referencing" class="anchor"></span>Boilerplate referencing<a class="fa fa-anchor" href="#boilerplate-referencing" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
-          <panel src="/test_site/testPanels/notInside._include_.html" expanded id="referencing-specified-path-in-boilerplate"><template slot="header">
+          <panel src="/test_site/testPanels/notInside._include_.html" expanded id="referencing-specified-path-in-boilerplate"><template #header>
               <h2 id="referencing-specified-path-in-boilerplate"><span id="referencing-specified-path-in-boilerplate" class="anchor"></span>Referencing specified path in boilerplate<a class="fa fa-anchor" href="#referencing-specified-path-in-boilerplate" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel</strong></p>
-          <panel src="/test_site/testPanels/NestedPanel._include_.html" expanded id="outer-nested-panel"><template slot="header">
+          <panel src="/test_site/testPanels/NestedPanel._include_.html" expanded id="outer-nested-panel"><template #header>
               <h2 id="outer-nested-panel"><span id="outer-nested-panel" class="anchor"></span>Outer nested panel<a class="fa fa-anchor" href="#outer-nested-panel" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
           <p><strong>Nested panel without src</strong></p>
-          <panel expanded id="outer-nested-panel-without-src"><template slot="header">
+          <panel expanded id="outer-nested-panel-without-src"><template #header>
               <h2 id="outer-nested-panel-without-src"><span id="outer-nested-panel-without-src" class="anchor"></span>Outer nested panel without src<a class="fa fa-anchor" href="#outer-nested-panel-without-src" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content of outer nested panel</strong></p>
-            <panel expanded id="inner-panel-header-without-src"><template slot="header">
+            <panel expanded id="inner-panel-header-without-src"><template #header>
                 <h2 id="inner-panel-header-without-src"><span id="inner-panel-header-without-src" class="anchor"></span>Inner panel header without src<a class="fa fa-anchor" href="#inner-panel-header-without-src" onclick="event.stopPropagation()"></a></h2>
               </template>
               <p><strong>Panel content of inner nested panel</strong></p>
             </panel>
           </panel>
           <p><strong>Panel with src from another Markbind site</strong></p>
-          <panel src="/test_site/sub_site/index._include_.html" expanded id="panel-with-src-from-another-markbind-site-header"><template slot="header">
+          <panel src="/test_site/sub_site/index._include_.html" expanded id="panel-with-src-from-another-markbind-site-header"><template #header>
               <h2 id="panel-with-src-from-another-markbind-site-header"><span id="panel-with-src-from-another-markbind-site-header" class="anchor"></span>Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
-          <panel src="/test_site/sub_site/testReuseSubsite._include_.html" expanded id="panel-with-src-from-another-markbind-site-header-2"><template slot="header">
+          <panel src="/test_site/sub_site/testReuseSubsite._include_.html" expanded id="panel-with-src-from-another-markbind-site-header-2"><template #header>
               <h2 id="panel-with-src-from-another-markbind-site-header-2"><span id="panel-with-src-from-another-markbind-site-header-2" class="anchor"></span>Panel with src from another Markbind site header<a class="fa fa-anchor" href="#panel-with-src-from-another-markbind-site-header-2" onclick="event.stopPropagation()"></a></h2>
             </template></panel>
         </div>
@@ -610,19 +610,19 @@
         <p>
           <trigger for="modal-with-panel">trigger</trigger>
         </p>
-        <b-modal id="modal-with-panel" hide-footer size modal-class="mb-zoom" ref="modal-with-panel"><template slot="modal-title">modal title with panel inside</template>
-          <panel expanded id="panel-inside-modal"><template slot="header">
+        <b-modal id="modal-with-panel" hide-footer size modal-class="mb-zoom" ref="modal-with-panel"><template #modal-title>modal title with panel inside</template>
+          <panel expanded id="panel-inside-modal"><template #header>
               <h2 id="panel-inside-modal"><span id="panel-inside-modal" class="anchor"></span>Panel inside modal<a class="fa fa-anchor" href="#panel-inside-modal" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside modal</strong></p>
           </panel>
         </b-modal>
         <p><strong>Unexpanded panel</strong></p>
-        <panel id="unexpanded-panel-header"><template slot="header">
+        <panel id="unexpanded-panel-header"><template #header>
             <h2 id="unexpanded-panel-header"><span id="unexpanded-panel-header" class="anchor"></span>Unexpanded panel header<a class="fa fa-anchor" href="#unexpanded-panel-header" onclick="event.stopPropagation()"></a></h2>
           </template>
           <p><strong>Panel content of unexpanded panel should not appear in search data</strong></p>
-          <panel expanded id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><template slot="header">
+          <panel expanded id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><template #header>
               <h2 id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data"><span id="panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" class="anchor"></span>Panel header inside unexpanded panel should not appear in search data<a class="fa fa-anchor" href="#panel-header-inside-unexpanded-panel-should-not-appear-in-search-data" onclick="event.stopPropagation()"></a></h2>
             </template>
             <p><strong>Panel content inside unexpanded panel should not appear in search data</strong></p>
@@ -675,24 +675,30 @@
         <section class="footnotes">
           <ol class="footnotes-list">
             <span id="pop:footnotefn-1-1" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger">
-              <div data-mb-slot-name="content">
-                <p>Here is the footnote. Footnotes will appear at the bottom of the page.</p>
+              <span data-mb-slot-name="content">
+                <div>
+                  <p>Here is the footnote. Footnotes will appear at the bottom of the page.</p>
 
-              </div>
+                </div>
+              </span>
             </span><span id="pop:footnotefn-1-2" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger">
-              <div data-mb-slot-name="content">
-                <p>Here's one with multiple blocks.</p>
-                <p>Subsequent paragraphs are indented to show that they
-                  belong to the previous footnote.</p>
+              <span data-mb-slot-name="content">
+                <div>
+                  <p>Here's one with multiple blocks.</p>
+                  <p>Subsequent paragraphs are indented to show that they
+                    belong to the previous footnote.</p>
 
-              </div>
+                </div>
+              </span>
             </span><span id="pop:footnotefn-1-3" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger">
-              <div data-mb-slot-name="content">
-                <p>Inlines notes are easier to write, since
-                  you don't have to pick an identifier and move down to type the
-                  note.</p>
+              <span data-mb-slot-name="content">
+                <div>
+                  <p>Inlines notes are easier to write, since
+                    you don't have to pick an identifier and move down to type the
+                    note.</p>
 
-              </div>
+                </div>
+              </span>
             </span>
 
             <li id="fn-1-1" class="footnote-item">

--- a/packages/cli/test/functional/test_site/expected/sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/index.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">
@@ -189,12 +189,12 @@
         <h4 id="should-have-anchor-4"><span id="should-have-anchor-4" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-4" onclick="event.stopPropagation()"></a></h4>
         <h5 id="should-have-anchor-5"><span id="should-have-anchor-5" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
         <h6 id="should-have-anchor-6"><span id="should-have-anchor-6" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
-        <panel id="should-have-anchor-7"><template slot="header">
+        <panel id="should-have-anchor-7"><template #header>
             <h4 id="should-have-anchor-7"><span id="should-have-anchor-7" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-7" onclick="event.stopPropagation()"></a></h4>
           </template>
           Lorem ipsum
         </panel>
-        <panel><template slot="header">
+        <panel><template #header>
             <p>Collapsed</p>
           </template>
           <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
@@ -205,7 +205,7 @@
           <h5 id="should-not-have-anchor-5"><span id="should-not-have-anchor-5" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-5" onclick="event.stopPropagation()"></a></h5>
           <h6 id="should-not-have-anchor-6"><span id="should-not-have-anchor-6" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-6" onclick="event.stopPropagation()"></a></h6>
         </panel>
-        <panel expanded><template slot="header">
+        <panel expanded><template #header>
             <p>Expanded</p>
           </template>
           <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>
@@ -226,12 +226,12 @@
           <h4 id="should-have-anchor-17"><span id="should-have-anchor-17" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-17" onclick="event.stopPropagation()"></a></h4>
           <h5 id="should-have-anchor-18"><span id="should-have-anchor-18" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-18" onclick="event.stopPropagation()"></a></h5>
           <h6 id="should-have-anchor-19"><span id="should-have-anchor-19" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-19" onclick="event.stopPropagation()"></a></h6>
-          <panel id="should-have-anchor-20"><template slot="header">
+          <panel id="should-have-anchor-20"><template #header>
               <h4 id="should-have-anchor-20"><span id="should-have-anchor-20" class="anchor"></span>should have anchor<a class="fa fa-anchor" href="#should-have-anchor-20" onclick="event.stopPropagation()"></a></h4>
             </template>
             Lorem ipsum
           </panel>
-          <panel><template slot="header">
+          <panel><template #header>
               <p>Collapsed</p>
             </template>
             <p>Headings in a collapsed-by-default panel should <strong>not</strong> have anchors</p>
@@ -242,7 +242,7 @@
             <h5 id="should-not-have-anchor-11"><span id="should-not-have-anchor-11" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-11" onclick="event.stopPropagation()"></a></h5>
             <h6 id="should-not-have-anchor-12"><span id="should-not-have-anchor-12" class="anchor"></span>should not have anchor<a class="fa fa-anchor" href="#should-not-have-anchor-12" onclick="event.stopPropagation()"></a></h6>
           </panel>
-          <panel expanded><template slot="header">
+          <panel expanded><template #header>
               <p>Expanded</p>
             </template>
             <p>Headings in a expanded-by-default panel <strong>should</strong> have anchors</p>

--- a/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -185,7 +185,7 @@
         <navbar type="dark" class=" temp-navbar">
           <li><a href="/" class="nav-link">One</a></li>
           <li><a href="/" class="nav-link">Two</a></li>
-          <dropdown class="nav-link temp-dropdown"><template slot="_header">Dropdown</template>
+          <dropdown class="nav-link temp-dropdown"><template #_header>Dropdown</template>
             <li><a class="dropdown-item" href="/">Dropdown One</a></li>
             <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
           </dropdown>
@@ -193,7 +193,7 @@
         </navbar>
 
         <p><strong>Test dropdown in body with text and class attributes</strong></p>
-        <dropdown class="test-class temp-dropdown"><template slot="_header">Test One</template>
+        <dropdown class="test-class temp-dropdown"><template #_header>Test One</template>
           <li><a class="dropdown-item" href="/">Dropdown One</a></li>
           <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
         </dropdown>
@@ -201,9 +201,9 @@
 
         <p><strong>Test dropdown in body without text and class attributes</strong></p>
         <dropdown class="temp-dropdown">
-          <button slot="button" type="button" class="btn dropdown-toggle">
-            Test Two
-            <span class="caret"></span></button>
+          <template #button><button type="button" class="btn dropdown-toggle">
+              Test Two
+              <span class="caret"></span></button></template>
           <li><a class="dropdown-item" href="/">Dropdown One</a></li>
           <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
         </dropdown>

--- a/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
+++ b/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testDates.html
+++ b/packages/cli/test/functional/test_site/expected/testDates.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -47,7 +47,7 @@
       <div>
         <header>
           <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-            <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+            <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
             <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
           </navbar>
           <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testExternalScripts.html
+++ b/packages/cli/test/functional/test_site/expected/testExternalScripts.html
@@ -47,7 +47,7 @@
       <div>
         <header>
           <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-            <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+            <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
             <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
           </navbar>
           <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">
@@ -183,14 +183,14 @@
       <div id="content-wrapper" class="fixed-header-padding">
         <p><strong>Multiple inclusions of a modal should be supported</strong></p>
         <div>
-          <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template slot="modal-title">Establishing Requirements</template>
+          <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template #modal-title>Establishing Requirements</template>
             <div>Requirements gathering, requirements elicitation, requirements analysis,
               requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
               of understanding what a software product should do.</div>
           </b-modal>
         </div>
         <div>
-          <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template slot="modal-title">Establishing Requirements</template>
+          <b-modal id="modal:bugRepro" hide-footer size="lg" modal-class="mb-zoom" ref="modal:bugRepro"><template #modal-title>Establishing Requirements</template>
             <div>Requirements gathering, requirements elicitation, requirements analysis,
               requirements capture are some of the terms commonly <strong>and</strong> interchangeably used to represent the activity
               of understanding what a software product should do.</div>

--- a/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testLayouts.html
+++ b/packages/cli/test/functional/test_site/expected/testLayouts.html
@@ -47,7 +47,7 @@
       <div>
         <header>
           <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-            <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+            <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
             <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
           </navbar>
           <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
@@ -47,7 +47,7 @@
       <div>
         <header>
           <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-            <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+            <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
             <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
           </navbar>
           <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
+++ b/packages/cli/test/functional/test_site/expected/testPanels/NestedPanel._include_.html
@@ -1,3 +1,3 @@
-<panel src="/test_site/testPanels/NormalPanelContent._include_.html" expanded id="nested-panel"><template slot="header">
+<panel src="/test_site/testPanels/NormalPanelContent._include_.html" expanded id="nested-panel"><template #header>
     <h2 id="nested-panel"><span id="nested-panel" class="anchor"></span>Nested Panel<a class="fa fa-anchor" href="#nested-panel" onclick="event.stopPropagation()"></a></h2>
   </template></panel>

--- a/packages/cli/test/functional/test_site/expected/testPlantUML.html
+++ b/packages/cli/test/functional/test_site/expected/testPlantUML.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
+++ b/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">
@@ -184,9 +184,11 @@
         <p><strong>Popover initiated by trigger should honor trigger attribute</strong></p>
         <span id="pop:xp-user-stories" trigger="click" data-mb-component-type="popover" v-b-popover.click.top.html="popoverInnerGetters" class="trigger-click">
           popover
-          <div data-mb-slot-name="content">
-            User stories
-          </div></span>
+          <span data-mb-slot-name="content">
+            <div>
+              User stories
+            </div>
+          </span></span>
         <i class="fa fa-arrow-circle-up fa-lg d-print-none" id="scroll-top-button" onclick="handleScrollTop()" aria-hidden="true"></i>
       </div>
       <nav id="page-nav" class="fixed-header-padding">

--- a/packages/cli/test/functional/test_site/expected/testThumbnails.html
+++ b/packages/cli/test/functional/test_site/expected/testThumbnails.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
+++ b/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
+++ b/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site/expected/test_md_fragment.html
+++ b/packages/cli/test/functional/test_site/expected/test_md_fragment.html
@@ -41,7 +41,7 @@
     <div>
       <header>
         <navbar type="dark" default-highlight-on="sibling-or-child" class=" temp-navbar">
-          <a slot="brand" href="/" title="Home" class="navbar-brand">Markbind Test Site</a>
+          <template #brand><a href="/" title="Home" class="navbar-brand">Markbind Test Site</a></template>
           <li><a class="nav-link" href="/test_site/bugs/index.html">Open Bugs</a></li>
         </navbar>
         <div class="bg-info display-4 text-center text-white">

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -64,8 +64,8 @@
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>
       Question should not have `algolia-no-index` class
-      <div slot="hint" class="algolia-no-index">Hint should have `algolia-no-index` class</div>
-      <div slot="answer" class="algolia-no-index">Answer should have `algolia-no-index` class</div>
+      <div slot="hint">Hint should have `algolia-no-index` class</div>
+      <div slot="answer">Answer should have `algolia-no-index` class</div>
     </question>
     <p><strong>Tabs except first tab should have algolia-no-index class</strong></p>
     <tabs>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -30,32 +30,33 @@
     <p>
     <p><strong>Test Algolia plugin adds algolia-no-index classes</strong></p>
     <p><strong>Dropdowns should have algolia-no-index class</strong></p>
-    <dropdown class="temp-dropdown algolia-no-index"><template slot="_header">Dropdown</template>
+    <dropdown class="temp-dropdown algolia-no-index"><template #_header>Dropdown</template>
       <li><a class="dropdown-item" href="/">One</a></li>
       <li><a class="dropdown-item" href="/">Two</a></li>
     </dropdown>
     <div class="temp-dropdown-placeholder"></div>
     <p><strong>Modal content should have algolia-no-index class</strong></p>
-    <b-modal id="modal:trigger_id" hide-footer size modal-class="mb-zoom" ref="modal:trigger_id" class="algolia-no-index"><template slot="modal-title">Modal</template>
+    <b-modal id="modal:trigger_id" hide-footer size modal-class="mb-zoom" ref="modal:trigger_id" class="algolia-no-index"><template #modal-title>Modal</template>
       Content should have `algolia-no-index` class
     </b-modal>
     <trigger for="modal:trigger_id">Trigger should not have `algolia-no-index` class</trigger>
     <p><strong>Panels that are not expanded should have algolia-no-index class</strong></p>
-    <panel class="algolia-no-index"><template slot="header">
+    <panel class="algolia-no-index"><template #header>
         <p>Panel</p>
       </template>
       Content
     </panel>
-    <panel expanded><template slot="header">
+    <panel expanded><template #header>
         <p>Panel</p>
       </template>
       Content
     </panel>
     <p><strong>Popover content should have algolia-no-index class</strong></p>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header" class="algolia-no-index">Title</span>
-      <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
-      <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
-    </span>
+      <span data-mb-slot-name="content" class="algolia-no-index">
+        <div>Content should have `algolia-no-index` class</div>
+      </span>
+      <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header" class="algolia-no-index">Title</span><span data-mb-slot-name="content" class="algolia-no-index">Content should have <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <p><strong>Tooltip content should have algolia-no-index class</strong></p>
@@ -64,46 +65,49 @@
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>
       Question should not have `algolia-no-index` class
-      <div slot="hint">Hint should have `algolia-no-index` class</div>
-      <div slot="answer">Answer should have `algolia-no-index` class</div>
-    </question>
+      <template #hint>
+        <div class="algolia-no-index">Hint should have `algolia-no-index` class</div>
+      </template>
+      <template #answer>
+        <div class="algolia-no-index">Answer should have `algolia-no-index` class</div>
+      </template></question>
     <p><strong>Tabs except first tab should have algolia-no-index class</strong></p>
     <tabs>
-      <tab><template slot="_header">First Tab</template>
+      <tab><template #_header>First Tab</template>
         Content<br>Content<br>Content<br>Content
       </tab>
-      <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
+      <tab class="algolia-no-index"><template #_header>Second Tab</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>
     <tabs>
-      <tab-group><template slot="_header">First Group</template>
-        <tab><template slot="_header">First Tab</template>
+      <tab-group><template #_header>First Group</template>
+        <tab><template #_header>First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
+        <tab class="algolia-no-index"><template #_header>Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab-group class="algolia-no-index"><template slot="_header">Second Group</template>
-        <tab><template slot="_header">First Tab</template>
+      <tab-group class="algolia-no-index"><template #_header>Second Group</template>
+        <tab><template #_header>First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
+        <tab class="algolia-no-index"><template #_header>Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
     </tabs>
     <tabs>
-      <tab-group><template slot="_header">Outer One</template>
-        <tab><template slot="_header">First Tab</template>
+      <tab-group><template #_header>Outer One</template>
+        <tab><template #_header>First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
+        <tab class="algolia-no-index"><template #_header>Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab><template slot="_header">Outer Two</template>
+      <tab><template #_header>Outer Two</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>

--- a/packages/cli/test/functional/test_site_convert/expected/Home.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Home.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/Page-1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Page-1.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/_Footer.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Footer.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/about.html
+++ b/packages/cli/test/functional/test_site_convert/expected/about.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_convert/expected/index.html
+++ b/packages/cli/test/functional/test_site_convert/expected/index.html
@@ -31,15 +31,17 @@
 
     <header fixed>
       <navbar placement="top" type="inverse" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">
-          <i class="far fa-file-image"></i></a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">
+            <i class="far fa-file-image"></i></a></template>
         <li><a href="/index.html" class="nav-link">HOME</a></li>
         <li><a href="/about.html" class="nav-link">ABOUT</a></li>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -34,16 +34,18 @@
         <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
+        <dropdown class="nav-link temp-dropdown"><template #_header>Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
         <div class="nav-link temp-dropdown-placeholder"></div>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -31,7 +31,7 @@
 
     <header fixed>
       <navbar type="dark" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -34,16 +34,18 @@
         <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
+        <dropdown class="nav-link temp-dropdown"><template #_header>Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
         <div class="nav-link temp-dropdown-placeholder"></div>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -31,7 +31,7 @@
 
     <header fixed>
       <navbar type="dark" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -34,16 +34,18 @@
         <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
+        <dropdown class="nav-link temp-dropdown"><template #_header>Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
         <div class="nav-link temp-dropdown-placeholder"></div>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -31,7 +31,7 @@
 
     <header fixed>
       <navbar type="dark" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -34,16 +34,18 @@
         <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
+        <dropdown class="nav-link temp-dropdown"><template #_header>Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
         <div class="nav-link temp-dropdown-placeholder"></div>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -31,7 +31,7 @@
 
     <header fixed>
       <navbar type="dark" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -31,7 +31,7 @@
 
     <header fixed>
       <navbar type="dark" class=" temp-navbar">
-        <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
+        <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
@@ -114,7 +114,7 @@
 </span></code></pre>
         <h2 id="sub-heading-1-1"><span id="sub-heading-1-1" class="anchor"></span>Sub Heading 1.1<a class="fa fa-anchor" href="#sub-heading-1-1" onclick="event.stopPropagation()"></a></h2>
         <p>A <span effect="scale" placement="top" trigger="hover" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content">❗️ some <strong>important explanation</strong></span>tooltip</span>, a <trigger for="modal:modalinfo" trigger="click">modal</trigger>, a <a href="https://markbind.org/">link</a>, a <span class="badge badge-danger">badge</span>, another <span class="badge badge-warning">badge</span>.</p>
-        <b-modal id="modal:modalinfo" hide-footer size modal-class="mb-zoom" ref="modal:modalinfo"><template slot="modal-title">Modal Title</template>
+        <b-modal id="modal:modalinfo" hide-footer size modal-class="mb-zoom" ref="modal:modalinfo"><template #modal-title>Modal Title</template>
           Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.
         </b-modal>
         <p><strong>A table:</strong></p>
@@ -149,17 +149,17 @@
         <div class="block-embed block-embed-service-youtube"><iframe type="text/html" src="//www.youtube.com/embed/v40b3ExbM0c" frameborder="0" width="640" height="390" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>
         <p><strong>Tabs:</strong></p>
         <tabs>
-          <tab><template slot="_header">Tab X</template>
+          <tab><template #_header>Tab X</template>
             Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.
           </tab>
-          <tab><template slot="_header">Tab Y</template>
+          <tab><template #_header>Tab Y</template>
             ...
           </tab>
-          <tab-group><template slot="_header">Tab group</template>
-            <tab><template slot="_header">Tab Y.1</template>
+          <tab-group><template #_header>Tab group</template>
+            <tab><template #_header>Tab Y.1</template>
               ...
             </tab>
-            <tab><template slot="_header">Tab Y.2</template>
+            <tab><template #_header>Tab Y.2</template>
               ...
             </tab>
           </tab-group>
@@ -176,49 +176,49 @@
         <box type="warning" dismissible>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </box>
-        <box type="tip"><template slot="_header">
+        <box type="tip"><template #_header>
             <p>Tip box heading</p>
           </template>
           tip
         </box>
-        <box type="success"><template slot="_header">
+        <box type="success"><template #_header>
             <p>Tip box heading</p>
           </template>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </box>
-        <box type="important" dismissible><template slot="_header">
+        <box type="important" dismissible><template #_header>
             <p>Tip box heading</p>
           </template>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         </box>
         <br>
         <h1 id="heading-3"><span id="heading-3" class="anchor"></span>Heading 3<a class="fa fa-anchor" href="#heading-3" onclick="event.stopPropagation()"></a></h1>
-        <panel type="info"><template slot="header">
+        <panel type="info"><template #header>
             <p>Expandable panel</p>
           </template>
           Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text. Some text some text some text some text some text some text some text some text some text some text some text some text some text some text. Some text some text some text some text some text some text. Some text some text some text some text some text some text some text.
         </panel>
         <br>
-        <panel type="success" minimized><template slot="header">
+        <panel type="success" minimized><template #header>
             <p>Expanded panel</p>
-          </template><template slot="_alt">
+          </template><template #_alt>
             <p>Minimized panel</p>
           </template>
           ...
         </panel>
         <br>
-        <panel type="seamless"><template slot="header">
+        <panel type="seamless"><template #header>
             <p>Expanded panel</p>
-          </template><template slot="_alt">
+          </template><template #_alt>
             <p>Minimized panel</p>
           </template>
           ...
         </panel>
         <br>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          <panel type="minimal" popup-url="https://markbind.org/userGuide/usingComponents.html#panels" no-switch><template slot="header">
+          <panel type="minimal" popup-url="https://markbind.org/userGuide/usingComponents.html#panels" no-switch><template #header>
               <p><em><strong>Minimal panel <strong>-&gt;</strong></strong></em></p>
-            </template><template slot="_alt">
+            </template><template #_alt>
               <p>Minimal panel</p>
             </template>
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -34,16 +34,18 @@
         <template #brand><a href="/index.html" title="Home" class="navbar-brand">Your Logo</a></template>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
+        <dropdown class="nav-link temp-dropdown"><template #_header>Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
         <div class="nav-link temp-dropdown-placeholder"></div>
-        <li slot="right">
-          <form class="navbar-form">
-            <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
-          </form>
-        </li>
+        <template #right>
+          <li>
+            <form class="navbar-form">
+              <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>
+            </form>
+          </li>
+        </template>
       </navbar>
     </header>
     <div id="flex-body">

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -194,7 +194,7 @@ class Page {
       }
 
       // Check if heading / panel is under a panel's header slots, which is handled specially below.
-      const slotParents = $(elem).parentsUntil(context).filter('[v-slot\\:header]').not(elem);
+      const slotParents = $(elem).parentsUntil(context).filter('[\\#header]').not(elem);
       const panelSlotParents = slotParents.parent('panel');
       if (panelSlotParents.length) {
         return;
@@ -202,7 +202,7 @@ class Page {
 
       if (elem.name === 'panel') {
         // Recurse only on the slot which has priority
-        const headings = $(elem).children('[v-slot\\:header]');
+        const headings = $(elem).children('[\\#header]');
         if (!headings.length) return;
 
         this._collectNavigableHeadings($, headings.first(), pageNavSelector);
@@ -236,7 +236,7 @@ class Page {
     $('b-modal').remove();
     $('panel').not('panel panel')
       .each((index, panel) => {
-        const slotHeader = $(panel).children('[v-slot\\:header]');
+        const slotHeader = $(panel).children('[\\#header]');
         if (slotHeader.length) {
           this.collectHeadingsAndKeywordsInContent(slotHeader.html(),
                                                    lastHeading, excludeHeadings, sourceTraversalStack);
@@ -248,7 +248,7 @@ class Page {
         if (!closestHeading) {
           closestHeading = lastHeading;
         }
-        const slotHeadings = $(panel).children('[v-slot\\:header]').find(':header');
+        const slotHeadings = $(panel).children('[\\#header]').find(':header');
         if (slotHeadings.length) {
           closestHeading = slotHeadings.first();
         }

--- a/packages/core/src/Page/index.js
+++ b/packages/core/src/Page/index.js
@@ -194,7 +194,7 @@ class Page {
       }
 
       // Check if heading / panel is under a panel's header slots, which is handled specially below.
-      const slotParents = $(elem).parentsUntil(context).filter('[slot="header"]').not(elem);
+      const slotParents = $(elem).parentsUntil(context).filter('[v-slot\\:header]').not(elem);
       const panelSlotParents = slotParents.parent('panel');
       if (panelSlotParents.length) {
         return;
@@ -202,7 +202,7 @@ class Page {
 
       if (elem.name === 'panel') {
         // Recurse only on the slot which has priority
-        const headings = $(elem).children('[slot="header"]');
+        const headings = $(elem).children('[v-slot\\:header]');
         if (!headings.length) return;
 
         this._collectNavigableHeadings($, headings.first(), pageNavSelector);
@@ -236,7 +236,7 @@ class Page {
     $('b-modal').remove();
     $('panel').not('panel panel')
       .each((index, panel) => {
-        const slotHeader = $(panel).children('[slot="header"]');
+        const slotHeader = $(panel).children('[v-slot\\:header]');
         if (slotHeader.length) {
           this.collectHeadingsAndKeywordsInContent(slotHeader.html(),
                                                    lastHeading, excludeHeadings, sourceTraversalStack);
@@ -248,7 +248,7 @@ class Page {
         if (!closestHeading) {
           closestHeading = lastHeading;
         }
-        const slotHeadings = $(panel).children('[slot="header"]').find(':header');
+        const slotHeadings = $(panel).children('[v-slot\\:header]').find(':header');
         if (slotHeadings.length) {
           closestHeading = slotHeadings.first();
         }

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -93,11 +93,13 @@ class NodeProcessor {
     if (!node.attribs) {
       return '';
     }
+
     const keys = Object.keys(node.attribs);
     const vslotShorthand = _.find(keys, key => key.startsWith('#'));
     if (!vslotShorthand) {
       return '';
     }
+
     return vslotShorthand.substring(1, vslotShorthand.length); // remove #
   }
 
@@ -114,10 +116,7 @@ class NodeProcessor {
     const hasAttributeSlot = node.children
       && node.children.some((child) => {
         const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-        if (!vslotShorthandName) {
-          return false;
-        }
-        return vslotShorthandName === slotName;
+        return vslotShorthandName && vslotShorthandName === slotName;
       });
 
     if (!hasAttributeSlot && _.has(node.attribs, attribute)) {

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -666,7 +666,7 @@ class NodeProcessor {
   /*
    * Transforms deprecated vue slot syntax (slot="test") into the updated Vue slot shorthand syntax (#test).
    */
-  static transformSlotNode(node) {
+  static transformOldSlotSyntax(node) {
     if (!node.children) {
       return;
     }
@@ -686,7 +686,7 @@ class NodeProcessor {
 
   processNode(node, context) {
     try {
-      NodeProcessor.transformSlotNode(node);
+      NodeProcessor.transformOldSlotSyntax(node);
       NodeProcessor.shiftSlotNodeDeeper(node);
 
       switch (node.name) {

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -140,7 +140,7 @@ class NodeProcessor {
    */
   static _transformSlottedComponents(node) {
     node.children.forEach((child) => {
-      // Turns <div #content>... into <div data-mb-slot-name=content>...
+      // Turns <template #content>... into <span data-mb-slot-name=content>...
       const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
       if (vslotShorthandName) {
         child.attribs['data-mb-slot-name'] = vslotShorthandName;

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -114,10 +114,7 @@ class NodeProcessor {
    */
   _processAttributeWithoutOverride(node, attribute, isInline, slotName = attribute) {
     const hasAttributeSlot = node.children
-      && node.children.some((child) => {
-        const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-        return vslotShorthandName && vslotShorthandName === slotName;
-      });
+      && node.children.some(child => NodeProcessor.getVslotShorthandName(child) === slotName);
 
     if (!hasAttributeSlot && _.has(node.attribs, attribute)) {
       let rendered;
@@ -148,9 +145,7 @@ class NodeProcessor {
       if (vslotShorthandName) {
         child.attribs['data-mb-slot-name'] = vslotShorthandName;
         delete child.attribs[`#${vslotShorthandName}`];
-      }
-      // similarly, need to transform templates to avoid Vue parsing
-      if (child.name === 'template') {
+        // similarly, need to transform templates to avoid Vue parsing
         child.name = 'span';
       }
     });
@@ -226,10 +221,7 @@ class NodeProcessor {
     const slotChildren = node.children
       && node.children.filter(child => NodeProcessor.getVslotShorthandName(child) !== '');
 
-    const headerSlot = slotChildren.find((child) => {
-      const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-      return vslotShorthandName === 'header';
-    });
+    const headerSlot = slotChildren.find(child => NodeProcessor.getVslotShorthandName(child) === 'header');
 
     if (headerSlot) {
       const header = NodeProcessor._findHeaderElement(headerSlot);
@@ -420,10 +412,8 @@ class NodeProcessor {
     NodeProcessor._renameAttribute(node, 'center', 'centered');
 
     const hasOkTitle = _.has(node.attribs, 'ok-title');
-    const hasFooter = node.children.some((child) => {
-      const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-      return vslotShorthandName && vslotShorthandName === 'modal-footer';
-    });
+    const hasFooter = node.children
+      .some(child => NodeProcessor.getVslotShorthandName(child) === 'modal-footer');
 
     if (!hasFooter && !hasOkTitle) {
       // markbind doesn't show the footer by default
@@ -489,10 +479,8 @@ class NodeProcessor {
    */
 
   _processDropdownAttributes(node) {
-    const hasHeaderSlot = node.children && node.children.some((child) => {
-      const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-      return vslotShorthandName && vslotShorthandName === 'header';
-    });
+    const hasHeaderSlot = node.children
+      && node.children.some(child => NodeProcessor.getVslotShorthandName(child) === 'header');
 
     // If header slot is present, the header attribute has no effect, and we can simply remove it.
     if (hasHeaderSlot) {

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -228,7 +228,6 @@ class NodeProcessor {
 
     const headerSlot = slotChildren.find((child) => {
       const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
-      // vslot is guaranteed to exist since we have filtered
       return vslotShorthandName === 'header';
     });
 

--- a/packages/core/src/html/NodeProcessor.js
+++ b/packages/core/src/html/NodeProcessor.js
@@ -490,7 +490,6 @@ class NodeProcessor {
    */
 
   _processDropdownAttributes(node) {
-    // Have not converted deprecated Vue slot syntax to shorthand, so we must handle both.
     const hasHeaderSlot = node.children && node.children.some((child) => {
       const vslotShorthandName = NodeProcessor.getVslotShorthandName(child);
       return vslotShorthandName && vslotShorthandName === 'header';

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -26,8 +26,8 @@ function addNoIndexClasses(content) {
     'panel:not([expanded])',
     // to target both popover and tooltip
     '[data-mb-component-type] [data-mb-slot-name]',
-    'question div[v-slot\\:hint]',
-    'question div[v-slot\\:answer]',
+    'question div["#hint"]',
+    'question div["#answer"]',
     'tab:nth-of-type(n+2)',
     'tab-group:nth-of-type(n+2)',
   ].join(', ');

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -26,8 +26,8 @@ function addNoIndexClasses(content) {
     'panel:not([expanded])',
     // to target both popover and tooltip
     '[data-mb-component-type] [data-mb-slot-name]',
-    'question div["#hint"]',
-    'question div["#answer"]',
+    'question div[\\#hint]',
+    'question div[\\#answer]',
     'tab:nth-of-type(n+2)',
     'tab-group:nth-of-type(n+2)',
   ].join(', ');

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -26,8 +26,8 @@ function addNoIndexClasses(content) {
     'panel:not([expanded])',
     // to target both popover and tooltip
     '[data-mb-component-type] [data-mb-slot-name]',
-    'question div[slot=hint]',
-    'question div[slot=answer]',
+    'question div[v-slot\\:hint]',
+    'question div[v-slot\\:answer]',
     'tab:nth-of-type(n+2)',
     'tab-group:nth-of-type(n+2)',
   ].join(', ');

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -26,8 +26,8 @@ function addNoIndexClasses(content) {
     'panel:not([expanded])',
     // to target both popover and tooltip
     '[data-mb-component-type] [data-mb-slot-name]',
-    'question div[\\#hint]',
-    'question div[\\#answer]',
+    'question template[\\#hint] div',
+    'question template[\\#answer] div',
     'tab:nth-of-type(n+2)',
     'tab-group:nth-of-type(n+2)',
   ].join(', ');

--- a/packages/core/test/unit/html/NodeProcessor.data.js
+++ b/packages/core/test/unit/html/NodeProcessor.data.js
@@ -11,8 +11,8 @@ module.exports.PROCESS_PANEL_ATTRIBUTES = `
 `;
 
 module.exports.PROCESS_PANEL_ATTRIBUTES_EXPECTED = `
-<panel><template slot="header"><h1>Lorem ipsum</h1>
-</template><template slot="_alt"><p><em>emphasized alt</em></p>
+<panel><template #header><h1>Lorem ipsum</h1>
+</template><template #_alt><p><em>emphasized alt</em></p>
 </template>
   Header and alt attributes should be processed and inserted under panel as internal slots and deleted.
 </panel>
@@ -30,11 +30,11 @@ module.exports.PROCESS_PANEL_HEADER_NO_OVERRIDE = `
 `;
 
 module.exports.PROCESS_PANEL_HEADER_NO_OVERRIDE_EXPECTED = `
-<panel><template slot="_alt"><p><strong>strong alt</strong></p>
+<panel><template #_alt><p><strong>strong alt</strong></p>
 </template>
-  <div slot="header">
+  <template #header><div>
     This existing header slot should be preserved in favour over header attribute.
-  </div>
+  </div></template>
   Header attribute should not be inserted under panel since there is both an alt attribute and header slot,
   but should be deleted.
   Alt attribute should be inserted under panel as slot.
@@ -50,7 +50,7 @@ module.exports.POST_PROCESS_PANEL_ID_ASSIGNED_USING_HEADER_SLOT = `
 `;
 
 module.exports.POST_PROCESS_PANEL_ID_ASSIGNED_USING_HEADER_SLOT_EXPECTED = `
-<panel id="slot-header"><template slot="header"><h1 id="slot-header">Slot Header</h1></template>
+<panel id="slot-header"><template #header><h1 id="slot-header">Slot Header</h1></template>
   Header and alt attributes should be processed and inserted under panel as internal slots and deleted.
 </panel>
 `;
@@ -65,9 +65,9 @@ module.exports.PROCESS_QUESTION_ATTRIBUTES = `
 `;
 
 module.exports.PROCESS_QUESTION_ATTRIBUTES_EXPECTED = `
-<question><template slot="answer"><p><strong>answer</strong></p>
-</template><template slot="hint"><p><strong>hint</strong></p>
-</template><template slot="header"><p><strong>header</strong></p>
+<question><template #answer><p><strong>answer</strong></p>
+</template><template #hint><p><strong>hint</strong></p>
+</template><template #header><p><strong>header</strong></p>
 </template>
 </question>
 `;
@@ -82,9 +82,9 @@ module.exports.PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE = `
 
 module.exports.PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
 <question>
-<template slot="header"></template>
-<template slot="hint"></template>
-<template slot="answer"></template>
+<template #header></template>
+<template #hint></template>
+<template #answer></template>
 </question>
 `;
 
@@ -94,7 +94,7 @@ module.exports.PROCESS_QOPTION_ATTRIBUTES = `
 `;
 
 module.exports.PROCESS_QOPTION_ATTRIBUTES_EXPECTED = `
-<q-option><template slot="reason"><p><strong>lorem ipsum</strong></p>
+<q-option><template #reason><p><strong>lorem ipsum</strong></p>
 </template>
 </q-option>
 `;
@@ -107,7 +107,7 @@ module.exports.PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE = `
 
 module.exports.PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
 <q-option>
-<template slot="reason"></template>
+<template #reason></template>
 </q-option>
 `;
 
@@ -117,7 +117,7 @@ module.exports.PROCESS_QUIZ_ATTRIBUTES = `
 `;
 
 module.exports.PROCESS_QUIZ_ATTRIBUTES_EXPECTED = `
-<quiz><template slot="intro"><p><strong>lorem ipsum</strong></p>
+<quiz><template #intro><p><strong>lorem ipsum</strong></p>
 </template>
 </quiz>
 `;
@@ -130,7 +130,7 @@ module.exports.PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE = `
 
 module.exports.PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
 <quiz>
-<template slot="intro"></template>
+<template #intro></template>
 </quiz>
 `;
 
@@ -162,8 +162,8 @@ module.exports.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE = `
 
 module.exports.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
 <span data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger">
-  <div data-mb-slot-name="header">Some header slot content that should not be overwritten</div>
-  <div data-mb-slot-name="content">Some content slot that should not be overwritten</div>
+  <span data-mb-slot-name="header"><div>Some header slot content that should not be overwritten</div></span>
+  <span data-mb-slot-name="content"><div>Some content slot that should not be overwritten</div></span>
   Content and header attributes should not be inserted under panel as slots, but should be deleted.
 </span>
 `;
@@ -221,7 +221,7 @@ module.exports.PROCESS_MODAL_HEADER = `
 `;
 
 module.exports.PROCESS_MODAL_HEADER_EXPECTED = `
-<b-modal hide-footer size modal-class="mb-zoom"><template slot="modal-title"><em>Lorem ipsum dolor sit amet</em></template>
+<b-modal hide-footer size modal-class="mb-zoom"><template #modal-title><em>Lorem ipsum dolor sit amet</em></template>
   Header attribute should be inserted as bootstrap-vue modal-title slot.
 </b-modal>
 `;
@@ -235,7 +235,7 @@ module.exports.PROCESS_MODAL_TITLE = `
 `;
 
 module.exports.PROCESS_MODAL_TITLE_EXPECTED = `
-<b-modal hide-footer size modal-class="mb-zoom"><template slot="modal-title"><strong>Lorem ipsum dolor sit amet</strong></template>
+<b-modal hide-footer size modal-class="mb-zoom"><template #modal-title><strong>Lorem ipsum dolor sit amet</strong></template>
   Title attribute should be inserted as internal _header slot.
 </b-modal>
 `;
@@ -247,7 +247,7 @@ module.exports.PROCESS_MODAL_TITLE_NO_OVERRIDE = `
 `;
 
 module.exports.PROCESS_MODAL_TITLE_NO_OVERRIDE_EXPECTED = `
-<b-modal hide-footer size modal-class="mb-zoom"><template slot="modal-title"><strong>Header header</strong></template>
+<b-modal hide-footer size modal-class="mb-zoom"><template #modal-title><strong>Header header</strong></template>
   Title attribute should not have priority over newer header attribute, and should be deleted.
 </b-modal>
 `;
@@ -259,7 +259,7 @@ module.exports.PROCESS_MODAL_OK_TEXT = `
 `;
 
 module.exports.PROCESS_MODAL_OK_TEXT_EXPECTED = `
-<b-modal ok-title="Custom OK" ok-only size modal-class="mb-zoom"><template slot="modal-title"><strong>Header header</strong></template>
+<b-modal ok-title="Custom OK" ok-only size modal-class="mb-zoom"><template #modal-title><strong>Header header</strong></template>
   ok-only attr should be set, hide-footer should not be set.
 </b-modal>
 `;
@@ -275,8 +275,8 @@ module.exports.PROCESS_MODAL_SLOTS_RENAMING = `
 
 module.exports.PROCESS_MODAL_SLOTS_RENAMING_EXPECTED = `
 <b-modal size modal-class="mb-zoom">
-  <div slot="modal-header">Should be renamed to header</div>
-  <div slot="modal-footer">Should be renamed to footer</div>
+  <template #modal-header><div>Should be renamed to header</div></template>
+  <template #modal-footer><div>Should be renamed to footer</div></template>
 </b-modal>
 `;
 
@@ -291,7 +291,7 @@ module.exports.PROCESS_TAB_HEADER = `
 `;
 
 module.exports.PROCESS_TAB_HEADER_EXPECTED = `
-<tab><template slot="_header"><strong>Lorem ipsum dolor sit amet</strong></template>
+<tab><template #_header><strong>Lorem ipsum dolor sit amet</strong></template>
   Header attribute should be inserted as internal _header slot and deleted.
 </tab>
 `;
@@ -303,7 +303,7 @@ module.exports.PROCESS_TAB_GROUP_HEADER = `
 `;
 
 module.exports.PROCESS_TAB_GROUP_HEADER_EXPECTED = `
-<tab-group><template slot="_header"><strong>Lorem ipsum dolor sit amet</strong></template>
+<tab-group><template #_header><strong>Lorem ipsum dolor sit amet</strong></template>
   Header attribute should be inserted as internal _header slot and deleted.
 </tab-group>
 `;
@@ -319,7 +319,7 @@ module.exports.PROCESS_BOX_ICON = `
 `;
 
 module.exports.PROCESS_BOX_ICON_EXPECTED = `
-<box><template slot="icon">🚀</template>
+<box><template #icon>🚀</template>
   Icon attribute should be inserted as internal icon slot and deleted.
 </box>
 `;
@@ -331,7 +331,7 @@ module.exports.PROCESS_BOX_HEADER = `
 `;
 
 module.exports.PROCESS_BOX_HEADER_EXPECTED = `
-<box><template slot="_header"><h4>Lorem ipsum dolor sit amet 🚀</h4>
+<box><template #_header><h4>Lorem ipsum dolor sit amet 🚀</h4>
 </template>
   Header attribute should be inserted as internal _header slot and deleted.
 </box>
@@ -346,7 +346,7 @@ module.exports.PROCESS_BOX_HEADING = `
 `;
 
 module.exports.PROCESS_BOX_HEADING_EXPECTED = `
-<box><template slot="_header"><h4>Lorem ipsum dolor sit amet 🚀</h4>
+<box><template #_header><h4>Lorem ipsum dolor sit amet 🚀</h4>
 </template>
   Heading attribute should be inserted as internal _header slot and deleted.
 </box>
@@ -363,7 +363,7 @@ module.exports.PROCESS_DROPDOWN_HEADER = `
 `;
 
 module.exports.PROCESS_DROPDOWN_HEADER_EXPECTED = `
-<dropdown><template slot="_header"><strong>Lorem ipsum dolor sit amet</strong></template>
+<dropdown><template #_header><strong>Lorem ipsum dolor sit amet</strong></template>
   Header attribute should be inserted as internal _header slot and deleted.
 </dropdown>
 `;
@@ -377,7 +377,7 @@ module.exports.PROCESS_DROPDOWN_TEXT_ATTR = `
 
 // TODO deprecate text attribute of dropdown
 module.exports.PROCESS_DROPDOWN_TEXT_ATTR_EXPECTED = `
-<dropdown><template slot="_header"><strong>Lorem ipsum dolor sit amet</strong></template>
+<dropdown><template #_header><strong>Lorem ipsum dolor sit amet</strong></template>
   Text attribute should be inserted as internal _header slot and deleted.
 </dropdown>
 `;
@@ -391,7 +391,7 @@ module.exports.PROCESS_DROPDOWN_HEADER_SHADOWS_TEXT = `
 
 // TODO deprecate text attribute of dropdown
 module.exports.PROCESS_DROPDOWN_HEADER_SHADOWS_TEXT_EXPECTED = `
-<dropdown><template slot="_header"><strong>Lorem ipsum dolor sit amet</strong></template>
+<dropdown><template #_header><strong>Lorem ipsum dolor sit amet</strong></template>
   Header attribute should be inserted as internal _header slot and deleted. Text attribute should be ignored.
 </dropdown>
 `;
@@ -405,7 +405,7 @@ module.exports.PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY = `
 
 module.exports.PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 <dropdown>
-  <strong slot="header">slot text</strong>
+  <template #header><strong>slot text</strong></template>
   Header attribute should be ignored and deleted while header slot is reserved.
 </dropdown>
 `;

--- a/packages/core/test/unit/html/NodeProcessor.test.js
+++ b/packages/core/test/unit/html/NodeProcessor.test.js
@@ -20,6 +20,8 @@ const processAndVerifyTemplate = (template, expectedTemplate, postProcess = fals
     const nodeProcessor = getNewDefaultNodeProcessor();
 
     if (postProcess) {
+      // need to process node first (convert slot to v-slot) before doing post-processing
+      dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));
       dom.forEach(node => nodeProcessor.postProcessNode(node));
     } else {
       dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));

--- a/packages/core/test/unit/html/NodeProcessor.test.js
+++ b/packages/core/test/unit/html/NodeProcessor.test.js
@@ -20,8 +20,6 @@ const processAndVerifyTemplate = (template, expectedTemplate, postProcess = fals
     const nodeProcessor = getNewDefaultNodeProcessor();
 
     if (postProcess) {
-      // need to process node first (convert slot to v-slot) before doing post-processing
-      dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));
       dom.forEach(node => nodeProcessor.postProcessNode(node));
     } else {
       dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));

--- a/packages/core/test/unit/html/NodeProcessor.test.js
+++ b/packages/core/test/unit/html/NodeProcessor.test.js
@@ -20,6 +20,11 @@ const processAndVerifyTemplate = (template, expectedTemplate, postProcess = fals
     const nodeProcessor = getNewDefaultNodeProcessor();
 
     if (postProcess) {
+      /*
+        Need to process node first (convert deprecated vue slot to updated shorthand syntax)
+        before doing post-processing.
+      */
+      dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));
       dom.forEach(node => nodeProcessor.postProcessNode(node));
     } else {
       dom.forEach(node => nodeProcessor.processNode(node, new Context(path.resolve(''))));

--- a/packages/core/test/unit/html/NodeProcessor.test.js
+++ b/packages/core/test/unit/html/NodeProcessor.test.js
@@ -164,7 +164,7 @@ test('deprecated vue slot syntax should be converted to updated Vue slot shortha
 
   const testNode = cheerio.parseHTML(test)[0];
 
-  NodeProcessor.transformSlotNode(testNode);
+  NodeProcessor.transformOldSlotSyntax(testNode);
 
   const expected = '<panel><div #header>test</div><p #test>test2</p></panel>';
 

--- a/packages/core/test/unit/html/NodeProcessor.test.js
+++ b/packages/core/test/unit/html/NodeProcessor.test.js
@@ -4,6 +4,7 @@ const htmlparser = require('htmlparser2');
 const { getNewDefaultNodeProcessor } = require('../utils/utils');
 const testData = require('./NodeProcessor.data');
 const { Context } = require('../../../src/html/Context');
+const { NodeProcessor } = require('../../../src/html/NodeProcessor');
 
 /**
  * Runs the processNode or postProcessNode method of NodeProcessor on the provided
@@ -155,4 +156,29 @@ test('renderFile converts markdown headers to <h1> with an id', async () => {
   const expected = ['<h1 id="index"><span id="index" class="anchor"></span>Index</h1>'].join('\n');
 
   expect(result).toEqual(expected);
+});
+
+test('deprecated vue slot syntax should be converted to updated Vue slot shorthand syntax', async () => {
+  // slot="test" converted to #test
+  const test = '<panel><div slot="header">test</div><p slot="test">test2</p></panel>';
+
+  const testNode = cheerio.parseHTML(test)[0];
+
+  NodeProcessor.transformSlotNode(testNode);
+
+  const expected = '<panel><div #header>test</div><p #test>test2</p></panel>';
+
+  expect(cheerio.html(testNode)).toEqual(expected);
+});
+
+test('slot nodes which have tag names other than "template" are shifted one level deeper ', async () => {
+  const test = '<panel><div #header>test</div></panel>';
+
+  const testNode = cheerio.parseHTML(test)[0];
+
+  NodeProcessor.shiftSlotNodeDeeper(testNode);
+
+  const expected = '<panel><template #header><div>test</div></template></panel>';
+
+  expect(cheerio.html(testNode)).toEqual(expected);
 });

--- a/packages/vue-components/src/Dropdown.vue
+++ b/packages/vue-components/src/Dropdown.vue
@@ -24,7 +24,7 @@
     </slot>
   </li>
   <submenu v-else-if="isSubmenu" ref="submenu">
-    <template v-for="(node, name) in $slots" :slot="name">
+    <template v-for="(node, name) in $slots" v-slot:[name]>
       <slot :name="name"></slot>
     </template>
   </submenu>

--- a/packages/vue-components/src/Panel.vue
+++ b/packages/vue-components/src/Panel.vue
@@ -1,6 +1,6 @@
 <template>
   <minimal-panel v-if="isMinimal" v-bind="$attrs">
-    <template v-for="(node, name) in $slots" :slot="name">
+    <template v-for="(node, name) in $slots" v-slot:[name]>
       <slot :name="name"></slot>
     </template>
   </minimal-panel>
@@ -9,7 +9,7 @@
     :type="type"
     v-bind="$attrs"
   >
-    <template v-for="(node, name) in $slots" :slot="name">
+    <template v-for="(node, name) in $slots" v-slot:[name]>
       <slot :name="name"></slot>
     </template>
   </nested-panel>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

This PR addresses part of #1078 in removing the deprecated Vue slot syntax.

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Update all the internal Vue slot syntax to v-slot (e.g. `slot="example"` to `v-slot:example`)

**Anything you'd like to highlight / discuss:**
Since the changes are coupled with the processing of the nodes, we have to be careful in ensuring that existing features are not affected. While I have ensured that all the existing test cases are passing, I'm not sure if this change will break some other existing features. Would be great if I can get some advice here :-/

There is, however, one area that I identified to have regressed but was not able to pinpoint the actual cause of it from my changes. 

Given the following, the item within the slot currently are not appearing as the panel header. I'm still looking into this issue. 
```
<panel  type="info" alt="hi">
  <p slot="header" class="card-title">
    <i><strong>
      <span style="color:#FF0000;">R</span>
      <span style="color:#FF7F00;">A</span>
      <span style="color:#FFFF00;">I</span>
      <span style="color:#00FF00;">N</span>
      <span style="color:#0000FF;">B</span>
      <span style="color:#4B0082;">O</span>
      <span style="color:#9400D3;">W</span>
    </strong></i>
  </p>
</panel>
```

**Testing instructions:**
`npm run test`

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Update deprecated Vue slot syntax. 

Our internal Vue slot syntax are deprecated according to official 
Vue documentation. To ensure our codebase is up-to-date, let's 
convert all the deprecated syntax to the latest Vue slot shorthand 
syntax that was introduced in version 2.6.0. 

We will still support the old slot syntax for backward compability, 
by processing and converting the old slot syntax to the new 
shorthand syntax. 

Externally, users will be able to use the latest shorthand syntax for
slots as well, as our processing targets the latest shorthand syntax. 

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
