### PR TITLE
Replace panel ::before element with scroll-margin-top

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -49,12 +49,7 @@ function detectAndApplyFixedHeaderStyles() {
     top: calc(-${headerHeight}px - ${bufferHeight}rem)
     }`,
   );
-  insertCss(`.card-container::before {
-        display: block;
-        content: '';
-        margin-top: calc(-${headerHeight}px - ${bufferHeight}rem);
-        height: calc(${headerHeight}px + ${bufferHeight}rem);
-      }`);
+  insertCss(`.card-container { scroll-margin-top: calc(${headerHeight}px + ${bufferHeight}rem); }`);
   insertCss(`.nav-menu-open { max-height: calc(100% - ${headerHeight}px); }`);
 
   const adjustHeaderClasses = () => {
@@ -73,9 +68,8 @@ function detectAndApplyFixedHeaderStyles() {
           case 'span.anchor':
             rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
             break;
-          case '.card-container::before':
-            rules[0].style.marginTop = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-            rules[0].style.height = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
+          case '.card-container':
+            rules[0].style.scrollMarginTop = `calc(${newHeaderHeight}px + ${bufferHeight}rem)`;
             break;
           case '.nav-menu-open':
             rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Resolves #1601.

By using `::before` to create spacing before a panel, this blocks certain elements before the panel which will hinder interactive elements (buttons not clickable etc.). The spacing is needed so that panels do not get blocked by the `fixed-header` when using anchor navigation.

Replaced `::before` with `scroll-margin-top` which similarly creates spacing before the panels when using anchor navigation and also do not block other elements.

**Anything you'd like to highlight / discuss:**
If there is a better workaround.

**Testing instructions:**
1. Create panel with header
```.html
<panel header="# Test">
</panel>
```
2. Click on panel link in `page-nav`
3. Panel should appear below the `fixed-header`
4. Can refer to #1601 issue, visit nav bar section in UG, details panel should be clickable now

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix blocking ::before pseudo element in panel

Using ::before in panels may block interactive elements before
the panels. The spacing created using ::before is needed so that
panels do not get blocked by the fixed header when using anchor
navigation.

Let's replace ::before with scroll-margin-top which similarly creates
spacing before the panels when using anchor navigation and also do
not block other elements.

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [x] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
