### PR TITLE
Fix reloading issue for custom site configs

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -18,7 +18,6 @@ const {
   INDEX_MARKDOWN_FILE,
   INDEX_MARKBIND_FILE,
   LAZY_LOADING_SITE_FILE_NAME,
-  SITE_CONFIG_NAME,
 } = require('@markbind/core/src/Site/constants');
 
 const liveServer = require('./src/lib/live-server');
@@ -177,7 +176,7 @@ program
         syncOpenedPages();
       }
       Promise.resolve('').then(async () => {
-        if (path.basename(filePath) === SITE_CONFIG_NAME) {
+        if (path.basename(filePath) === site.siteConfigPath) {
           return site.reloadSiteConfig();
         }
         if (site.isDependencyOfPage(filePath)) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #1576.

Initially, it was checking if a modified file has the same name as the `SITE_CONFIG_NAME` constant. This causes an issue if a custom site config is used as it will not be the same as `SITE_CONFIG_NAME`. This has been updated to compare with `site.siteConfigPath` instead which will resolve the above issue.

**Anything you'd like to highlight / discuss:**
`NIL`

**Testing instructions:**
1) Serve a markbind site with a custom site config `markbind serve -s <custom site config path>`
2) Edit the relevant attributes in site config
3) Site should be reloaded with the updated changes

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix reloading issue for custom site configs

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
