### PR TITLE
Lazy serve: fix untracked tab bug on backwards navigation

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -140,11 +140,9 @@ program
 
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
-      if (onePagePath) {
-        logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-        site.changeCurrentOpenedPages(normalizedActiveUrls);
-      }
+      logger.info('Synchronizing opened pages list before reload');
+      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);
@@ -157,11 +155,9 @@ program
 
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
-      if (onePagePath) {
-        logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-        site.changeCurrentOpenedPages(normalizedActiveUrls);
-      }
+      logger.info('Synchronizing opened pages list before reload');
+      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (path.basename(filePath) === SITE_CONFIG_NAME) {
           return site.reloadSiteConfig();
@@ -177,11 +173,9 @@ program
 
     const removeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
-      if (onePagePath) {
-        logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-        site.changeCurrentOpenedPages(normalizedActiveUrls);
-      }
+      logger.info('Synchronizing opened pages list before reload');
+      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -142,10 +142,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
-          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
-          return fsUtil.removeExtension(completeUrl);
-        });
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {
@@ -162,10 +159,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
-          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
-          return fsUtil.removeExtension(completeUrl);
-        });
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {
@@ -185,10 +179,7 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
-          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
-          return fsUtil.removeExtension(completeUrl);
-        });
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -142,7 +142,10 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+          return fsUtil.removeExtension(completeUrl);
+        });
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {
@@ -159,7 +162,10 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+          return fsUtil.removeExtension(completeUrl);
+        });
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {
@@ -179,7 +185,10 @@ program
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       if (onePagePath) {
         logger.info('Synchronizing opened pages list before reload');
-        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+          const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+          return fsUtil.removeExtension(completeUrl);
+        });
         site.changeCurrentOpenedPages(normalizedActiveUrls);
       }
       Promise.resolve('').then(() => {

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -140,9 +140,11 @@ program
 
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
-      logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-      site.changeCurrentOpenedPages(normalizedActiveUrls);
+      if (onePagePath) {
+        logger.info('Synchronizing opened pages list before reload');
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        site.changeCurrentOpenedPages(normalizedActiveUrls);
+      }
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);
@@ -155,9 +157,11 @@ program
 
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
-      logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-      site.changeCurrentOpenedPages(normalizedActiveUrls);
+      if (onePagePath) {
+        logger.info('Synchronizing opened pages list before reload');
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        site.changeCurrentOpenedPages(normalizedActiveUrls);
+      }
       Promise.resolve('').then(() => {
         if (path.basename(filePath) === SITE_CONFIG_NAME) {
           return site.reloadSiteConfig();
@@ -173,9 +177,11 @@ program
 
     const removeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
-      logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
-      site.changeCurrentOpenedPages(normalizedActiveUrls);
+      if (onePagePath) {
+        logger.info('Synchronizing opened pages list before reload');
+        const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+        site.changeCurrentOpenedPages(normalizedActiveUrls);
+      }
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
           return site.rebuildSourceFiles(filePath);

--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -367,12 +367,8 @@ LiveServer.start = function(options) {
 
     // CHANGED: Enhanced client websocket addition process to record the client as an active tab entry
     const reqUrl = path.dirname(request.url);
-    // Guard clause for MarkBind's _include_ files, no need to recognize as an active tab
-    if (reqUrl.endsWith('._include_.html')) {
-      return;
-    }
 
-    // If present an entry with empty client, reuse existing entry to maintain order from pre-reload 
+    // If an entry with empty client is present, reuse existing entry to maintain order from pre-reload 
     const existingTab = LiveServer.activeTabs.find(tab => tab.url === reqUrl && !tab.client);
     if (existingTab) {
       existingTab.client = ws;
@@ -380,7 +376,7 @@ LiveServer.start = function(options) {
     }
 
     // Insert new entry to the active tabs list
-    LiveServer.activeTabs.unshift({ url: reqUrl, client: ws});
+    LiveServer.activeTabs.unshift({ url: reqUrl, client: ws });
   });
 
   var ignored = [


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

Bug caught in the implementation of PR #1513, where navigating backwards with the back button causes the multiple-tab development structure to not work properly, as in that case the page immediately undergoes socket establishment phase, skipping request-response phase altogether as previously assumed.

Reproduction is outlined in here https://github.com/MarkBind/markbind/pull/1513#issuecomment-803596210

**Overview of changes:**
- Moved active tab entry addition to socket establishment phase.
- `isLiveReloadRequest` is now unused and thus removed.
- Now `client` is only empty if it is cleared before the live-reload. The check on whether an entry is active or in reloading can now be tested with that property instead of `isReloading`. Thus, `isReloading` is removed.
- Also, there is no need to have `prevClient` to differentiate whether an entry is undergoing reload or still waiting for socket establishment. `prevClient` is also removed.
- Added extra guard on fs events so that opened pages list sync only happens on lazy serve mode.

**Anything you'd like to highlight / discuss:**

**Testing instructions:**
Use `markbind serve -o`

To test the fix (using the `docs` folder as the source files, can try it in default template or any other with adaptation):
1. Navigate to another page in an already-open tab (e.g. from the `index.html` page automatically open on start)
2. Navigate back to the previous page with the back button in the browser
3. First, verify there are no errors thrown in the logs
4. Edit the source file of that page and save it
5. Verify that the updated entries of the opened pages list is reflected accurately in the logs.

Also try out the updated test cases outlined here https://github.com/MarkBind/markbind/pull/1522#issuecomment-808908369

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Lazy serve: fix untracked tab bug on backwards navigation

---

**Checklist:** :ballot_box_with_check:

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x]  Pinged someone for a review!
