### PR TITLE
Adopt lazy loading for Pic component

### DIFF
--- a/docs/userGuide/syntax/pictures.mbdf
+++ b/docs/userGuide/syntax/pictures.mbdf
@@ -22,7 +22,7 @@ alt | `string` | | **This must be specified.**<br>The alternative text of the im
 height | `string` | | The height of the image in pixels.
 src | `string` | | **This must be specified.**<br>The URL of the image.<br>The URL can be specified as absolute or relative references. More info in: _[Intra-Site Links]({{baseUrl}}/userGuide/formattingContents.html#intraSiteLinks)_
 width | `string` | | The width of the image in pixels.<br>If both width and height are specified, width takes priority over height. It is to maintain the image's aspect ratio.
-eager | `boolean` | false | Whether the image is lazy loaded.
+eager | `boolean` | false | The `<picture>` component lazy loads its images by default.<br>If you want to eagerly load the images, simply specify this attribute.
 
 <span id="short" class="d-none">
 

--- a/docs/userGuide/syntax/pictures.mbdf
+++ b/docs/userGuide/syntax/pictures.mbdf
@@ -22,7 +22,7 @@ alt | `string` | | **This must be specified.**<br>The alternative text of the im
 height | `string` | | The height of the image in pixels.
 src | `string` | | **This must be specified.**<br>The URL of the image.<br>The URL can be specified as absolute or relative references. More info in: _[Intra-Site Links]({{baseUrl}}/userGuide/formattingContents.html#intraSiteLinks)_
 width | `string` | | The width of the image in pixels.<br>If both width and height are specified, width takes priority over height. It is to maintain the image's aspect ratio.
-eager | `boolean` | false | The `<picture>` component lazy loads its images by default.<br>If you want to eagerly load the images, simply specify this attribute.
+eager | `boolean` | false | The `<pic>` component lazy loads its images by default.<br>If you want to eagerly load the images, simply specify this attribute.
 
 <span id="short" class="d-none">
 

--- a/docs/userGuide/syntax/pictures.mbdf
+++ b/docs/userGuide/syntax/pictures.mbdf
@@ -8,6 +8,10 @@
 <pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
+
+<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo" eager>
+  MarkBind Logo
+</pic>
 </variable>
 </include>
 
@@ -18,6 +22,7 @@ alt | `string` | | **This must be specified.**<br>The alternative text of the im
 height | `string` | | The height of the image in pixels.
 src | `string` | | **This must be specified.**<br>The URL of the image.<br>The URL can be specified as absolute or relative references. More info in: _[Intra-Site Links]({{baseUrl}}/userGuide/formattingContents.html#intraSiteLinks)_
 width | `string` | | The width of the image in pixels.<br>If both width and height are specified, width takes priority over height. It is to maintain the image's aspect ratio.
+eager | `boolean` | false | Whether the image is lazy loaded.
 
 <span id="short" class="d-none">
 

--- a/packages/vue-components/src/Pic.vue
+++ b/packages/vue-components/src/Pic.vue
@@ -6,7 +6,7 @@
       :alt="alt"
       :width="computedWidth"
       class="img-fluid rounded"
-      loading="lazy"
+      :loading="computedLoadType"
       @load.once="computeWidth"
     />
     <span class="image-caption">
@@ -36,6 +36,10 @@ export default {
       type: String,
       default: '',
     },
+    eager: {
+      type: Boolean,
+      default: false,
+    },
     addClass: {
       type: String,
       default: '',
@@ -53,6 +57,9 @@ export default {
         return this.width;
       }
       return this.widthFromHeight;
+    },
+    computedLoadType() {
+      return this.eager ? 'eager' : 'lazy';
     },
   },
   data() {

--- a/packages/vue-components/src/Pic.vue
+++ b/packages/vue-components/src/Pic.vue
@@ -6,6 +6,7 @@
       :alt="alt"
       :width="computedWidth"
       class="img-fluid rounded"
+      loading="lazy"
       @load.once="computeWidth"
     />
     <span class="image-caption">


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [X] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

Resolves #1559 

**Overview of changes:**
Use `loading=lazy` attribute to defer loading of images for Pic components

Image is only loaded lazily as seen in the video
https://user-images.githubusercontent.com/60393696/124390276-5bde0880-dd1d-11eb-9cc9-f972f4995ad0.mp4


**Anything you'd like to highlight / discuss:**
In the issue description, it was mentioned that the height/width resolution might have to be moved accordingly. I tried a few examples and it seems to work as normal on my side. Is this concern regarding the `computeWidth` function? From what I googled online, the images are loaded once it reaches calculated distance from the viewport. (Source: https://web.dev/browser-level-image-lazy-loading/)
**Testing instructions:**

<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

Adopt lazy loading for Pic component

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [X] Updated the documentation for feature additions and enhancements
- [X] Added tests for bug fixes or features
- [X] Linked all related issues
- [X] No blatantly unrelated changes
- [ ] Pinged someone for a review!
