### PR TITLE
Show all tabs when printing

### DIFF
--- a/packages/vue-components/src/Tab.vue
+++ b/packages/vue-components/src/Tab.vue
@@ -3,13 +3,13 @@
     <div
       v-show="show"
       role="tabpanel"
-      class="tab-pane active"
+      class="tab-pane active printable-tab-pane"
       :class="{hide:!show}"
     >
-      <slot></slot>
-      <div ref="header" class="d-none">
+      <div ref="header" class="d-none printable-tab-header">
         <slot name="_header"></slot>
       </div>
+      <slot></slot>
       <hr />
     </div>
   </transition>
@@ -93,5 +93,18 @@ export default {
 
     .fade-leave-active {
         transition: opacity 0s;
+    }
+
+    @media print {
+        .printable-tab-header {
+            display: block !important;
+            margin: 10px 0;
+            font-weight: 600;
+            font-size: 1.5rem;
+        }
+
+        .printable-tab-pane {
+            display: block !important;
+        }
     }
 </style>

--- a/packages/vue-components/src/Tab.vue
+++ b/packages/vue-components/src/Tab.vue
@@ -3,13 +3,18 @@
     <div
       v-show="show"
       role="tabpanel"
-      class="tab-pane active printable-tab-pane"
+      class="tab-pane active printable-tab-pane d-print-block"
       :class="{hide:!show}"
     >
-      <div ref="header" class="d-none printable-tab-header">
-        <slot name="_header"></slot>
+      <div class="nav-tabs printable-tab-header d-none d-print-flex">
+        <div class="nav-link active">
+          <span><slot name="_header"></slot></span>
+        </div>
       </div>
       <slot></slot>
+      <div ref="header" class="d-none">
+        <slot name="_header"></slot>
+      </div>
       <hr />
     </div>
   </transition>
@@ -97,14 +102,15 @@ export default {
 
     @media print {
         .printable-tab-header {
-            display: block !important;
-            margin: 10px 0;
-            font-weight: 600;
-            font-size: 1.3rem;
+            margin-bottom: 15px;
+            border-bottom: 1px solid #dee2e6;
+        }
+
+        .printable-tab-header > div {
+            margin-bottom: -2px;
         }
 
         .printable-tab-pane {
-            display: block !important;
             padding: 10px;
         }
     }

--- a/packages/vue-components/src/Tab.vue
+++ b/packages/vue-components/src/Tab.vue
@@ -100,11 +100,12 @@ export default {
             display: block !important;
             margin: 10px 0;
             font-weight: 600;
-            font-size: 1.5rem;
+            font-size: 1.3rem;
         }
 
         .printable-tab-pane {
             display: block !important;
+            padding: 10px;
         }
     }
 </style>

--- a/packages/vue-components/src/Tab.vue
+++ b/packages/vue-components/src/Tab.vue
@@ -7,14 +7,11 @@
       :class="{hide:!show}"
     >
       <div class="nav-tabs printable-tab-header d-none d-print-flex">
-        <div class="nav-link active">
-          <span><slot name="_header"></slot></span>
+        <div ref="header" class="nav-link active">
+          <slot name="_header"></slot>
         </div>
       </div>
       <slot></slot>
-      <div ref="header" class="d-none">
-        <slot name="_header"></slot>
-      </div>
       <hr />
     </div>
   </transition>

--- a/packages/vue-components/src/TabGroup.vue
+++ b/packages/vue-components/src/TabGroup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="printable-tab-group">
-    <div ref="header" class="d-none printable-tab-group-header">
+    <div ref="header" class="printable-tab-group-header d-none d-print-block">
       <slot name="_header"></slot>
     </div>
     <slot></slot>
@@ -81,8 +81,7 @@ export default {
         }
 
         .printable-tab-group-header {
-            display: block !important;
-            font-size: 1.3rem;
+            margin-bottom: 10px;
             text-decoration: underline;
         }
     }

--- a/packages/vue-components/src/TabGroup.vue
+++ b/packages/vue-components/src/TabGroup.vue
@@ -1,9 +1,9 @@
 <template>
-  <div>
-    <slot></slot>
-    <div ref="header" class="d-none">
+  <div class="printable-tab-group">
+    <div ref="header" class="d-none printable-tab-group-header">
       <slot name="_header"></slot>
     </div>
+    <slot></slot>
   </div>
 </template>
 
@@ -70,5 +70,20 @@ export default {
 <style scoped>
     .nav-tabs {
         margin-bottom: 15px;
+    }
+
+    @media print {
+        .printable-tab-group {
+            border: 1px solid #dee2e6;
+            border-radius: 5px;
+            padding: 10px;
+            margin: 10px 0;
+        }
+
+        .printable-tab-group-header {
+            display: block !important;
+            font-size: 1.3rem;
+            text-decoration: underline;
+        }
     }
 </style>

--- a/packages/vue-components/src/Tabset.vue
+++ b/packages/vue-components/src/Tabset.vue
@@ -2,7 +2,7 @@
   <div :class="[addClass]">
     <!-- Nav tabs -->
     <ul
-      class="nav nav-tabs"
+      class="nav nav-tabs no-print"
       :class="getNavStyleClass"
       role="tablist"
     >
@@ -106,5 +106,11 @@ export default {
 <style scoped>
     .nav-tabs {
         margin-bottom: 15px;
+    }
+
+    @media print {
+        .no-print {
+            display: none;
+        }
     }
 </style>

--- a/packages/vue-components/src/Tabset.vue
+++ b/packages/vue-components/src/Tabset.vue
@@ -1,8 +1,8 @@
 <template>
-  <div :class="[addClass]">
+  <div :class="[addClass, 'printable-tabs']">
     <!-- Nav tabs -->
     <ul
-      class="nav nav-tabs no-print"
+      class="nav nav-tabs d-print-none"
       :class="getNavStyleClass"
       role="tablist"
     >
@@ -109,8 +109,10 @@ export default {
     }
 
     @media print {
-        .no-print {
-            display: none;
+        .printable-tabs {
+            border: 1px solid #dee2e6;
+            border-radius: 5px;
+            padding: 20px;
         }
     }
 </style>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #1491. 

1. Show all the content and display the header of the tabs when printing. 
2. Tabs in `tab-group` will be grouped together. 
3. The tab navigation is hidden when printing to prevent repetition as the header is already added to the top of each section.

**Anything you'd like to highlight / discuss:**
1. Should disabled tabs be printed as well? The current implementation will print out all tabs regardless of whether they are disabled or not. 
2. Is the current format of the `tab-group` fine? Do let me know if this can be improved on.

**Testing instructions:**
1. Create a few `tabs` and `tab-group`
```
<tabs>
  <tab header="First tab">
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ullamcorper ultrices lobortis.
  </tab>
  <tab header="Second tab">
    Some content of the second tab...
  </tab>
  <tab header="Third tab">
    Additional content from third tab...
  </tab>
  <tab-group header="Example Tab Group">
    <tab header="Tab Group 1">
      Some content in a tab group 1...
    </tab>
    <tab header="Tab Group 2">
      Some content in a tab group 2...
    </tab>
  </tab-group>
</tabs>
```
2. Print the page
3. All tabs should be shown in the preview

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Support printing of all tabs

Tabs are supposed to contain alternative contents. 
Readers can click on each tab to see its content. However, 
when a page is printed or converted to PDF, the reader can 
only see the content of the active tab.

Let's display all the tabs and its content when it is printed.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
