### PR TITLE
Implement live preview for pages in site.json

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -18,6 +18,7 @@ const {
   INDEX_MARKDOWN_FILE,
   INDEX_MARKBIND_FILE,
   LAZY_LOADING_SITE_FILE_NAME,
+  SITE_CONFIG_NAME,
 } = require('@markbind/core/src/Site/constants');
 
 const cliUtil = require('./src/util/cliUtil');
@@ -152,8 +153,8 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (filePath.replace(/^.*[\\\/]/, '') === "site.json") {
-          return site.reloadSiteConfig();
+        if (filePath.replace(/^.*[\\\/]/, '') === SITE_CONFIG_NAME) {
+          return site.reloadSiteConfig(filePath);
         }
         if (site.isDependencyOfPage(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -152,6 +152,9 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
+        if (filePath.replace(/^.*[\\\/]/, '') === "site.json") {
+          return site.reloadSiteConfig();
+        }
         if (site.isDependencyOfPage(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);
         }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -153,7 +153,7 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (filePath.replace(/^.*[\\\/]/, '') === SITE_CONFIG_NAME) {
+        if (filePath.replace(/^.*[\\/]/, '') === SITE_CONFIG_NAME) {
           return site.reloadSiteConfig(filePath);
         }
         if (site.isDependencyOfPage(filePath)) {

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -154,7 +154,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
         if (filePath.replace(/^.*[\\/]/, '') === SITE_CONFIG_NAME) {
-          return site.reloadSiteConfig(filePath);
+          return site.reloadSiteConfig();
         }
         if (site.isDependencyOfPage(filePath)) {
           return site.rebuildAffectedSourceFiles(filePath);

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -153,7 +153,7 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       Promise.resolve('').then(() => {
-        if (filePath.replace(/^.*[\\/]/, '') === SITE_CONFIG_NAME) {
+        if (path.basename(filePath) === SITE_CONFIG_NAME) {
           return site.reloadSiteConfig();
         }
         if (site.isDependencyOfPage(filePath)) {

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -816,6 +816,11 @@ class Site {
     }
   }
 
+  async reloadSiteConfig() {
+    await this.readSiteConfig();
+    await this._rebuildSourceFiles();
+  }
+
   /**
    * Checks if a specified file path is a dependency of a page
    * @param {string} filePath file path to check

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -34,6 +34,7 @@ _.difference = require('lodash/difference');
 _.flatMap = require('lodash/flatMap');
 _.has = require('lodash/has');
 _.isBoolean = require('lodash/isBoolean');
+_.isEqual = require('lodash/isEqual');
 _.isUndefined = require('lodash/isUndefined');
 _.noop = require('lodash/noop');
 _.omitBy = require('lodash/omitBy');
@@ -817,8 +818,12 @@ class Site {
   }
 
   async reloadSiteConfig() {
+    const oldSiteConfig = this.siteConfig;
     await this.readSiteConfig();
-    await this._rebuildSourceFiles();
+    if (!_.isEqual(oldSiteConfig.pages, this.siteConfig.pages)) {
+      await this.rebuildSourceFiles();
+      await this.writeSiteData();
+    }
   }
 
   /**

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -918,9 +918,9 @@ class Site {
   }
 
   /**
-   * Creates and returns a new page with the given page config details and favicon url
-   * @param {*} page config
-   * @param {*} faviconUrl of the page
+   * Creates and returns a new Page with the given page config details and favicon url
+   * @param {Page} page config
+   * @param {String} faviconUrl of the page
    */
   createNewPage(page, faviconUrl) {
     return this.createPage({

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -827,9 +827,6 @@ class Site {
     // Get pages with edited attributes but with the same src
     const editedPages = _.differenceWith(this.addressablePages, oldAddressablePages, (newPage, oldPage) => {
       if (!_.isEqual(newPage, oldPage)) {
-        if (newPage.glob) {
-          return !oldPagesSrc.includes(newPage.glob);
-        }
         return !oldPagesSrc.includes(newPage.src);
       }
       return true;

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -851,7 +851,7 @@ class Site {
   }
 
   /**
-   * Updates the pageConfig of the pages that have been edited
+   * Creates new pages and replaces the original pages with the updated version
    */
   updatePages(pagesToUpdate) {
     pagesToUpdate.forEach((pageToUpdate) => {

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -839,8 +839,10 @@ class Site {
     const isNewPage = (newPage, oldPage) => _.isEqual(newPage, oldPage) || newPage.src === oldPage.src;
 
     const addedPages = _.differenceWith(this.addressablePages, oldAddressablePages, isNewPage);
-    const removedPages = _.differenceWith(oldAddressablePages, this.addressablePages, isNewPage);
+    const removedPages = _.differenceWith(oldAddressablePages, this.addressablePages, isNewPage)
+      .map(filePath => Site.setExtension(filePath.src, '.html'));
     if (!_.isEmpty(addedPages) || !_.isEmpty(removedPages)) {
+      await this.removeAsset(removedPages);
       await this.rebuildSourceFiles();
       await this.writeSiteData();
     } else {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Addresses part of #48.

This PR intends to support live preview for the `pages` property in `site.json`. When `site.json` is edited, `reloadSiteConfig` function will read in the new values and check for changes in `pages`. If there is added/removed pages, all pages will be rebuilt. This implementation is similar to setting the glob to track all `.md` and `.mbd` files in `pages` (`"glob": ["**/index.md", "**/*.+(md|mbd)"]`). If new pages are added/removed, all pages will be rebuilt in the [`addHandler`](https://github.com/MarkBind/markbind/blob/master/packages/cli/index.js#L144).

If the attributes of a page are edited, then only that specific page/pages dependent on this will be rebuilt. For example, if the `"title"` of a page at `contents/index.md` is changed, then only `contents/index.html` will be regenerated. The rest of the pages will not be rebuilt.

**Anything you'd like to highlight / discuss:**
Current implementation will rebuild all pages when there is a change in `pages`. ~Not sure if I should only 'watch' for added/removed pages and then only update the relevant pages that will be affected.~ 

EDIT: After looking around at the other handlers ([`addHandler`](https://github.com/MarkBind/markbind/blob/master/packages/cli/index.js#L140) and [`removeHandler`](https://github.com/MarkBind/markbind/blob/master/packages/cli/index.js#L164)), it seems all pages should be rebuilt if the added/removed file is a page/dependency of page.

**Testing instructions:**
1. Serve a MarkBind site using `markbind serve`
2. Open and edit the `pages` property in `site.json`
3. Live preview should be updated to reflect he latest changes

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Implement live preview for pages in site.json

When pages are added or removed from site.json, the respective 
generated pages are not built or removed from the live preview. 
Similarly, edited pages attributes are not reflected as well. A server 
reboot is necessary to display the new changes.

Let's support live preview for pages in site.json so that the user 
does not have to restart the server each time the pages property 
is edited.
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
