### PR TITLE
Fix typo in docs for Tooltips

### DIFF
--- a/docs/userGuide/syntax/tooltips.mbdf
+++ b/docs/userGuide/syntax/tooltips.mbdf
@@ -4,16 +4,16 @@
 <variable name="highlightStyle">html</variable>
 <variable name="code">
 <tooltip content="Lorem ipsum dolor sit amet" placement="top">
-  <button class="btn btn-secondary">Popover on top</button>
+  <button class="btn btn-secondary">Tooltip on top</button>
 </tooltip>
 <tooltip content="Lorem ipsum dolor sit amet" placement="left">
-  <button class="btn btn-secondary">Popover on left</button>
+  <button class="btn btn-secondary">Tooltip on left</button>
 </tooltip>
 <tooltip content="Lorem ipsum dolor sit amet" placement="right">
-  <button class="btn btn-secondary">Popover on right</button>
+  <button class="btn btn-secondary">Tooltip on right</button>
 </tooltip>
 <tooltip content="Lorem ipsum dolor sit amet" placement="bottom">
-  <button class="btn btn-secondary">Popover on bottom</button>
+  <button class="btn btn-secondary">Tooltip on bottom</button>
 </tooltip>
 <hr />
 Trigger


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

**Overview of changes:**
Fixed a typo where 'Tooltip' was named 'Popover'.

In the Tooltips section:
![Screenshot 2022-02-09 at 4 23 07 PM](https://user-images.githubusercontent.com/61113575/153154982-2ba54261-132e-4c32-90ef-b2262ce2c381.png)

**Proposed commit message: (wrap lines at 72 characters)**

```
Fix typo in docs for tooltips
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->
