### PR TITLE
Fix formatting errors in user guide

### DIFF
--- a/docs/userGuide/components/advanced.md
+++ b/docs/userGuide/components/advanced.md
@@ -65,13 +65,13 @@ However, we **$$do not recommend$$** using this syntax as it is deprecated and w
 <trigger for="modal:tip-example" trigger="click">Click here to show Modal.</trigger>
 
 <modal id="modal:tip-example">
-  <div slot="header" class="modal-title text-center">
+  <span slot="header" class="modal-title text-center">
     <span style="font-size:20pt"><span style="color:red;">BIG</span> header</span>
-  </div>
+  </span>
     Modal allows you to style both header and footer individually, with style classes and inline styles.
-  <div slot="footer" class="text-center">
+  <span slot="footer" class="text-center">
     <span style="font-size:10pt">Tiny <span style="color:green;">footer</span></span>
-  </div>
+  </span>
 </modal>
 </variable>
 <variable name="highlightStyle">html</variable>

--- a/docs/userGuide/syntax/code.mbdf
+++ b/docs/userGuide/syntax/code.mbdf
@@ -22,7 +22,6 @@ To enable syntax coloring, specify a language next to the backticks before the f
 <div id="main-example">
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```xml
 <foo>
   <bar type="name">goo</bar>
@@ -37,7 +36,6 @@ Line numbers are provided by default. To hide line numbers, add the class `no-li
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```xml {.no-line-numbers}
 <foo>
   <bar type="name">goo</bar>
@@ -50,7 +48,6 @@ You can have your line numbers start with a value other than `1` with the `start
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```js {start-from=6}
 function add(a, b) {
     return a + b;
@@ -82,7 +79,6 @@ For ranges, you only need to use line-slices on either ends.
 <include src="codeAndOutputCode.md" boilerplate >
 
 <variable name="code">
-
 ```java {highlight-lines="1,3[:],6-8,10[:]-12"}
 import java.util.List;
 
@@ -108,7 +104,6 @@ To add a heading, add the attribute `heading` with the heading text as the value
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```xml {heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>
@@ -121,7 +116,6 @@ Headings support inline Markdown, except for `Inline Code` and %%Dim%% text styl
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```{heading="**Bold**, _Italic_, ___Bold and Italic___, ~~Strike through~~, ****Super Bold****, $$Underline$$, ==Highlight==, :+1: :exclamation: :x: :construction:<br>We support page breaks"}
 <foo></foo>
 ```
@@ -133,7 +127,6 @@ You can also use multiple features together, as shown below.
 
 <include src="codeAndOutputCode.md" boilerplate >
 <variable name="code">
-
 ```xml {highlight-lines="2" heading="Heading title"}
 <foo>
   <bar type="name">goo</bar>

--- a/docs/userGuide/syntax/lists.mbdf
+++ b/docs/userGuide/syntax/lists.mbdf
@@ -74,7 +74,7 @@ first number
 
 
 ****Radio-button lists:****
-<span id="main-example-markbind">
+<div id="main-example-markbind">
 <include src="codeAndOutput.md" boilerplate >
 <variable name="highlightStyle">markdown</variable>
 <variable name="code">
@@ -83,7 +83,7 @@ first number
 - (x) Item 3
 </variable>
 </include>
-</span>
+</div>
 
 <span id="short" class="d-none">
 

--- a/docs/userGuide/syntax/questions.mbdf
+++ b/docs/userGuide/syntax/questions.mbdf
@@ -229,11 +229,11 @@ If no keywords are provided, the answer will always be marked as correct when pl
 Keywords are validated by simply looking for the keyword as a pattern in the user's answer!
 This works well for some
 <popover header="When does validation work?">cases
-  <div slot="content">
+  <span slot="content">
   When the keywords specified are rather long (eg. `requirements`), it reduces the chance that this keyword can be mistakenly validated.
   <br><br>
   In contrast, something short and common like `take` which can easily be part of another word (eg. `mis-take-nly`) would be mistakenly validated.
-  </div>
+  </span>
 </popover>
 and not others.
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Some of the tags / newlines in the user guide don't observe markdown rules following the implicit fixes in #1403 , and elsewhere

Causing things like this:
![Untitled](https://user-images.githubusercontent.com/3306138/107841201-d13f5000-6df3-11eb-9551-318bb5fb862c.png)


**Overview of changes:**
- change some inline tags to 'block' markdown tags and vice versa
  - changes to inline tags are due to the parent tag not being able to hold 'block' tags
  - changes to block tags (just one) as the parent tag should be able to hold other 'block' tags
- remove some newlines

so everything renders properly

**Anything you'd like to highlight / discuss:**


**Testing instructions:**

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix formatting errors in user guide

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
