### PR TITLE
Page nav as element

### DIFF
--- a/docs/_markbind/layouts/devGuide.md
+++ b/docs/_markbind/layouts/devGuide.md
@@ -26,7 +26,7 @@
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      {{ pageNav }}
+      <page-nav />
     </div>
   </nav>
 </div>

--- a/docs/_markbind/layouts/userGuide.md
+++ b/docs/_markbind/layouts/userGuide.md
@@ -41,7 +41,7 @@
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      {{ pageNav }}
+      <page-nav />
     </div>
   </nav>
 </div>

--- a/docs/userGuide/syntax/pageNavigationMenus.mbdf
+++ b/docs/userGuide/syntax/pageNavigationMenus.mbdf
@@ -15,7 +15,7 @@
 
 2. **(Optional) You may also specify a page navigation title** within `<frontmatter>` that will be placed at the top of the page navigation menu.
 
-3. **Position the page navigation menu** within your layout using the `{% raw %}{{ pageNav }}{% endraw %}` variable.
+3. **Position the page navigation menu** within your layout using the `<page-nav />` component.
 
 4. **(Optional) To make pageNav accessible on smaller screens, you can use the `<page-nav-button />` component in the [navbar]({{baseUrl}}/userGuide/usingComponents.html#navbars).**
 
@@ -31,10 +31,10 @@ In the page that you want to have page navigation, you may show only `<h1>` and 
 </frontmatter>
 ```
 
-Then, in your [layout file]({{baseUrl}}/userGuide/tweakingThePageStructure.html#layouts), use the `{% raw %}{{ pageNav }}{% endraw %}` variable to position the pageNav.
+Then, in your [layout file]({{baseUrl}}/userGuide/tweakingThePageStructure.html#layouts), use the `<page-nav />` component to position the pageNav.
 
 {% if not doNotShowPageNav %}
-{{ icon_example }} <trigger for="modal:page-nav-example">Example usage of the `{% raw %}{{ pageNav }}{% endraw %}` variable</trigger>
+{{ icon_example }} <trigger for="modal:page-nav-example">Example usage of the `<page-nav />` component</trigger>
 
 <modal header="Using the `pageNav` variable in a layout" id="modal:page-nav-example" large>
 <include src="../tweakingThePageStructure.md#layout-code-snippet">

--- a/docs/userGuide/tweakingThePageStructure.md
+++ b/docs/userGuide/tweakingThePageStructure.md
@@ -93,8 +93,8 @@ Next, edit the layout file to your liking, and add the `{% raw %}{{ content }}{%
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      <!-- Insert a page navigation menu using the {{ pageNav }} variable -->
-      {{ pageNav }}
+      <!-- Insert a page navigation menu using the <page-nav /> component -->
+      <page-nav />
     </div>
   </nav>
 </div>

--- a/packages/cli/test/functional/test_site/_markbind/layouts/default.md
+++ b/packages/cli/test/functional/test_site/_markbind/layouts/default.md
@@ -24,7 +24,7 @@
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      {{ pageNav }}
+      <page-nav />
     </div>
   </nav>
 </div>

--- a/packages/cli/test/functional/test_site/expected/bugs/index.html
+++ b/packages/cli/test/functional/test_site/expected/bugs/index.html
@@ -202,7 +202,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/index.html
+++ b/packages/cli/test/functional/test_site/expected/index.html
@@ -765,7 +765,6 @@
             </nav>
 
           </overlay-source>
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/index.html
@@ -210,7 +210,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/index.html
@@ -201,7 +201,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/nested_sub_site/testNunjucksPathResolving.html
@@ -206,7 +206,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/sub_site/testNunjucksPathResolving.html
@@ -206,7 +206,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
+++ b/packages/cli/test/functional/test_site/expected/testAnchorGeneration.html
@@ -268,7 +268,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
+++ b/packages/cli/test/functional/test_site/expected/testAntiFOUCStyles.html
@@ -223,7 +223,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
+++ b/packages/cli/test/functional/test_site/expected/testCodeBlocks.html
@@ -381,7 +381,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testDates.html
+++ b/packages/cli/test/functional/test_site/expected/testDates.html
@@ -205,7 +205,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
+++ b/packages/cli/test/functional/test_site/expected/testEmptyFrontmatter.html
@@ -204,7 +204,6 @@
         </div>
         <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
           <div class="nav-component slim-scroll">
-
           </div>
         </overlay-source>
       </div>

--- a/packages/cli/test/functional/test_site/expected/testExternalScripts.html
+++ b/packages/cli/test/functional/test_site/expected/testExternalScripts.html
@@ -207,7 +207,6 @@
         </div>
         <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
           <div class="nav-component slim-scroll">
-
           </div>
         </overlay-source>
       </div>

--- a/packages/cli/test/functional/test_site/expected/testIncludeBoilerplate.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludeBoilerplate.html
@@ -289,7 +289,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludeMultipleModals.html
@@ -210,7 +210,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
+++ b/packages/cli/test/functional/test_site/expected/testIncludePluginsRendered.html
@@ -200,7 +200,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testLayouts.html
+++ b/packages/cli/test/functional/test_site/expected/testLayouts.html
@@ -204,7 +204,6 @@
         </div>
         <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
           <div class="nav-component slim-scroll">
-
           </div>
         </overlay-source>
       </div>

--- a/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
+++ b/packages/cli/test/functional/test_site/expected/testLayoutsOverride.html
@@ -204,7 +204,6 @@
         </div>
         <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
           <div class="nav-component slim-scroll">
-
           </div>
         </overlay-source>
       </div>

--- a/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
+++ b/packages/cli/test/functional/test_site/expected/testNunjucksPathResolving.html
@@ -206,7 +206,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testPanelMarkdownParsing.html
+++ b/packages/cli/test/functional/test_site/expected/testPanelMarkdownParsing.html
@@ -256,7 +256,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testPlantUML.html
+++ b/packages/cli/test/functional/test_site/expected/testPlantUML.html
@@ -204,7 +204,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
+++ b/packages/cli/test/functional/test_site/expected/testPopoverTrigger.html
@@ -203,7 +203,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testThumbnails.html
+++ b/packages/cli/test/functional/test_site/expected/testThumbnails.html
@@ -296,7 +296,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
+++ b/packages/cli/test/functional/test_site/expected/testTooltipSpacing.html
@@ -204,7 +204,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
+++ b/packages/cli/test/functional/test_site/expected/testVariableContainsInclude.html
@@ -196,7 +196,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site/expected/test_md_fragment.html
+++ b/packages/cli/test/functional/test_site/expected/test_md_fragment.html
@@ -197,7 +197,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/Home.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Home.html
@@ -64,7 +64,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/Page-1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/Page-1.html
@@ -64,7 +64,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/_Footer.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Footer.html
@@ -64,7 +64,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
+++ b/packages/cli/test/functional/test_site_convert/expected/_Sidebar.html
@@ -67,7 +67,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/about.html
+++ b/packages/cli/test/functional/test_site_convert/expected/about.html
@@ -65,7 +65,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic1.html
@@ -69,7 +69,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic2.html
@@ -68,7 +68,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3a.html
@@ -68,7 +68,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_convert/expected/contents/topic3b.html
@@ -68,7 +68,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_convert/expected/index.html
+++ b/packages/cli/test/functional/test_site_convert/expected/index.html
@@ -64,7 +64,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic1.html
@@ -93,7 +93,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic2.html
@@ -92,7 +92,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3a.html
@@ -92,7 +92,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/contents/topic3b.html
@@ -92,7 +92,6 @@
       </div>
       <overlay-source id="page-nav" class="fixed-header-padding" tag-name="nav" to="page-nav">
         <div class="nav-component slim-scroll">
-
         </div>
       </overlay-source>
     </div>

--- a/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
+++ b/packages/cli/test/functional/test_site_templates/test_default/expected/index.html
@@ -241,7 +241,6 @@
             <a class="nav-link py-1" href="#heading-3">Heading 3&#x200E;</a>
 
           </overlay-source>
-
         </div>
       </overlay-source>
     </div>

--- a/packages/core/src/Layout/LayoutManager.js
+++ b/packages/core/src/Layout/LayoutManager.js
@@ -57,7 +57,7 @@ class LayoutManager {
       return false;
     }
 
-    return this.layouts[name] && this.layouts[name].hasPageNav;
+    return this.layouts[name] && this.layouts[name].layoutPageNavUuid;
   }
 
   combineLayoutWithPage(name, pageContent, pageNav, pageIncludedFiles) {

--- a/packages/core/src/Site/siteConvertLayout.njk
+++ b/packages/core/src/Site/siteConvertLayout.njk
@@ -33,7 +33,7 @@
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      {% raw %}{{ pageNav }}{% endraw %}
+      <page-nav />
     </div>
   </nav>
 </div>

--- a/packages/core/template/default/_markbind/layouts/default.md
+++ b/packages/core/template/default/_markbind/layouts/default.md
@@ -40,7 +40,7 @@
   </div>
   <nav id="page-nav" class="fixed-header-padding">
     <div class="nav-component slim-scroll">
-      {{ pageNav }}
+      <page-nav />
     </div>
   </nav>
 </div>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [x] Others, please explain:

Standardise this syntax before release

**Overview of changes:**
- Adopt the same hacky uuid approach to `{{ pageNav }}` replacement for `<page-nav />`
- `<page-nav />` is replaced into and enforced as a _unique_ uuid
- This uuid is post replaced after layout processing with the page's page nav.

**Anything you'd like to highlight / discuss:**
na

**Testing instructions:**
Automated tests only have trivial whitespace diffs, a result of collapsing `{{ pageNav }}`'s whitespace.

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Change {{ pageNav }} variable to <page-nav />

Using a nunjucks variable for page navs with the new layout system is
inconsistent with the use of <site-nav />.

Let's standardise these syntaxes.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No blatantly unrelated changes
- [ ] Pinged someone for a review!
