### PR TITLE
Update markdown-it-linkify-images to v2.0.0

### DIFF
--- a/docs/userGuide/syntax/images.md
+++ b/docs/userGuide/syntax/images.md
@@ -23,3 +23,18 @@
 
 ![alt text here](https://markbind.org/images/logo-lightbackground.png "title here")
 </span>
+
+MarkBind also supports the `=Wx` shorthand for specifying image width:
+
+<include src="codeAndOutput.md" boilerplate >
+<variable name="highlightStyle">markdown</variable>
+<variable name="code">
+This image has a width of 100px: ![](https://markbind.org/images/logo-lightbackground.png =100x)
+</variable>
+</include>
+
+<box type="info">
+  The width of images cannot exceed that of their parent container. If the specified width is too large, it will be ignored.
+</box>
+
+MarkBind does not support setting the height of images through the `=WxH` or `=xH` syntax. This is because images are automatically resized to ensure responsiveness based on their width.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 				"markdown-it-attrs": "^4.1.3",
 				"markdown-it-emoji": "^1.4.0",
 				"markdown-it-imsize": "^2.0.1",
-				"markdown-it-linkify-images": "^1.1.1",
+				"markdown-it-linkify-images": "^2.0.0",
 				"markdown-it-mark": "^3.0.0",
 				"markdown-it-regexp": "^0.4.0",
 				"markdown-it-sub": "^1.0.0",
@@ -17627,35 +17627,9 @@
 			"integrity": "sha1-zKBCeQXQUziiR8ucqdloxc3dUXA="
 		},
 		"node_modules/markdown-it-linkify-images": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/markdown-it-linkify-images/-/markdown-it-linkify-images-1.1.1.tgz",
-			"integrity": "sha512-1IEmAaAjIgAwY+tZI0sxDXdy9QKHutj5cN0lH2JBiSZt+2NYKrWRJj0cloQW3OFIfP2MLFA1E+6OLJhXPiLgNw==",
-			"dependencies": {
-				"markdown-it": "^8.4.2"
-			}
-		},
-		"node_modules/markdown-it-linkify-images/node_modules/linkify-it": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-			"dependencies": {
-				"uc.micro": "^1.0.1"
-			}
-		},
-		"node_modules/markdown-it-linkify-images/node_modules/markdown-it": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"entities": "~1.1.1",
-				"linkify-it": "^2.0.0",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			},
-			"bin": {
-				"markdown-it": "bin/markdown-it.js"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-linkify-images/-/markdown-it-linkify-images-2.0.0.tgz",
+			"integrity": "sha512-8a85tX2OlA48C5BRNDtaaqaUmyvs1QLefnPgCB6NIwWcofVl5cS68I2P4vWSaKN/VZNS28EgG6uNtHawVNlt1w=="
 		},
 		"node_modules/markdown-it-mark": {
 			"version": "3.0.1",
@@ -40946,34 +40920,9 @@
 			"integrity": "sha1-zKBCeQXQUziiR8ucqdloxc3dUXA="
 		},
 		"markdown-it-linkify-images": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/markdown-it-linkify-images/-/markdown-it-linkify-images-1.1.1.tgz",
-			"integrity": "sha512-1IEmAaAjIgAwY+tZI0sxDXdy9QKHutj5cN0lH2JBiSZt+2NYKrWRJj0cloQW3OFIfP2MLFA1E+6OLJhXPiLgNw==",
-			"requires": {
-				"markdown-it": "^8.4.2"
-			},
-			"dependencies": {
-				"linkify-it": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-					"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-					"requires": {
-						"uc.micro": "^1.0.1"
-					}
-				},
-				"markdown-it": {
-					"version": "8.4.2",
-					"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-					"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"entities": "~1.1.1",
-						"linkify-it": "^2.0.0",
-						"mdurl": "^1.0.1",
-						"uc.micro": "^1.0.5"
-					}
-				}
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it-linkify-images/-/markdown-it-linkify-images-2.0.0.tgz",
+			"integrity": "sha512-8a85tX2OlA48C5BRNDtaaqaUmyvs1QLefnPgCB6NIwWcofVl5cS68I2P4vWSaKN/VZNS28EgG6uNtHawVNlt1w=="
 		},
 		"markdown-it-mark": {
 			"version": "3.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "markdown-it-attrs": "^4.1.3",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-imsize": "^2.0.1",
-    "markdown-it-linkify-images": "^1.1.1",
+    "markdown-it-linkify-images": "^2.0.0",
     "markdown-it-mark": "^3.0.0",
     "markdown-it-regexp": "^0.4.0",
     "markdown-it-sub": "^1.0.0",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes #671

**Overview of changes:**
Update `markdown-it-linkify-images` to v2.0.0

**Anything you'd like to highlight / discuss:**
- The `=WxH` and `=Wx` syntax are now working
- However, `=xH` doesn't work because [`{ imgClass: 'img-fluid' }`](https://github.com/MarkBind/markbind/blob/3d8495a5a215b352b1a46b7772c11be62676372c/packages/core/src/lib/markdown-it/index.js#L34) sets the `height` attribute of the image to `auto`, which seems to be overriding the user-defined height.

**Testing instructions:**
```
These work:
![](https://vuejs.org/images/logo.png =20x20)
![](https://vuejs.org/images/logo.png =20x)
<panel header="**width & height** :rocket: ![](https://vuejs.org/images/logo.png =20x20)"> ...  </panel>
<panel header="**width** ![](https://vuejs.org/images/logo.png =20x)" type="seamless"> ...  </panel>

These don't work (`=xH`):
![](https://vuejs.org/images/logo.png =x20)
<panel header="**height** :rocket: ![](https://vuejs.org/images/logo.png =x20)" type="seamless"> ...  </panel>
```

**Proposed commit message: (wrap lines at 72 characters)**
```
Update markdown-it-linkify-images to v2.0.0

markdown-it-linkify-images at v1.1.1 overrides image width and height
attributes.

Let's upgrade to v2.0.0 which fixes this problem.
```

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [ ] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->
