### PR TITLE
Fix unresponsive fixed header padding

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -61,27 +61,31 @@ function detectAndApplyFixedHeaderStyles() {
     const newHeaderHeight = headerSelector.height();
     const sheets = document.styleSheets;
     for (let i = 0; i < sheets.length; i += 1) {
-      const rules = sheets[i].cssRules;
-      // eslint-disable-next-line lodash/prefer-get
-      if (rules && rules[0] && rules[0].selectorText) {
-        switch (rules[0].selectorText) {
-        case '.fixed-header-padding':
-          sheets[i].deleteRule(0);
-          sheets[i].insertRule(`.fixed-header-padding { padding-top: ${newHeaderHeight}px !important }`);
-          break;
-        case 'span.anchor':
-          rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-          break;
-        case '.card-container::before':
-          rules[0].style.marginTop = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-          rules[0].style.height = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
-          break;
-        case '.nav-menu-open':
-          rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;
-          break;
-        default:
-          break;
+      try {
+        const rules = sheets[i].cssRules;
+        // eslint-disable-next-line lodash/prefer-get
+        if (rules && rules[0] && rules[0].selectorText) {
+          switch (rules[0].selectorText) {
+          case '.fixed-header-padding':
+            sheets[i].deleteRule(0);
+            sheets[i].insertRule(`.fixed-header-padding { padding-top: ${newHeaderHeight}px !important }`);
+            break;
+          case 'span.anchor':
+            rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
+            break;
+          case '.card-container::before':
+            rules[0].style.marginTop = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
+            rules[0].style.height = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
+            break;
+          case '.nav-menu-open':
+            rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;
+            break;
+          default:
+            break;
+          }
         }
+      } catch (e) {
+        // cssRules is not accessible for this stylesheet due to CORS, continue to the next stylesheet
       }
     }
   };


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #1590.

The fixed header padding is dynamically adjusted by accessing the `cssRules` property of individual stylesheet. But due to [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) security, the `cssRules` is not accessible and its rules cannot be modified if the stylesheet is imported from a different domain (external stylesheet etc.), causing the function to throw an error. This is resolved by wrapping the function in a try/catch block so that stylesheets that are imported from another domain will be skipped.

**Anything you'd like to highlight / discuss:**
`NIL`

**Testing instructions:**
1. Import stylesheet from another domain. Eg. `<link rel="stylesheet" href="https://somedomain.com/main.css">`
2. Adjust the window size till page/site nav appears
3. Fixed header padding should be dynamically adjusted

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix unresponsive fixed header padding

When external stylesheets from different domains are used,
the cssRules of these stylesheets cannot be accessed or
modified due to CORS policy. This causes the method that
adjusts the fixed header padding to throw an error and
terminate prematurely.

Let's wrap this method in a try/catch block so that external
stylesheets from other domains will be skipped if cssRules
is not accessible.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
