### PR TITLE
Fix running functional tests in packages/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint . --ext .js,.vue && npm run csslint",
     "lintfix": "eslint . --ext .js,.vue --fix && npm run csslintfix",
     "setup": "npm ci && lerna clean --yes && lerna bootstrap --hoist",
-    "test": "npm run lint && cross-env TEST_MODE=true lerna run test --stream",
-    "updatetest": "cross-env TEST_MODE=true lerna run updatetest --stream"
+    "test": "npm run lint && lerna run test --stream",
+    "updatetest": "lerna run updatetest --stream"
   },
   "devDependencies": {
     "eslint": "^7.25.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/MarkBind/markbind.git"
   },
   "scripts": {
-    "test": "jest --colors && cd test/functional && node test.js",
+    "test": "jest --colors && cd test/functional && cross-env TEST_MODE=true node test.js",
     "updatetest": "cd test/functional && node updatetest.js"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/MarkBind/markbind.git"
   },
   "scripts": {
-    "test": "jest --colors && cd test/functional && cross-env TEST_MODE=true node test.js",
+    "test": "jest --colors && cd test/functional && node test.js",
     "updatetest": "cd test/functional && node updatetest.js"
   },
   "dependencies": {

--- a/packages/cli/test/functional/test.js
+++ b/packages/cli/test/functional/test.js
@@ -18,6 +18,7 @@ function printFailedMessage(err, siteName) {
   console.log(`Test result: ${siteName} FAILED`);
 }
 
+process.env.TEST_MODE = true;
 process.env.FORCE_COLOR = '3';
 
 const execOptions = {

--- a/packages/cli/test/functional/updatetest.js
+++ b/packages/cli/test/functional/updatetest.js
@@ -17,6 +17,7 @@ function printFailedMessage(err, siteName) {
   console.log(`Failed to update: ${siteName}`);
 }
 
+process.env.TEST_MODE = true;
 process.env.FORCE_COLOR = '3';
 
 const execOptions = {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Fixes #1641 
**Overview of changes:**
#### ✍️ Action taken  
Setting the environment variable `TEST_MODE=true` before running a comparison between expected and actual HTML generated.

#### 📘 Background & Elaboration
Initially running `npm run test` within the `cli` package results in inconsistent behavior as compared to running `npm run test` in the root directory. After some investigation and hints provided by @wxwxwxwx9 [here](https://github.com/MarkBind/markbind/issues/1641#issuecomment-894279137), I discovered that indeed tests under `packages/cli` behaves differently because the test_site HTML generated is different. To be exact, the HTML generated is minified. This caused a problem with the `jsdiff.diffChars` function used in functional tests, making it both slow running and reaching a conclusion that the two files being compared are different.

By setting the environment variable, the following function in `packages\core\src\Page\index.js` will output beautified HTML as required, thus passing the test cases.
```javascript
  async outputPageHtml(content, pageNav) {
    const renderedTemplate = this.pageConfig.template.render(
      this.prepareTemplateData(content, !!pageNav)); // page.njk

    const outputTemplateHTML = process.env.TEST_MODE
      ? htmlBeautify(renderedTemplate, this.pageConfig.pluginManager.htmlBeautifyOptions)
      : renderedTemplate;

    await fs.outputFile(this.pageConfig.resultPath, outputTemplateHTML);
  }
```

**Anything you'd like to highlight / discuss:**
This issue is indeed a regression from a past PR. Though the fix is simple, it served as a great first issue for me as I had to spend some hours digging around the packages, which ended up helping me understand the repo better. So thanks @wxwxwxwx9!
To continue the discussion in #1641, I have the following points that perhaps would like to get others to comment on:
- I played around with [`diff-match-patch`](https://github.com/google/diff-match-patch) in place of `jsdiff` and it seems to be more performant to do the text comparison. There are a few issues around performance in jsdiff's repo about it vs diff-match-patch, kpdecker/jsdiff#225 and kpdecker/jsdiff#163. Perhaps we could explore this alternative in the future.
- On the same note, perhaps we could explore switching to jest's snapshot testing instead.
- Similarly, I am wondering if we should trigger the functional tests with jest as well, instead of calling the `node test.js` command. With jest and some refactoring, we could have better test feedback for functional tests. This could also potentially be a good starting point where we organize the existing functional tests code better.

**Testing instructions:**
Run `npm run test` in the root directory and in `packages/cli`, both should run successfully. 
<!--
  Any special testing instructions in not including our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->
Fix running functional tests in packages/cli

Functional tests are failing when invoked under packages/cli.

Let's set `TEST_MODE = true`  within `test.js` and `updatetest.js` to
output beautified HTML for comparison and make the tests pass again.

Use of `cross-env TEST_MODE=true` in `package.json` has been removed
in favor of inline configuration.

---

**Checklist:** :ballot_box_with_check:

<!--
  Prefix your pull request title with [WIP] if any of these are not complete yet

  Tick non-applicable items as well
-->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
