### PR TITLE
Restyle minimal panel header to full opacity

### DIFF
--- a/packages/vue-components/src/panels/MinimalPanel.vue
+++ b/packages/vue-components/src/panels/MinimalPanel.vue
@@ -159,7 +159,6 @@ export default {
 
   .morph-title {
     padding: 0 0.3em;
-    color: black;
     border-color: black;
     background-color: transparent;
     vertical-align: top;
@@ -181,10 +180,6 @@ export default {
     flex-direction: column;
     border: 0;
     margin: 0;
-  }
-
-  .card-title {
-    color: black;
   }
 
   .header-fade-enter {

--- a/packages/vue-components/src/panels/MinimalPanel.vue
+++ b/packages/vue-components/src/panels/MinimalPanel.vue
@@ -17,7 +17,7 @@
           <span
             v-show="!isHeaderAtBottom"
             ref="headerWrapper"
-            :class="['card-title', 'card-title-transparent', { 'ellipses': !hasHeaderBool }]"
+            :class="['card-title', { 'ellipses': !hasHeaderBool }]"
           >
             <span class="card-title-inline"><slot name="header"></slot></span>
             <span
@@ -159,14 +159,13 @@ export default {
 
   .morph-title {
     padding: 0 0.3em;
-    color: rgba(0, 0, 0, 0.5);
+    color: black;
     border-color: rgba(0, 0, 0, 0.5);
     background-color: transparent;
     vertical-align: top;
   }
 
   .morph-title:hover, .morph-title:active, .morph-title:focus {
-    color: black;
     border-color: black;
     background-color: rgba(244, 244, 244, 0.3);
   }
@@ -183,13 +182,8 @@ export default {
     margin: 0;
   }
 
-  .card-title-transparent {
-    opacity: 0.5;
-    transition: opacity 0.5s;
-  }
-
-  .card:hover .card-title-transparent {
-    opacity: 1;
+  .card-title {
+    color: black;
   }
 
   .header-fade-enter {

--- a/packages/vue-components/src/panels/MinimalPanel.vue
+++ b/packages/vue-components/src/panels/MinimalPanel.vue
@@ -160,14 +160,15 @@ export default {
   .morph-title {
     padding: 0 0.3em;
     color: black;
-    border-color: rgba(0, 0, 0, 0.5);
+    border-color: black;
     background-color: transparent;
     vertical-align: top;
   }
 
   .morph-title:hover, .morph-title:active, .morph-title:focus {
-    border-color: black;
-    background-color: rgba(244, 244, 244, 0.3);
+    color: white;
+    border-color: #343a40;
+    background-color: #343a40;
   }
 
   .card-collapse {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Feature addition or enhancement

Resolves #1273 

**Overview of changes:**
- Removed the 50% opacity styling of the panel header during collapsed and minimized states.
- As the heading is now not dimmed, there is no need for the dim-to-full hover transition, so I also removed it.

**Anything you'd like to highlight / discuss:**
- Originally I thought to keep the existing dim-to-full hover transition for the case when the user explicitly wants the header to be dim, but as discussed in the issue comments, there may be extra work needed in achieving that, such as the user has to specify dim header through a new panel attribute rather than the usual `%%` for text, which may be a bit unnatural. So, I decided to scrap it. I have no preference though so if you think we should keep it do let me know. @ang-zeyu 

**Testing instructions:**
Test with `-d` flag.

**Proposed commit message: (wrap lines at 72 characters)**
Restyle minimal panel header to full opacity

---

**Checklist:** :ballot_box_with_check:

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
