### PR TITLE
Fixed: Broken link in About Us #1800

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -4,7 +4,7 @@
 
 # About Us
 
-<span class="lead">MarkBind is a project **based in [National University of Singapore, School of Computing](http://www.comp.nus.edu.sg/)**, and is funded by an education grant from [NUS Center for Development of Teaching and Learning](http://www.cdtl.nus.edu.sg/).</span>
+<span class="lead">MarkBind is a project **based in [National University of Singapore, School of Computing](http://www.comp.nus.edu.sg/)**, and is funded by an education grant from [NUS Center for Development of Teaching and Learning](https://nus.edu.sg/cdtl).</span>
 
 The **project team**:
 


### PR DESCRIPTION
Hey @tlylt I have fixed the link in About Us. I have updated it to https://nus.edu.sg/cdtl.
Please Review my PR.
Thanks!

Reviewer(tlylt) edits:
Fixes #1800 
**Proposed commit message: (wrap lines at 72 characters)**
Fix broken link in UG's About Us page