### PR TITLE
[WIP] Fix default html index page not detected by watchers

### DIFF
--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -421,8 +421,20 @@ LiveServer.start = function(options) {
     }
 
     // Only reload active tabs if the changed file is opened in one of them
+    const normalizeUrl = (url) => {
+      if (!url || url.length === 0) {
+        return "index.html";
+      }
+
+      if (path.extname(url) === '.html') {
+        return url;
+      }
+
+      return path.posix.join(url, 'index.html');
+    };
+
     let normalizedPath = fsUtil.ensurePosix(path.relative(root, changePath));
-    if (LiveServer.activeTabs.some(tab => tab.client && tab.url === normalizedPath)) {
+    if (LiveServer.activeTabs.some(tab => tab.client && normalizeUrl(tab.url) === normalizedPath)) {
       LiveServer.sendMessageToActiveTabs('reload');
     }
   }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes #1682 

**Overview of changes:**
This PR fixed the handling of default index.html page that is not detected by live server module. The current diagnosis is that "*/" is compared with "*/index.html" yielding negative results.

**Anything you'd like to highlight / discuss:**
This is a PR in relation to CS3281 application. This PR is still work in progress, as tests are yet to be introduced to the live server module.

**Testing instructions:**

0. `mkdir test && cd test`
1. `markbind init`
2. `markbind serve -d`
3. Edit the index.md file and the changes will be reflected on the browser.

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix default html index page not detected by watchers

<!--
  See this link for more info on how to write a good commit message:
  https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message

  As best as possible, write a succinct commit title in 50 characters
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements (not relevant)
- [ ] Added tests for bug fixes or features (work in progress)
- [X] Linked all related issues
- [ ] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
