### PR TITLE
Lazy serve: Fix improper handling of incomplete active urls

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -141,7 +141,10 @@ program
     const addHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file add: ${filePath}`);
       logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+        const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+        return fsUtil.removeExtension(completeUrl);
+      });
       site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {
@@ -156,7 +159,10 @@ program
     const changeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file change: ${filePath}`);
       logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+        const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+        return fsUtil.removeExtension(completeUrl);
+      });
       site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (path.basename(filePath) === SITE_CONFIG_NAME) {
@@ -174,7 +180,10 @@ program
     const removeHandler = (filePath) => {
       logger.info(`[${new Date().toLocaleTimeString()}] Reload for file deletion: ${filePath}`);
       logger.info('Synchronizing opened pages list before reload');
-      const normalizedActiveUrls = liveServer.getActiveUrls().map(url => fsUtil.removeExtension(url));
+      const normalizedActiveUrls = liveServer.getActiveUrls().map((url) => {
+        const completeUrl = path.extname(url) === '' ? path.join(url, 'index') : url;
+        return fsUtil.removeExtension(completeUrl);
+      });
       site.changeCurrentOpenedPages(normalizedActiveUrls);
       Promise.resolve('').then(() => {
         if (site.isFilepathAPage(filePath) || site.isDependencyOfPage(filePath)) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Bug reported and acknowledged in https://github.com/MarkBind/markbind/pull/1522#issuecomment-811090873.

Incomplete urls are defaulted to `index.md` in the path specified, e.g. `hostName/userGuide` serves `hostName/userGuide/index`, though the request URL is still referring to `hostName/userGuide`. This results in `getActiveUrls` returning just `/userGuide`, which will be stored as `userGuide` to the current opened pages list, and thus any file change to the actual file `userGuide/index` can not be detected and rebuilt accordingly.

**Overview of changes:**
- Adds a processing step of active urls retrieved from `live-server` before passing it to MarkBind's opened pages list, to append `index` on every incomplete urls.

**Anything you'd like to highlight / discuss:**


**Testing instructions:**
- Try opening `127.0.0.1:8080` (without `/index`)
- Edit root's `index.md`
- Verify that MarkBind correctly logs that the current opened pages list is `index`.

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Lazy serve: Fix improper handling of incomplete active urls

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
