### PR TITLE
Implement live preview for site.json

### DIFF
--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -10,6 +10,8 @@
 **_Live preview_** is:
 - Regeneration of affected content upon any change to <tooltip content="`.md`, `.mbd`, `.mbdf`, `.njk` files ... anything your content depends on!">source files</tooltip>, then reloading the updated site in the Browser.
 
+- Regeneration will also occur upon any modification to attributes in `site.json` with the exception of [`baseUrl`](siteJsonFile.md#baseurl).
+
 - Copying <tooltip content="files that don't affect page generation (eg. images), but are used in the site">assets</tooltip> to the site output folder.
 
 Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.

--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -14,7 +14,6 @@
 
 Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.
 
-
 </span>
 
 <br>

--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -10,9 +10,12 @@
 **_Live preview_** is:
 - Regeneration of affected content upon any change to <tooltip content="`.md`, `.mbd`, `.mbdf`, `.njk` files ... anything your content depends on!">source files</tooltip>, then reloading the updated site in the Browser.
 
+- Regeneration will also occur upon any modification to attributes in `site.json` with the exception of [`baseUrl`](siteJsonFile.md#baseurl-no-live-preview).
+
 - Copying <tooltip content="files that don't affect page generation (eg. images), but are used in the site">assets</tooltip> to the site output folder.
 
 Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.
+
 
 </span>
 

--- a/docs/userGuide/glossary.md
+++ b/docs/userGuide/glossary.md
@@ -10,8 +10,6 @@
 **_Live preview_** is:
 - Regeneration of affected content upon any change to <tooltip content="`.md`, `.mbd`, `.mbdf`, `.njk` files ... anything your content depends on!">source files</tooltip>, then reloading the updated site in the Browser.
 
-- Regeneration will also occur upon any modification to attributes in `site.json` with the exception of [`baseUrl`](siteJsonFile.md#baseurl-no-live-preview).
-
 - Copying <tooltip content="files that don't affect page generation (eg. images), but are used in the site">assets</tooltip> to the site output folder.
 
 Use [the `serve` command](cliCommands.html#serve-command) to launch a live preview.

--- a/docs/userGuide/siteJsonFile.md
+++ b/docs/userGuide/siteJsonFile.md
@@ -81,12 +81,10 @@ Here is a typical `site.json` file:
 
 <include src="deployingTheSite.md#warning-about-baseUrl" />
 
-<span id="baseurl-no-live-preview">
 <box type="warning">
 
-Note: `baseUrl` does not support live preview as there is no use case for changing it in during `markbind serve`.
+Note: `baseUrl` does not support [live preview](glossary.md#live-preview) as there is no use case for changing it in during `markbind serve`.
 </box>
-</span>
 
 #### **`faviconPath`**
 

--- a/docs/userGuide/siteJsonFile.md
+++ b/docs/userGuide/siteJsonFile.md
@@ -81,6 +81,10 @@ Here is a typical `site.json` file:
 
 <include src="deployingTheSite.md#warning-about-baseUrl" />
 
+<box type="warning">
+
+Note: `baseUrl` does not support live reload as it should not change in `markbind serve` mode.
+</box>
 
 #### **`faviconPath`**
 

--- a/docs/userGuide/siteJsonFile.md
+++ b/docs/userGuide/siteJsonFile.md
@@ -81,10 +81,12 @@ Here is a typical `site.json` file:
 
 <include src="deployingTheSite.md#warning-about-baseUrl" />
 
+<span id="baseurl-no-live-preview">
 <box type="warning">
 
-Note: `baseUrl` does not support live reload as it should not change in `markbind serve` mode.
+Note: `baseUrl` does not support live preview as there is no use case for changing it in during `markbind serve`.
 </box>
+</span>
 
 #### **`faviconPath`**
 

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1276,15 +1276,18 @@ class Site {
 
   /**
    * Copies bootstrap theme to the assets folder if a valid theme is specified
-   * @param {Boolean} toCopyDefault bootstrap theme to the assets folder
+   * @param {Boolean} isRebuild only true if it is a rebuild
    */
-  copyBootstrapTheme(toCopyDefault) {
+  copyBootstrapTheme(isRebuild) {
     const { theme } = this.siteConfig;
-    if (!toCopyDefault && (!theme || !_.has(SUPPORTED_THEMES_PATHS, theme))) {
+
+    // If is it the initial build using the default theme or if the theme specified
+    // is not valid, then do nothing.
+    if ((!isRebuild && !theme) || (theme && !_.has(SUPPORTED_THEMES_PATHS, theme))) {
       return _.noop;
     }
 
-    const themeSrcPath = toCopyDefault && !theme
+    const themeSrcPath = !theme
       ? require.resolve('@markbind/core-web/asset/css/bootstrap.min.css')
       : SUPPORTED_THEMES_PATHS[theme];
     const themeDestPath = path.join(this.siteAssetsDestPath, 'css', 'bootstrap.min.css');

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1281,7 +1281,7 @@ class Site {
   copyBootstrapTheme(isRebuild) {
     const { theme } = this.siteConfig;
 
-    // If is it the initial build using the default theme or if the theme specified
+    // If it is the initial build using the default theme or if the theme specified
     // is not valid, then do nothing.
     if ((!isRebuild && !theme) || (theme && !_.has(SUPPORTED_THEMES_PATHS, theme))) {
       return _.noop;

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -846,7 +846,13 @@ class Site {
   async reloadSiteConfig() {
     const oldAddressablePages = this.addressablePages.slice();
     const oldPagesSrc = oldAddressablePages.map(page => page.src);
+    const oldIgnore = this.siteConfig.ignore;
     await this.readSiteConfig();
+    await this.handlePageReload(oldAddressablePages, oldPagesSrc);
+    await this.handleIgnoreReload(oldIgnore);
+  }
+
+  async handlePageReload(oldAddressablePages, oldPagesSrc) {
     this.collectAddressablePages();
 
     // Comparator for the _differenceWith comparison below
@@ -887,6 +893,19 @@ class Site {
         }
       });
     });
+  }
+
+  async handleIgnoreReload(oldIgnore) {
+    const assetsToRemove = _.difference(this.siteConfig.ignore, oldIgnore);
+    const assetsToAdd = _.difference(oldIgnore, this.siteConfig.ignore);
+    
+    if (!_.isEmpty(assetsToRemove)) {
+      await this._removeMultipleAssets(assetsToRemove);
+    }
+
+    if (!_.isEmpty(assetsToAdd)) {
+      await this._buildMultipleAssets(assetsToAdd);
+    }
   }
 
   /**

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -855,7 +855,7 @@ class Site {
     const oldAddressablePages = this.addressablePages.slice();
     const oldPagesSrc = oldAddressablePages.map(page => page.src);
     await this.readSiteConfig();
-    await this.handleIgnoreReload(oldSiteConfig);
+    await this.handleIgnoreReload(oldSiteConfig.ignore);
     await this.handlePageReload(oldAddressablePages, oldPagesSrc, oldSiteConfig);
     await this.handleStyleReload(oldSiteConfig.style);
   }

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -1285,8 +1285,10 @@ class Site {
   copyBootstrapTheme(isRebuild) {
     const { theme } = this.siteConfig;
 
-    // If it is the initial build using the default theme or if the theme specified
-    // is not valid, then do nothing.
+    /**
+     * If it is the initial build using the default theme or if the theme specified
+     * is not valid, then do nothing.
+     */
     if ((!isRebuild && !theme) || (theme && !_.has(SUPPORTED_THEMES_PATHS, theme))) {
       return _.noop;
     }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #48.

A follow up to #1514, which supported live preview for the pages attribute. This PR will support live preview for all the other attributes in `site.json`. A server restart is no longer required for these changes to be reflected when serving the site through `markbind serve`. Since most of the attributes in `site.json` (except `baseUrl`, `pages` and `deploy`) will affect majority of the pages, hence all pages will be regenerated when any of these attributes (except those listed above) is modified. 

For the `style` attribute, if a `bootswatch` theme is specified/added, its `bootstrap.min.css` theme file will overwrite the existing file and all pages are rebuilt. Similarly, if a `bootswatch` theme is removed, the default `bootstrap.min.css`, which is located at `core-web/asset/css` will overwrite the existing file.

**Anything you'd like to highlight / discuss:**
Would appreciate if you can let me know if I missed any attributes or if any of the attributes (other than those listed above) that does not require all pages to be rebuilt when it is modified.

**Testing instructions:**
1. Serve a MarkBind site using `markbind serve`
2. Open and edit the any of the attributes in site.json
3. Live preview should be updated to reflect the latest changes
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Implement live preview for site.json

When attributes other than pages in site.json are modified, a server 
restart is required to reflect the changes on the live preview. This can 
become a hassle to the user as they will need to frequently restart 
the server when trying out different site configuration.

Let's support live preview for all the attributes in site.json so that the 
latest changes can be reflected without restarting the server.
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
