### PR TITLE
Toggle fixed header on scroll

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -52,7 +52,7 @@ function detectAndApplyFixedHeaderStyles() {
       }`);
   insertCss(`.nav-menu-open { max-height: calc(100% - ${headerHeight}px); }`);
 
-  const resizeHeader = () => {
+  const adjustHeaderClasses = () => {
     const newHeaderHeight = headerSelector.height();
     const sheets = document.styleSheets;
     for (let i = 0; i < sheets.length; i += 1) {
@@ -83,23 +83,12 @@ function detectAndApplyFixedHeaderStyles() {
 
   const toggleHeaderOverflow = () => {
     const headerMaxHeight = headerSelector.css('max-height');
+    // reset overflow when header shows again to allow content
+    // in the header such as search dropdown etc. to overflow
     if (headerMaxHeight === '100%') {
       headerSelector.css('overflow', '');
-      resizeHeader();
+      adjustHeaderClasses();
     }
-  };
-
-  const addResizeHeaderListener = () => {
-    const resizeObserver = new ResizeObserver(() => {
-      const headerMaxHeight = headerSelector.css('max-height');
-      // set overflow to hidden if max-height is not 100%
-      if (headerMaxHeight !== '100%') {
-        headerSelector.css('overflow', 'hidden');
-        return;
-      }
-      resizeHeader();
-    });
-    resizeObserver.observe(headerSelector[0]);
   };
 
   let lastOffset = 0;
@@ -118,7 +107,16 @@ function detectAndApplyFixedHeaderStyles() {
     lastOffset = currentOffset;
   };
 
-  addResizeHeaderListener();
+  const resizeObserver = new ResizeObserver(() => {
+    const headerMaxHeight = headerSelector.css('max-height');
+    // hide header overflow when user scrolls to support transition effect
+    if (headerMaxHeight !== '100%') {
+      headerSelector.css('overflow', 'hidden');
+      return;
+    }
+    adjustHeaderClasses();
+  });
+  resizeObserver.observe(headerSelector[0]);
   headerSelector[0].addEventListener('transitionend', toggleHeaderOverflow);
   window.addEventListener('scroll', toggleHeaderOnScroll);
 }

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -52,34 +52,54 @@ function detectAndApplyFixedHeaderStyles() {
       }`);
   insertCss(`.nav-menu-open { max-height: calc(100% - ${headerHeight}px); }`);
 
-  const addResizeHeaderListener = () => {
-    const resizeObserver = new ResizeObserver(() => {
-      const newHeaderHeight = headerSelector.height();
-      const sheets = document.styleSheets;
-      for (let i = 0; i < sheets.length; i += 1) {
-        const rules = sheets[i].cssRules;
-        // eslint-disable-next-line lodash/prefer-get
-        if (rules && rules[0] && rules[0].selectorText) {
-          switch (rules[0].selectorText) {
-          case '.fixed-header-padding':
-            sheets[i].deleteRule(0);
-            sheets[i].insertRule(`.fixed-header-padding { padding-top: ${newHeaderHeight}px !important }`);
-            break;
-          case 'span.anchor':
-            rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-            break;
-          case 'span.card-container::before':
-            rules[0].style.marginTop = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-            rules[0].style.height = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
-            break;
-          case '.nav-menu-open':
-            rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;
-            break;
-          default:
-            break;
-          }
+  const resizeHeader = () => {
+    const newHeaderHeight = headerSelector.height();
+    const sheets = document.styleSheets;
+    for (let i = 0; i < sheets.length; i += 1) {
+      const rules = sheets[i].cssRules;
+      // eslint-disable-next-line lodash/prefer-get
+      if (rules && rules[0] && rules[0].selectorText) {
+        switch (rules[0].selectorText) {
+        case '.fixed-header-padding':
+          sheets[i].deleteRule(0);
+          sheets[i].insertRule(`.fixed-header-padding { padding-top: ${newHeaderHeight}px !important }`);
+          break;
+        case 'span.anchor':
+          rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
+          break;
+        case 'span.card-container::before':
+          rules[0].style.marginTop = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
+          rules[0].style.height = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
+          break;
+        case '.nav-menu-open':
+          rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;
+          break;
+        default:
+          break;
         }
       }
+    }
+  };
+
+  const toggleHeaderOverflow = () => {
+    const headerMaxHeight = headerSelector.css('max-height');
+    if (headerMaxHeight === '100%') {
+      headerSelector.css('overflow', '');
+      resizeHeader();
+    }
+  };
+
+  const addResizeHeaderListener = () => {
+    const resizeObserver = new ResizeObserver(() => {
+      const headerMaxHeight = headerSelector.css('max-height');
+      // set overflow to hidden if max-height is not 100%
+      if (headerMaxHeight !== '100%') {
+        headerSelector.css('overflow', 'hidden');
+        // re-check after 0.6s to account for transition time
+        setTimeout(toggleHeaderOverflow, 600);
+        return;
+      }
+      resizeHeader();
     });
     resizeObserver.observe(headerSelector[0]);
   };

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -86,9 +86,12 @@ function detectAndApplyFixedHeaderStyles() {
 
   let lastOffset = 0;
   const toggleHeaderOnScroll = () => {
+    // prevent toggling of header on desktop site
     if (window.innerWidth > 767) { return; }
     const currentOffset = window.pageYOffset;
-    if ((window.innerHeight + currentOffset) >= document.body.offsetHeight) { return; }
+    const isEndOfPage = (window.innerHeight + currentOffset) >= document.body.offsetHeight;
+    // to prevent page from auto scrolling when header is toggled at the end of page
+    if (isEndOfPage) { return; }
     if (currentOffset > lastOffset) {
       headerSelector.addClass('hide-header');
     } else {

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -83,7 +83,20 @@ function detectAndApplyFixedHeaderStyles() {
     });
     resizeObserver.observe(headerSelector[0]);
   };
+
+  let lastOffset = 0;
+  const toggleHeaderOnScroll = () => {
+    const currentOffset = window.pageYOffset;
+    if (currentOffset > lastOffset) {
+      headerSelector.addClass('hide-header');
+    } else {
+      headerSelector.removeClass('hide-header');
+    }
+    lastOffset = currentOffset;
+  };
+
   addResizeHeaderListener();
+  setTimeout(() => window.addEventListener('scroll', toggleHeaderOnScroll), 500);
 }
 
 function updateSearchData(vm) {

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -95,8 +95,6 @@ function detectAndApplyFixedHeaderStyles() {
       // set overflow to hidden if max-height is not 100%
       if (headerMaxHeight !== '100%') {
         headerSelector.css('overflow', 'hidden');
-        // re-check after 0.6s to account for transition time
-        setTimeout(toggleHeaderOverflow, 600);
         return;
       }
       resizeHeader();
@@ -121,6 +119,7 @@ function detectAndApplyFixedHeaderStyles() {
   };
 
   addResizeHeaderListener();
+  headerSelector[0].addEventListener('transitionend', toggleHeaderOverflow);
   window.addEventListener('scroll', toggleHeaderOnScroll);
 }
 

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -86,7 +86,9 @@ function detectAndApplyFixedHeaderStyles() {
 
   let lastOffset = 0;
   const toggleHeaderOnScroll = () => {
+    if (window.innerWidth > 767) { return; }
     const currentOffset = window.pageYOffset;
+    if ((window.innerHeight + currentOffset) >= document.body.offsetHeight) { return; }
     if (currentOffset > lastOffset) {
       headerSelector.addClass('hide-header');
     } else {
@@ -96,7 +98,7 @@ function detectAndApplyFixedHeaderStyles() {
   };
 
   addResizeHeaderListener();
-  setTimeout(() => window.addEventListener('scroll', toggleHeaderOnScroll), 500);
+  window.addEventListener('scroll', toggleHeaderOnScroll);
 }
 
 function updateSearchData(vm) {

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -119,7 +119,6 @@ code.hljs.inline {
 
 header[fixed] {
     max-height: 100%;
-    overflow: hidden;
     position: fixed;
     transition: max-height 0.6s ease-in;
     width: 100%;

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -123,6 +123,11 @@ header[fixed] {
     z-index: 1001;
 }
 
+header[fixed].hide-header {
+    height: 0;
+    overflow: hidden;
+}
+
 /* #app is treated as the main container */
 #app {
     display: flex;

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -118,14 +118,17 @@ code.hljs.inline {
 /* Header */
 
 header[fixed] {
+    max-height: 100%;
+    overflow: hidden;
     position: fixed;
+    transition: max-height 0.6s ease-in;
     width: 100%;
     z-index: 1001;
 }
 
 header[fixed].hide-header {
-    height: 0;
-    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.6s ease-out;
 }
 
 /* #app is treated as the main container */

--- a/packages/vue-components/src/Overlay.vue
+++ b/packages/vue-components/src/Overlay.vue
@@ -59,6 +59,7 @@ export default {
     toggleNavMenu() {
       if (!this.show) {
         publish('closeOverlay');
+        // to prevent scrolling of the body when overlay is overscrolled
         document.body.style.overflow = 'hidden';
       } else {
         document.body.style.removeProperty('overflow');

--- a/packages/vue-components/src/Overlay.vue
+++ b/packages/vue-components/src/Overlay.vue
@@ -57,7 +57,12 @@ export default {
   },
   methods: {
     toggleNavMenu() {
-      if (!this.show) { publish('closeOverlay'); }
+      if (!this.show) {
+        publish('closeOverlay');
+        document.body.style.overflow = 'hidden';
+      } else {
+        document.body.style.removeProperty('overflow');
+      }
       this.show = !this.show;
     },
     navMenuLoaded() {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #980.

As discussed, fixed header might take up too much space especially on devices with smaller screen, leaving less space for content. A workaround is to hide the fixed header when scrolling down to give more space to content. Header can still be easily accessed by scrolling up.

**Anything you'd like to highlight / discuss:**
Should the header hide on both mobile and desktop version when scrolling down? Since this issue affect mainly mobile users, we can continue to fixed the header for desktop version so the header does not need to be hidden there. The current implementation works on both versions.

**Testing instructions:**
`npm run test`
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Implement fixed header toggling on scroll
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
