### PR TITLE
Dial down header hiding sensitivity

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -91,9 +91,18 @@ function detectAndApplyFixedHeaderStyles() {
   };
 
   let lastOffset = 0;
+  let lastHash = window.location.hash;
   const toggleHeaderOnScroll = () => {
     // prevent toggling of header on desktop site
     if (window.innerWidth > 767) { return; }
+
+    if (lastHash !== window.location.hash) {
+      lastHash = window.location.hash;
+      headerSelector.removeClass('hide-header');
+      return;
+    }
+    lastHash = window.location.hash;
+
     const currentOffset = window.pageYOffset;
     const isEndOfPage = (window.innerHeight + currentOffset) >= document.body.offsetHeight;
     // to prevent page from auto scrolling when header is toggled at the end of page

--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -98,7 +98,14 @@ function detectAndApplyFixedHeaderStyles() {
     const isEndOfPage = (window.innerHeight + currentOffset) >= document.body.offsetHeight;
     // to prevent page from auto scrolling when header is toggled at the end of page
     if (isEndOfPage) { return; }
+
     if (currentOffset > lastOffset) {
+      const headerEnd = headerSelector.height() + headerSelector[0].getBoundingClientRect().top;
+      const isBeforeHeader = currentOffset < headerEnd;
+      if (isBeforeHeader) {
+        return;
+      }
+
       headerSelector.addClass('hide-header');
     } else {
       headerSelector.removeClass('hide-header');
@@ -117,7 +124,14 @@ function detectAndApplyFixedHeaderStyles() {
   });
   resizeObserver.observe(headerSelector[0]);
   headerSelector[0].addEventListener('transitionend', toggleHeaderOverflow);
-  window.addEventListener('scroll', toggleHeaderOnScroll);
+
+  let scrollTimeout;
+  window.addEventListener('scroll', () => {
+    if (scrollTimeout) {
+      clearTimeout(scrollTimeout);
+    }
+    scrollTimeout = setTimeout(toggleHeaderOnScroll, 20);
+  });
 }
 
 function updateSearchData(vm) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:


Fixes #1602 

**Overview of changes:**
- Debounce scroll handler to avoid overly "immediate" hiding / showing
- Prevent hiding the header when the page offset < the end of the header

**Anything else to highlight**
Tested this on an android phone, which _should_ also work in theory for ios which allows "scrolling past the window"

**Testing instructions:**
Best tested on an actual mobile device

**Proposed commit message: (wrap lines at 72 characters)**
Reduce mobile header hiding sensitivity

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [x] Pinged someone for a review!
