### PR TITLE
Fix node-processing bug from dropdown temporary placeholder

### DIFF
--- a/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -185,44 +185,29 @@
         <navbar type="dark" class=" temp-navbar">
           <li><a href="/" class="nav-link">One</a></li>
           <li><a href="/" class="nav-link">Two</a></li>
-          <div class="nav-link temp-dropdown-placeholder"></div>
-          <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
           <dropdown class="nav-link temp-dropdown"><template slot="_header">Dropdown</template>
             <li><a class="dropdown-item" href="/">Dropdown One</a></li>
             <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
           </dropdown>
+          <div class="nav-link temp-dropdown-placeholder"></div>
         </navbar>
 
         <p><strong>Test dropdown in body with text and class attributes</strong></p>
-        <div class="test-class temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="test-class temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="test-class temp-dropdown"><template slot="_header">Test One</template>
           <li><a class="dropdown-item" href="/">Dropdown One</a></li>
           <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
         </dropdown>
+        <div class="test-class temp-dropdown-placeholder"></div>
 
         <p><strong>Test dropdown in body without text and class attributes</strong></p>
-        <dropdown>
+        <dropdown class="temp-dropdown">
           <button slot="button" type="button" class="btn dropdown-toggle">
             Test Two
             <span class="caret"></span></button>
           <li><a class="dropdown-item" href="/">Dropdown One</a></li>
           <li><a class="dropdown-item" href="/">Dropdown Two</a></li>
         </dropdown>
+        <div class="temp-dropdown-placeholder"></div>
 
         <p><strong>Filler text</strong></p>
         <p><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br></p>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -53,7 +53,7 @@
     </panel>
     <p><strong>Popover content should have algolia-no-index class</strong></p>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span>
-      <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
+      <div data-mb-slot-name="content">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
     </span>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
@@ -75,7 +75,7 @@
     </tabs>
     <tabs>
       <tab-group><template slot="_header">First Group</template>
-        <tab><template slot="_header">First Tab</template>
+        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
@@ -83,7 +83,7 @@
         </tab>
       </tab-group>
       <tab-group class="algolia-no-index"><template slot="_header">Second Group</template>
-        <tab><template slot="_header">First Tab</template>
+        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
@@ -93,14 +93,14 @@
     </tabs>
     <tabs>
       <tab-group><template slot="_header">Outer One</template>
-        <tab><template slot="_header">First Tab</template>
+        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab><template slot="_header">Outer Two</template>
+      <tab class="algolia-no-index"><template slot="_header">Outer Two</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -30,62 +30,34 @@
     <p>
     <p><strong>Test Algolia plugin adds algolia-no-index classes</strong></p>
     <p><strong>Dropdowns should have algolia-no-index class</strong></p>
-    <div class="temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
-    <div class="temp-dropdown temp-dropdown-placeholder"></div>
     <dropdown class="temp-dropdown algolia-no-index"><template slot="_header">Dropdown</template>
       <li><a class="dropdown-item" href="/">One</a></li>
       <li><a class="dropdown-item" href="/">Two</a></li>
     </dropdown>
+    <div class="temp-dropdown-placeholder"></div>
     <p><strong>Modal content should have algolia-no-index class</strong></p>
-    <modal header="Modal" id="modal:trigger_id">
+    <b-modal id="modal:trigger_id" hide-footer size modal-class="mb-zoom" ref="modal:trigger_id" class="algolia-no-index"><template slot="modal-title">Modal</template>
       Content should have `algolia-no-index` class
-    </modal>
+    </b-modal>
     <trigger for="modal:trigger_id">Trigger should not have `algolia-no-index` class</trigger>
     <p><strong>Panels that are not expanded should have algolia-no-index class</strong></p>
-    <panel header="Panel" class="algolia-no-index">
+    <panel class="algolia-no-index"><template slot="header">
+        <p>Panel</p>
+      </template>
       Content
     </panel>
-    <panel header="Panel" expanded>
+    <panel expanded><template slot="header">
+        <p>Panel</p>
+      </template>
       Content
     </panel>
     <p><strong>Popover content should have algolia-no-index class</strong></p>
-    <popover effect="fade" header="Title" placement="top">
-      <div slot="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span>
+      <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
-    </popover>
-    <popover effect="fade" header="Title" content="Content as attribute does not require `algolia-no-index` class" placement="top">
-      <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></popover>
+    </span>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+      <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>
       Question should not have `algolia-no-index` class
@@ -94,41 +66,41 @@
     </question>
     <p><strong>Tabs except first tab should have algolia-no-index class</strong></p>
     <tabs>
-      <tab header="First Tab">
+      <tab><template slot="_header">First Tab</template>
         Content<br>Content<br>Content<br>Content
       </tab>
-      <tab header="Second Tab" class="algolia-no-index">
+      <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>
     <tabs>
-      <tab-group header="First Group">
-        <tab header="First Tab">
+      <tab-group><template slot="_header">First Group</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab header="Second Tab" class="algolia-no-index">
+        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab-group header="Second Group" class="algolia-no-index">
-        <tab header="First Tab">
+      <tab-group class="algolia-no-index"><template slot="_header">Second Group</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab header="Second Tab" class="algolia-no-index">
+        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
     </tabs>
     <tabs>
-      <tab-group header="Outer One">
-        <tab header="First Tab">
+      <tab-group><template slot="_header">Outer One</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
-        <tab header="Second Tab" class="algolia-no-index">
+        <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab header="Outer Two" class="algolia-no-index">
+      <tab><template slot="_header">Outer Two</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -34,14 +34,11 @@
         <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <div class="nav-link temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
+        <div class="nav-link temp-dropdown-placeholder"></div>
         <li slot="right">
           <form class="navbar-form">
             <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -34,14 +34,11 @@
         <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <div class="nav-link temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
+        <div class="nav-link temp-dropdown-placeholder"></div>
         <li slot="right">
           <form class="navbar-form">
             <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -34,14 +34,11 @@
         <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <div class="nav-link temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
+        <div class="nav-link temp-dropdown-placeholder"></div>
         <li slot="right">
           <form class="navbar-form">
             <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -34,14 +34,11 @@
         <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <div class="nav-link temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
+        <div class="nav-link temp-dropdown-placeholder"></div>
         <li slot="right">
           <form class="navbar-form">
             <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -34,14 +34,11 @@
         <a slot="brand" href="/index.html" title="Home" class="navbar-brand">Your Logo</a>
         <li><a href="/contents/topic1.html" class="nav-link">Topic 1</a></li>
         <li><a href="/contents/topic2.html" class="nav-link">Topic 2</a></li>
-        <div class="nav-link temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
-        <div class="nav-link temp-dropdown temp-dropdown-placeholder"></div>
         <dropdown class="nav-link temp-dropdown"><template slot="_header">Topic 3</template>
           <li><a href="/contents/topic3a.html" class="dropdown-item">Topic 3a</a></li>
           <li><a href="/contents/topic3b.html" class="dropdown-item">Topic 3b</a></li>
         </dropdown>
+        <div class="nav-link temp-dropdown-placeholder"></div>
         <li slot="right">
           <form class="navbar-form">
             <searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback" menu-align-right></searchbar>

--- a/packages/core/src/html/tempStyleProcessor.js
+++ b/packages/core/src/html/tempStyleProcessor.js
@@ -15,8 +15,8 @@ function insertTemporaryStyles(node) {
     // TODO remove attributes.text once text attribute is fully deprecated
     const placeholder = `<div>${attributes.header || attributes.text || ''}</div>`;
     const $dropdown = cheerio(node);
-    $dropdown.before(placeholder);
-    $dropdown.prev().addClass(attributes.class).addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
+    $dropdown.after(placeholder);
+    $dropdown.next().addClass(attributes.class).addClass(TEMP_DROPDOWN_PLACEHOLDER_CLASS);
     $dropdown.addClass(TEMP_DROPDOWN_CLASS);
   }
 }

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,10 +24,10 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    'popover div[slot=content]',
+    'span[data-mb-component-type="popover"] div[data-mb-slot-name="content"]',
     'question div[slot=hint]',
     'question div[slot=answer]',
-    'tab:not(:first-child)',
+    'tab:nth-of-type(n+2)',
     'tab-group:not(:first-child)',
   ].join(', ');
   $(noIndexSelectors).addClass('algolia-no-index');

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,10 +24,10 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    'span[data-mb-component-type="popover"] div[data-mb-slot-name="content"]',
+    'popover div[slot=content]',
     'question div[slot=hint]',
     'question div[slot=answer]',
-    'tab:nth-of-type(n+2)',
+    'tab:not(:first-child)',
     'tab-group:not(:first-child)',
   ].join(', ');
   $(noIndexSelectors).addClass('algolia-no-index');


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
This issue was discovered in #1464. And this fix is needed for #1464 to continue. 

Moved the dropdown temporary placeholder after the `<dropdown>` node itself. This is because having it before (as it is currently) would interfere with the processing of the nodes and it can be seen from the expected html file for `test_site_algolia_expected` that the nodes after dropdown are not processed properly. There are also a lot of duplicated `<div class="temp-dropdown-placeholder"></div>`. 

Moving the placeholder after would allow the nodes after `<dropdown>` to be processed properly and this also means that we will need to update the algolia selectors (which will be done in a separate PR).

**Anything you'd like to highlight / discuss:**
If the method of resolution is appropriate. 

**Testing instructions:**
`npm run test`

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix node-processing bug from dropdown temporary placeholder.

Inserting the dropdown temporary placeholder before the dropdown itself
introduces some node processing bug, where nodes (e.g. panel) are not
processed properly after dropdown. Furthermore, it generates a lot of
duplicated dropdown temporary placeholder. This issue can be seen from 
the test in `test_site_algolia_expected`. 

Let's insert the dropdown temporary placeholder after the dropdown node
to circumvent this problem. Having it after the dropdown node will ensure
that the node processing is executed in a normal / fixed processing order.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
