### PR TITLE
Lazy serve: Rebuild current opened pages on add/remove page

### DIFF
--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -207,7 +207,7 @@ class Site {
 
     if (this.toRebuild.has(this.currentPageViewed)) {
       this.beforeSiteGenerate();
-      this.rebuildPageBeingViewed(this.currentPageViewed);
+      this.rebuildPagesBeingViewed(this.currentPageViewed);
       return true;
     }
 
@@ -751,7 +751,7 @@ class Site {
     }
   }
 
-  async _rebuildPageBeingViewed(normalizedUrls) {
+  async _rebuildPagesBeingViewed(normalizedUrls) {
     const startTime = new Date();
     const normalizedUrlArray = Array.isArray(normalizedUrls) ? normalizedUrls : [normalizedUrls];
     const uniqueUrls = _.uniq(normalizedUrlArray);
@@ -775,7 +775,7 @@ class Site {
       this._setTimestampVariable();
       await this.runPageGenerationTasks([pageGenerationTask]);
       await this.writeSiteData();
-      Site.calculateBuildTimeForRebuildPageBeingViewed(startTime);
+      Site.calculateBuildTimeForRebuildPagesBeingViewed(startTime);
     } catch (err) {
       await Site.rejectHandler(err, [this.tempPath, this.outputPath]);
     }
@@ -784,9 +784,9 @@ class Site {
   }
 
   /**
-   * Helper function for _rebuildPageBeingViewed().
+   * Helper function for _rebuildPagesBeingViewed().
    */
-  static calculateBuildTimeForRebuildPageBeingViewed(startTime) {
+  static calculateBuildTimeForRebuildPagesBeingViewed(startTime) {
     const endTime = new Date();
     const totalBuildTime = (endTime - startTime) / 1000;
     return logger.info(`Lazy website regeneration complete! Total build time: ${totalBuildTime}s`);
@@ -851,7 +851,7 @@ class Site {
     if (this.onePagePath) {
       this.mapAddressablePagesToPages(this.addressablePages || [], this.getFavIconUrl());
 
-      await this.rebuildPageBeingViewed(this.currentOpenedPages);
+      await this._rebuildPagesBeingViewed(this.currentOpenedPages);
       await this.lazyBuildAllPagesNotViewed(this.currentOpenedPages);
       return;
     }
@@ -1638,7 +1638,7 @@ class Site {
  */
 Site.prototype.buildAsset = delay(Site.prototype._buildMultipleAssets, 1000);
 
-Site.prototype.rebuildPageBeingViewed = delay(Site.prototype._rebuildPageBeingViewed, 1000);
+Site.prototype.rebuildPagesBeingViewed = delay(Site.prototype._rebuildPagesBeingViewed, 1000);
 
 /**
  * Rebuild pages that are affected by changes in filePaths

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -798,7 +798,7 @@ class Site {
     if (this.onePagePath) {
       this.mapAddressablePagesToPages(this.addressablePages || [], this.getFavIconUrl());
 
-      await this.rebuildPageBeingViewed(this.currentPageViewed);
+      await this.rebuildPageBeingViewed(this.currentOpenedPages);
       await this.lazyBuildAllPagesNotViewed();
       return;
     }

--- a/packages/core/src/Site/index.js
+++ b/packages/core/src/Site/index.js
@@ -207,6 +207,11 @@ class Site {
 
     if (this.toRebuild.has(this.currentPageViewed)) {
       this.beforeSiteGenerate();
+      /*
+       Lazy loading only builds the page being viewed, but the user may be quick enough
+       to trigger multiple page builds before the first one has finished building,
+       hence we need to take this into account by using the delayed variant of the method.
+       */
       this.rebuildPagesBeingViewed(this.currentPageViewed);
       return true;
     }
@@ -757,12 +762,6 @@ class Site {
     const uniqueUrls = _.uniq(normalizedUrlArray);
     uniqueUrls.forEach(normalizedUrl => logger.info(
       `Building ${normalizedUrl} as some of its dependencies were changed since the last visit`));
-
-    /*
-     Lazy loading only builds the page being viewed, but the user may be quick enough
-     to trigger multiple page builds before the first one has finished building,
-     hence we need to take this into account.
-     */
 
     const pagesToRebuild = this.pages.filter(page =>
       uniqueUrls.some(pageUrl => FsUtil.removeExtension(page.pageConfig.sourcePath) === pageUrl));


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Follow up on #1513 (ref: https://github.com/MarkBind/markbind/pull/1513#issuecomment-818603397).

After multi-tab development is established, the add/remove page flow has yet to be updated to use the current opened pages. Currently it is still rebuilding only the current viewed page.

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
- Modified `rebuildPageBeingViewed` to adopt the page generation tasks flow
- Changed the call of `rebuildPageBeingViewed` on `rebuildSourceFiles` to use `Site.currentOpenedPages`

Another problem arises, as on `rebuildSourceFiles`, the line after is a call to `lazyBuildAllPagesNotViewed`, which tests the pages against `Site.currentPageViewed`, so `toRebuild` will be refilled with almost every page, which will trigger another rebuild once live-reload starts. So, I also:

- Modified `lazyBuildAllPagesNotViewed` to use a supplied `viewedPages` and test the pages against that instead
- Modified any call to the above function appropriately, e.g. on `lazyBuildSourceFiles` to only use the current viewed page, on `rebuildSourceFiles` to use the current opened pages.

**Anything you'd like to highlight / discuss:**
- This PR only aims to adapt the add/remove flow to use the current opened pages, so the behaviour of add/remove flow is still kept as is. That means, the issue stated in #1543 still exists for now.

**Testing instructions:**

With the default template from `markbind init`:
- `markbind serve -o`
- Aside from the index page, open another page on a new tab
- Add a new page (easy way is to duplicate one of the files in `contents`)
- Observe in the logs that both the pages opened are rebuilt

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Lazy-serve: Rebuild opened pages on add/remove page

With the addition of the multi-tab development flow, single-page serve
can keep track of all opened pages instead of a single currently
viewed page. This flow is already adopted in page edit events,
but it has yet to be adopted in page addition or removal.

Let's adopt the multi-tab development mechanism on the page addition' +
and removal flow.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
