### PR TITLE
Fix algolia selectors for no-indexing

### DIFF
--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -56,10 +56,10 @@
       <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
     </span>
-    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content" class="algolia-no-index">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
-    <p><strong>Tooltip content should have algolia-no-index class</strong></p>
-    <span placement="top" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content" class="algolia-no-index">Content should have algolia-no-index class</span>
+    <p><strong>Tooltip content should not have algolia-no-index class</strong></p>
+    <span placement="top" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -52,14 +52,14 @@
       Content
     </panel>
     <p><strong>Popover content should have algolia-no-index class</strong></p>
-    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header" class="algolia-no-index">Title</span>
       <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
     </span>
-    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header" class="algolia-no-index">Title</span><span data-mb-slot-name="content" class="algolia-no-index">Content should have <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
-    <p><strong>Tooltip content should not have algolia-no-index class</strong></p>
-    <span placement="top" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+    <p><strong>Tooltip content should have algolia-no-index class</strong></p>
+    <span placement="top" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content" class="algolia-no-index">Content should have <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -53,7 +53,7 @@
     </panel>
     <p><strong>Popover content should have algolia-no-index class</strong></p>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span>
-      <div data-mb-slot-name="content">Content should have `algolia-no-index` class</div>
+      <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
     </span>
     <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
@@ -75,7 +75,7 @@
     </tabs>
     <tabs>
       <tab-group><template slot="_header">First Group</template>
-        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
@@ -83,7 +83,7 @@
         </tab>
       </tab-group>
       <tab-group class="algolia-no-index"><template slot="_header">Second Group</template>
-        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
@@ -93,14 +93,14 @@
     </tabs>
     <tabs>
       <tab-group><template slot="_header">Outer One</template>
-        <tab class="algolia-no-index"><template slot="_header">First Tab</template>
+        <tab><template slot="_header">First Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
         <tab class="algolia-no-index"><template slot="_header">Second Tab</template>
           Content<br>Content<br>Content<br>Content
         </tab>
       </tab-group>
-      <tab class="algolia-no-index"><template slot="_header">Outer Two</template>
+      <tab><template slot="_header">Outer Two</template>
         Content<br>Content<br>Content<br>Content
       </tab>
     </tabs>

--- a/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
+++ b/packages/cli/test/functional/test_site_algolia_plugin/expected/index.html
@@ -56,7 +56,10 @@
       <div data-mb-slot-name="content" class="algolia-no-index">Content should have `algolia-no-index` class</div>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
     </span>
-    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+    <span effect="fade" placement="top" data-mb-component-type="popover" v-b-popover.hover.top.html="popoverInnerGetters" class="trigger"><span data-mb-slot-name="header">Title</span><span data-mb-slot-name="content" class="algolia-no-index">Content as attribute does not require <code class="hljs inline no-lang" v-pre>algolia-no-index</code> class</span>
+      <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
+    <p><strong>Tooltip content should have algolia-no-index class</strong></p>
+    <span placement="top" data-mb-component-type="tooltip" v-b-tooltip.hover.top.html="tooltipInnerContentGetter" class="trigger"><span data-mb-slot-name="_content" class="algolia-no-index">Content should have algolia-no-index class</span>
       <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button></span>
     <p><strong>Question hint and answer should have algolia-no-index class</strong></p>
     <question>

--- a/packages/cli/test/functional/test_site_algolia_plugin/index.md
+++ b/packages/cli/test/functional/test_site_algolia_plugin/index.md
@@ -39,9 +39,9 @@
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
-**Tooltip content should have algolia-no-index class**
+**Tooltip content should not have algolia-no-index class**
 
-<tooltip content="Content should have algolia-no-index class" placement="top">
+<tooltip content="Content as attribute does not require `algolia-no-index` class" placement="top">
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </tooltip>
 

--- a/packages/cli/test/functional/test_site_algolia_plugin/index.md
+++ b/packages/cli/test/functional/test_site_algolia_plugin/index.md
@@ -39,6 +39,12 @@
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
+**Tooltip content should have algolia-no-index class**
+
+<tooltip content="Content should have algolia-no-index class" placement="top">
+  <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
+</tooltip>
+
 **Question hint and answer should have algolia-no-index class**
 
 <question>

--- a/packages/cli/test/functional/test_site_algolia_plugin/index.md
+++ b/packages/cli/test/functional/test_site_algolia_plugin/index.md
@@ -35,13 +35,13 @@
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
-<popover effect="fade" header="Title" content="Content as attribute does not require `algolia-no-index` class" placement="top">
+<popover effect="fade" header="Title" content="Content should have `algolia-no-index` class" placement="top">
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </popover>
 
-**Tooltip content should not have algolia-no-index class**
+**Tooltip content should have algolia-no-index class**
 
-<tooltip content="Content as attribute does not require `algolia-no-index` class" placement="top">
+<tooltip content="Content should have `algolia-no-index` class" placement="top">
   <button class="btn btn-secondary">Trigger should not have `algolia-no-index` class</button>
 </tooltip>
 

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,8 +24,7 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    // to target popover and tooltips
-    '[data-mb-component-type] [data-mb-slot-name="content"], [data-mb-slot-name="_content"]',
+    '[data-mb-component-type] :not(span)[data-mb-slot-name]',
     'question div[slot=hint]',
     'question div[slot=answer]',
     'tab:nth-of-type(n+2)',

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,7 +24,8 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    '[data-mb-component-type] :not(span)[data-mb-slot-name]',
+    // to target both popover and tooltip
+    '[data-mb-component-type] [data-mb-slot-name]',
     'question div[slot=hint]',
     'question div[slot=answer]',
     'tab:nth-of-type(n+2)',

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -28,7 +28,7 @@ function addNoIndexClasses(content) {
     'question div[slot=hint]',
     'question div[slot=answer]',
     'tab:nth-of-type(n+2)',
-    'tab-group:not(:first-child)',
+    'tab-group:nth-of-type(n+2)',
   ].join(', ');
   $(noIndexSelectors).addClass('algolia-no-index');
   return $.html();

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,10 +24,10 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    'popover div[slot=content]',
+    'span[data-mb-component-type="popover"] div[data-mb-slot-name="content"]',
     'question div[slot=hint]',
     'question div[slot=answer]',
-    'tab:not(:first-child)',
+    'tab:nth-of-type(n+2)',
     'tab-group:not(:first-child)',
   ].join(', ');
   $(noIndexSelectors).addClass('algolia-no-index');

--- a/packages/core/src/plugins/algolia.js
+++ b/packages/core/src/plugins/algolia.js
@@ -24,7 +24,8 @@ function addNoIndexClasses(content) {
     'dropdown',
     'b-modal',
     'panel:not([expanded])',
-    'span[data-mb-component-type="popover"] div[data-mb-slot-name="content"]',
+    // to target popover and tooltips
+    '[data-mb-component-type] [data-mb-slot-name="content"], [data-mb-slot-name="_content"]',
     'question div[slot=hint]',
     'question div[slot=answer]',
     'tab:nth-of-type(n+2)',


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

This PR fixes the erroneous algolia selectors after the PR fix from #1467. 

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Updated the algolia selectors to correctly select elements to add `algolia-no-index`.

**Anything you'd like to highlight / discuss:**
If there would be other selectors that need to be fixed in algolia. 

**Testing instructions:**
`npm run test`

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix algolia selectors for no-indexing. 

The algolia selectors are not selecting the correct elements to insert
the `algolia-no-index` class to exclude the element from indexing. 

Let's fix the algolia selectors by updating them to select the correct
elements.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
