### PR TITLE
Fix live-server to keep client on CSS refresh

### DIFF
--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -406,9 +406,11 @@ LiveServer.start = function(options) {
     // CHANGED: Prepare tab entry data before issuing reload
     LiveServer.activeTabs.forEach(tab => {
       if (tab.client) {
-        // Clear the client from the entry to be refilled in the socket establishment phase after reload
         const client = tab.client;
-        tab.client = undefined;
+        // Clear the client from the entry to be refilled in the socket establishment phase after reload
+        if (!cssChange) {
+          tab.client = undefined;
+        }
         client.send(cssChange ? 'refreshcss' : 'reload');
       }
     });


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Bug found during development of #1539.

On inspection of `live-server`'s injected script, the `refreshcss` routine is not really reloading the page. It simply manipulates the DOM to fetch the newest versions of the CSS files used. So, on `refreshcss`, the client should stay intact.

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Added a conditional to clear client only when it's not a CSS change.

**Anything you'd like to highlight / discuss:**


**Testing instructions:**

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix live-server to keep client on CSS refresh

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
