### PR TITLE
Fix page & site nav component paddings

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/cli/test/functional/test_site/expected/stylesheets/styles.css
+++ b/packages/cli/test/functional/test_site/expected/stylesheets/styles.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/cli/test/functional/test_site/stylesheets/styles.css
+++ b/packages/cli/test/functional/test_site/stylesheets/styles.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/cli/test/functional/test_site_convert/expected/stylesheets/main.css
+++ b/packages/cli/test/functional/test_site_convert/expected/stylesheets/main.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/cli/test/functional/test_site_convert/non_markbind_site/stylesheets/main.css
+++ b/packages/cli/test/functional/test_site_convert/non_markbind_site/stylesheets/main.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/stylesheets/main.css
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/stylesheets/main.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/core-web/src/styles/page-nav.css
+++ b/packages/core-web/src/styles/page-nav.css
@@ -1,5 +1,9 @@
 /* Page navigation */
 
+#mb-page-nav {
+    padding: 0.8rem 12px 0 12px;
+}
+
 #mb-page-nav a:link,
 #mb-page-nav a:visited {
     color: #9b9b9b;

--- a/packages/core/template/default/stylesheets/main.css
+++ b/packages/core/template/default/stylesheets/main.css
@@ -81,12 +81,11 @@ mark {
 }
 
 .site-nav-top {
-    margin-top: 0.8rem;
+    margin: 0.8rem 0;
     padding: 0 12px 12px 12px;
 }
 
 .nav-component {
-    padding: 0.8rem 12px 0 12px;
     overflow-y: auto;
 }
 

--- a/packages/vue-components/src/SiteNav.vue
+++ b/packages/vue-components/src/SiteNav.vue
@@ -46,10 +46,6 @@ export default {
         padding-left: 0;
     }
 
-    .site-nav-list-root {
-        margin: 0 -12px;
-    }
-
     .site-nav-default-list-item {
         display: flex;
         padding: 0.5rem 0 0 2.8rem;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes https://github.com/MarkBind/markbind/pull/1562#issuecomment-832482550
Follow up to #1403

**Overview of changes:**
`.nav-component`'s (an "always there" layout element) padding is removed and shifted accordingly to the site and page nav.

For the site nav, the corresponding negative margin simply shouldn't be there at all with the layouts system shift. (#1403)
For the page-nav, the padding is moved into the component instead (https://github.com/MarkBind/markbind/pull/1562#issuecomment-832482550)

**Anything you'd like to highlight / discuss:**


**Testing instructions:**

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix page & site nav component paddings
<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
