### PR TITLE
Fix MarkBind internal package dependencies

### DIFF
--- a/docs/devGuide/projectManagement.md
+++ b/docs/devGuide/projectManagement.md
@@ -80,11 +80,12 @@ For general best practices, refer to the guide [_Working with PRs_ @SE-EDU](http
 
 1. **Make sure to start with a "clean slate"** by running `lerna clean` and then `npm run setup` in the root MarkBind directory.
 
-1. **Increment the version number** by running `lerna version --no-push`. Which to increment (`patch`, `minor` or `major`) depends on what PRs are merged for the new version, which means you must know beforehand about the changes.
+1. **Increment the version number** by running `lerna version --no-push --exact`. Which to increment (`patch`, `minor` or `major`) depends on what PRs are merged for the new version, which means you must know beforehand about the changes.
 
    <box type="info" seamless>
-  
-   The end result of this command is version commit with an appropriate tag. We will make use of the generated tag and commit message later.
+
+   * We will specify updated version numbers exactly to ensure that each version will consistently fetch the same versioned internal packages.
+   * The end result of this command is version commit with an appropriate tag. We will make use of the generated tag and commit message later.
    </box>
 
 1. **Build the core-web package bundle** by executing `npm run build:web` in the root directory, after which you should see changes in the bundles located in `packages/core-web/dist`. <br><br>Take a peek at the diff for the bundles to see if there are any strange changes.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,8 +25,8 @@
     "updatetest": "cd test/functional && node updatetest.js"
   },
   "dependencies": {
-    "@markbind/core": "^3.1.1",
-    "@markbind/core-web": "^3.1.1",
+    "@markbind/core": "3.1.1",
+    "@markbind/core-web": "3.1.1",
     "bluebird": "^3.7.2",
     "chalk": "^3.0.0",
     "cheerio": "^0.22.0",

--- a/packages/core-web/package.json
+++ b/packages/core-web/package.json
@@ -30,7 +30,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
     "@babel/runtime": "^7.10.5",
-    "@markbind/vue-components": "^3.1.1",
+    "@markbind/vue-components": "3.1.1",
     "babel-loader": "^8.1.0",
     "bootstrap-vue": "^2.16.0",
     "cross-env": "^7.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@markbind/core-web": "^3.1.1",
+    "@markbind/core-web": "3.1.1",
     "@primer/octicons": "^15.0.1",
     "@sindresorhus/slugify": "^0.9.1",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"

  If the pull request completely addresses the issue, use one of the issue closing keywords. https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #1845

**Anything you'd like to highlight / discuss:**
Not sure if `packages/core-web/package.json`'s dev dep on `vue-components` needs to be adjusted as well (may not be necessary). 

**Testing instructions:**
nil

**Proposed commit message: (wrap lines at 72 characters)**
Ensure the referenced versions of MarkBind packages are exact

The use of range versions for internal packages results in
incorrect versioning of MarkBind packages when using an
older version of MarkBind.

Let's remove the compatible versioning and use the exact match.

This ensures the versions of internal packages downloaded
will be exact and provide the expected functionalities.


**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->
