### PR TITLE
Add Components page to developer guide

### DIFF
--- a/docs/_markbind/layouts/devGuide.md
+++ b/docs/_markbind/layouts/devGuide.md
@@ -14,6 +14,7 @@
   * [Project Structure]({{baseUrl}}/devGuide/design/projectStructure.html)
   * [Architecture]({{baseUrl}}/devGuide/design/architecture.html)
   * [Server Side Rendering]({{baseUrl}}/devGuide/design/serverSideRendering.html)
+* [Writing Components]({{baseUrl}}/devGuide/writingComponents.html)
 * [Writing Plugins]({{baseUrl}}/devGuide/writingPlugins.html)
 * [Project management]({{baseUrl}}/devGuide/projectManagement.html)
 * Appendices :expanded:

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -23,7 +23,7 @@ The main logic of the node processing flow can be found in [`packages/core/src/h
 
 A MarkBind source file is first parsed into a series of 
 <popover header=":bulb: What is a _**node**_?" content="A HTML file can be represented as a tree structure called the [DOM](https://www.w3schools.com/js/js_htmldom.asp), comprising HTML elements (or _nodes_).">nodes</popover>.
-In general, each component will be parsed as a node, which may contain other childnodes (components or otherwise).
+In general, each component will be parsed as a node, which may contain other child nodes (components or otherwise).
 
 Each node is then processed to implement MarkBind functionalities, such as checking for invalid intrasite links and rendering markdown.
 Components may undergo further processing (in `processNode`) and/or post-processing (in `postProcessNode`) to further transform the node to the desired HTML.
@@ -83,10 +83,10 @@ Hence, MarkBind slots can be accessed in a Vue component either through the [nam
 ### As a Plugin
 
 MarkBind components can be implemented as a plugin as well. 
-This is suitable for more lightweight components where the implementation is largely in processing the node, where it is fitting to use MarkBind plugins' `processNode` or `postRender` interfaces. 
+This is suitable for more lightweight components where the implementation is largely in processing the node, making it fitting to use MarkBind plugins' `processNode` or `postRender` interfaces. 
 These interfaces provide additional entry points for modifying the page generated, and do not replace MarkBind's usual node processing.
 
-The [Writing Plugins]({{baseUrl}}/devGuide/writingPlugins.html) guide is a good place to get started on plugins.
+The [Writing Plugins]({{baseUrl}}/devGuide/writingPlugins.html) page is a good guide to get started on plugins.
 
 {{ icon_examples }} 
 * The [`tree` component](https://github.com/MarkBind/markbind/blob/master/packages/core/src/plugins/default/markbind-plugin-tree.js) is implemented as a default plugin
@@ -117,10 +117,10 @@ Components should be compatible with SSR (Server-Side Rendering).
 Minimally, there should be no SSR issues (viewable from the browser console), though a lack of warnings does **not** mean that there are no SSR problems. 
 A guide on SSR for MarkBind can be found [here]({{baseUrl}}/devGuide/design/serverSideRendering.html). 
 
-Vue-component-specific tips for resolving SSR issues:
+Vue-specific tips for resolving SSR issues:
 * The `mount` and `beforeMount` lifecycle hooks will only be executed on the client, not the server
 * When using `v-if`, ensure that it will evaluate to the same value on both the client and server 
-* Take note of how the Vue component will be compiled, ensure that the HTML is correct and aligns on both client- and server- side
+* Take note of how the Vue component will be compiled, ensuring that the HTML is correct and aligns on both client- and server- side
 * Conditionally render data when it has been fully loaded
 
 #### Bundle size
@@ -134,7 +134,7 @@ Ideally, this should not increase MarkBind's bundle size too much.
 When choosing to use a third-party library or package, it should ideally be well-maintained and not have too many dependencies.
 While dependencies may be inevitable, a package with dependencies on large libraries may lag behind the most recent releases of these libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
 
-For instance, if `bootstrap-vue` depends on Bootstrap and Vue, MarkBind will need to wait for `bootstrap-vue` to migrate to the newest versions of both Bootstrap and Vue before MarkBind can migrate to these versions of Bootstrap and Vue as well.
+For instance, if `bootstrap-vue` depends on Bootstrap and Vue, we will need to wait for `bootstrap-vue` to migrate to the newest versions of both Bootstrap and Vue before MarkBind can migrate to these versions of Bootstrap and Vue as well.
 
 <box type="tip" seamless>
 

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -11,13 +11,13 @@
 
 <div class="lead">
 
-This page explains various concerns related to MarkBind components, focused on implementation and testing.
+This page explains how MarkBind components work, focused on implementation and testing.
 </div>
 
 MarkBind provides a number of components (e.g. expandable panels, tooltips) dynamically express content. 
 In order to serve content on the browser, MarkBind syntax is converted to valid HTML.
 
-<panel header="How are components in MarkBind syntax parsed and converted to HTML?" minimized>
+<panel header="How are components in MarkBind syntax parsed and converted to HTML?">
 
 The main logic of the node processing flow can be found in `NodeProcessor`.
 

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -44,7 +44,7 @@ These transformations may take place at various stages of node processing: befor
 Many MarkBind components are implemented as Vue components, either by creating a component in the `vue-components` package, or by importing a component from an external library.
 This can be useful when a more complicated set of features is needed, where a Vue component can provide an interface for us to manage these functionalities.
 
-Vue components are registered in `vue-components/src/index.js`, which allows them to be used in any Vue instance without needing to be imported first.
+Vue components are registered in `vue-components/src/index.js`, which allows them to be used in the template section of any Vue instance without needing to be imported first.
 
 <panel header="How do MarkBind attributes/slots get passed to the Vue component?">
 
@@ -67,7 +67,7 @@ Hence, MarkBind slots can be accessed in a Vue component either through the [nam
 ### As a Plugin
 
 MarkBind components can be implemented as a plugin as well. 
-This is suitable for more lightweight components where the implementation is largely in processing the node, making it suitable to use MarkBind Plugins' `processNode` or `postRender` interfaces.
+This is suitable for more lightweight components where the implementation is largely in processing the node, where it is fitting to use MarkBind Plugins' `processNode` or `postRender` interfaces.
 
 {{ icon_examples }} 
 * The `tree` component is implemented as a default plugin

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -14,14 +14,30 @@
 This page explains various concerns related to MarkBind components, focused on implementation and testing.
 </div>
 
+MarkBind provides a number of components (e.g. expandable panels, tooltips) dynamically express content. 
+In order to serve content on the browser, MarkBind syntax is converted to valid HTML.
+
+<panel header="How are components in MarkBind syntax parsed and converted to HTML?" minimized>
+
+The main logic of the node processing flow can be found in `NodeProcessor`.
+
+A MarkBind source file is first parsed into a series of 
+<popover header=":bulb: What is a _**node**_?" content="A HTML file can be represented as a tree structure called the [DOM](https://www.w3schools.com/js/js_htmldom.asp), comprising HTML elements (or _nodes_).">nodes</popover>.
+In general, each component will be parsed as a node, which may contain other childnodes (components or otherwise).
+
+Each node is then processed to implement MarkBind functionalities, such as checking for invalid intrasite links and rendering markdown.
+Components may undergo further processing (in `processNode`) and/or post-processing (in `postProcessNode`) to further transform the node to the desired HTML.
+MarkBind identifies each component by the node's _name_ (e.g. `panel`, `question`). 
+
+`cheerio` is then used to convert all nodes back into HTML, and this HTML is served to the browser as a MarkBind page.
+</panel>
+
+<br>
+<br>
+
 ## Implementing Components
 
 There are multiple ways to implement MarkBind components.
-
-<box type='warning' light>
-
-If an author has a conflicting slot and attribute, MarkBind should **log a warning** to let them know!
-</box>
 
 ### Transforming the Node Directly
 
@@ -96,7 +112,7 @@ It is important to consider reactivity when implementing a component that may ha
 
 Components should be compatible with SSR. 
 Minimally, there should be no SSR issues (viewable from the browser console), though a lack of warnings does **not** mean that there are no SSR problems. 
-A guide on SSR for MarkBind can be found [here]({{baseUrl}}/devGuide/serverSideRendering.html). 
+A guide on SSR for MarkBind can be found [here]({{baseUrl}}/devGuide/design/serverSideRendering.html). 
 
 Vue-component-specific tips for resolving SSR issues:
 * The `mount` and `beforeMount` lifecycle hooks will only be executed on the client, not the server
@@ -111,5 +127,22 @@ Ideally, this should not increase MarkBind's bundle size too much.
 
 #### Dependencies
 
-When choosing to use an external library, it should ideally be well-maintained and not have too many dependencies, especially high-level dependencies. High-level dependencies may lag behind the most recent releases of other libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
+When choosing to use a third-party library or package, it should ideally be well-maintained and not have too many dependencies, especially high-level dependencies. 
+While dependencies may be inevitable, a package that depends on <tooltip content="e.g. frameworks like Vue, Bootstrap">higher-level libraries</tooltip> may lag behind the most recent releases of these libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
+
+<box type="tip" light>
+
+You are welcome to raise any concerns during the initial discussion phase for other devs to weigh in on the tradeoffs!
+</box>
+
+#### Attributes and Slots
+
+MarkBind components may support <popover header="`header` is an **attribute** here:" content="`<panel header='Hello'></panel>`">attributes</popover>, <popover header="`header` is a **slot** here:" content="`<div slot='header'>Hello</div>`">slots</popover> or both. 
+Some components allow users to supply the same content as either a slot or an attribute.
+If an author provides the same content as both a slot and an attribute, in most cases, the slot should override the attribute. 
+
+<box type='warning' light>
+
+MarkBind should also **log a warning** to inform the author of this conflict!
+</box>
 

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -14,12 +14,12 @@
 This page explains how MarkBind components work, focused on implementation and testing.
 </div>
 
-MarkBind provides a number of components (e.g. expandable panels, tooltips) dynamically express content. 
+MarkBind provides a number of components (e.g. expandable panels, tooltips) to dynamically express content. 
 In order to serve content on the browser, MarkBind syntax is converted to valid HTML.
 
 <panel header="How are components in MarkBind syntax parsed and converted to HTML?">
 
-The main logic of the node processing flow can be found in `NodeProcessor`.
+The main logic of the node processing flow can be found in [`packages/core/src/html/NodeProcessor.js`](https://github.com/MarkBind/markbind/blob/master/packages/core/src/html/NodeProcessor.js).
 
 A MarkBind source file is first parsed into a series of 
 <popover header=":bulb: What is a _**node**_?" content="A HTML file can be represented as a tree structure called the [DOM](https://www.w3schools.com/js/js_htmldom.asp), comprising HTML elements (or _nodes_).">nodes</popover>.
@@ -64,11 +64,11 @@ Vue components are registered in `vue-components/src/index.js`, which allows the
 
 <panel header="How do MarkBind attributes/slots get passed to the Vue component?">
 
-##### Attributes
+##### <trigger for="pop:markbind-attributes">Attributes</trigger>
 
 MarkBind attributes are passed to the Vue component as **props**. The type of the prop will be a `String`.
 
-##### Slots
+##### <trigger for="pop:markbind-slots">Slots</trigger>
 
 MarkBind slots are passed as **named slots** to the Vue component. The name of the MarkBind slot will be the same as the name of the Vue slot.
 Hence, MarkBind slots can be accessed in a Vue component either through the [named slots](https://v2.vuejs.org/v2/guide/components-slots.html#Named-Slots) or through the [`$slots` API](https://v2.vuejs.org/v2/api/#vm-slots).
@@ -77,16 +77,19 @@ Hence, MarkBind slots can be accessed in a Vue component either through the [nam
 <br>
 
 {{ icon_examples }} 
-* As a wrapper for an external library (Modal component)
-* To implement a set of customised behaviours (Quiz component)
+* As a wrapper for an external library ([Modal component](https://github.com/MarkBind/markbind/blob/master/packages/vue-components/src/Modal.vue))
+* To implement a set of customised behaviours ([Quiz component](https://github.com/MarkBind/markbind/blob/master/packages/vue-components/src/questions/Quiz.vue))
 
 ### As a Plugin
 
 MarkBind components can be implemented as a plugin as well. 
-This is suitable for more lightweight components where the implementation is largely in processing the node, where it is fitting to use MarkBind Plugins' `processNode` or `postRender` interfaces.
+This is suitable for more lightweight components where the implementation is largely in processing the node, where it is fitting to use MarkBind plugins' `processNode` or `postRender` interfaces. 
+These interfaces provide additional entry points for modifying the page generated, and do not replace MarkBind's usual node processing.
+
+The [Writing Plugins]({{baseUrl}}/devGuide/writingPlugins.html) guide is a good place to get started on plugins.
 
 {{ icon_examples }} 
-* The `tree` component is implemented as a default plugin
+* The [`tree` component](https://github.com/MarkBind/markbind/blob/master/packages/core/src/plugins/default/markbind-plugin-tree.js) is implemented as a default plugin
 
 ## Testing Components
 
@@ -110,7 +113,7 @@ It is important to consider reactivity when implementing a component that may ha
 
 #### SSR
 
-Components should be compatible with SSR. 
+Components should be compatible with SSR (Server-Side Rendering). 
 Minimally, there should be no SSR issues (viewable from the browser console), though a lack of warnings does **not** mean that there are no SSR problems. 
 A guide on SSR for MarkBind can be found [here]({{baseUrl}}/devGuide/design/serverSideRendering.html). 
 
@@ -124,24 +127,27 @@ Vue-component-specific tips for resolving SSR issues:
 
 When creating a new component, you may need to import a package or library to support some functionality. 
 Ideally, this should not increase MarkBind's bundle size too much.
+[Bundlephobia](https://bundlephobia.com/) may be useful to quickly look up the size of a package!
 
 #### Dependencies
 
-When choosing to use a third-party library or package, it should ideally be well-maintained and not have too many dependencies, especially high-level dependencies. 
-While dependencies may be inevitable, a package that depends on <tooltip content="e.g. frameworks like Vue, Bootstrap">higher-level libraries</tooltip> may lag behind the most recent releases of these libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
+When choosing to use a third-party library or package, it should ideally be well-maintained and not have too many dependencies.
+While dependencies may be inevitable, a package with dependencies on large libraries may lag behind the most recent releases of these libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
 
-<box type="tip" light>
+For instance, if `bootstrap-vue` depends on Bootstrap and Vue, MarkBind will need to wait for `bootstrap-vue` to migrate to the newest versions of both Bootstrap and Vue before MarkBind can migrate to these versions of Bootstrap and Vue as well.
 
-You are welcome to raise any concerns during the initial discussion phase for other devs to weigh in on the tradeoffs!
+<box type="tip" seamless>
+
+Feel free to raise any concerns during the initial discussion phase for other devs to weigh in on the tradeoffs!
 </box>
 
 #### Attributes and Slots
 
-MarkBind components may support <popover header="`header` is an **attribute** here:" content="`<panel header='Hello'></panel>`">attributes</popover>, <popover header="`header` is a **slot** here:" content="`<div slot='header'>Hello</div>`">slots</popover> or both. 
+MarkBind components may support <popover id="pop:markbind-attributes" header="`header` is an **attribute** here:" content="`<panel header='Hello'></panel>`">attributes</popover>, <popover id="pop:markbind-slots" header="`header` is a **slot** here:" content="`<div slot='header'>Hello</div>`">slots</popover> or both. 
 Some components allow users to supply the same content as either a slot or an attribute.
 If an author provides the same content as both a slot and an attribute, in most cases, the slot should override the attribute. 
 
-<box type='warning' light>
+<box type='warning' seamless>
 
 MarkBind should also **log a warning** to inform the author of this conflict!
 </box>

--- a/docs/devGuide/writingComponents.md
+++ b/docs/devGuide/writingComponents.md
@@ -1,0 +1,115 @@
+{% set title = "Writing Components" %}
+<span id="title" class="d-none">{{ title }}</span>
+
+<frontmatter>
+  title: "{{ title }}"
+  layout: devGuide.md
+  pageNav: default
+</frontmatter>
+
+# {{ title }}
+
+<div class="lead">
+
+This page explains various concerns related to MarkBind components, focused on implementation and testing.
+</div>
+
+## Implementing Components
+
+There are multiple ways to implement MarkBind components.
+
+<box type='warning' light>
+
+If an author has a conflicting slot and attribute, MarkBind should **log a warning** to let them know!
+</box>
+
+### Transforming the Node Directly
+
+One way to implement a MarkBind component is to transform the node itself.
+This is a more low-level implementation that can be useful when a node only needs to be modified slightly.
+
+When a node is processed, MarkBind syntax is converted to HTML, and any remaining attributes will also be converted to HTML attributes. 
+This can be useful if you just need to add a HTML attribute to the node, or modify the value of an existing attribute.
+
+These transformations may take place at various stages of node processing: before (`preProcessNode`), during (`processNode`), or after (`postProcessNode`).
+
+{{ icon_examples }} 
+* Adding a class to a node (setting line numbers for code blocks)
+* Modifying attributes and adding a directive to a node ([former implementation](https://github.com/MarkBind/markbind/blob/502df135e07baebd9d4eea8ccc0654c990047792/packages/core/src/html/bootstrapVueProcessor.js#L73) of popovers)
+
+</box>
+
+### Vue Components
+
+Many MarkBind components are implemented as Vue components, either by creating a component in the `vue-components` package, or by importing a component from an external library.
+This can be useful when a more complicated set of features is needed, where a Vue component can provide an interface for us to manage these functionalities.
+
+Vue components are registered in `vue-components/src/index.js`, which allows them to be used in any Vue instance without needing to be imported first.
+
+<panel header="How do MarkBind attributes/slots get passed to the Vue component?">
+
+##### Attributes
+
+MarkBind attributes are passed to the Vue component as **props**. The type of the prop will be a `String`.
+
+##### Slots
+
+MarkBind slots are passed as **named slots** to the Vue component. The name of the MarkBind slot will be the same as the name of the Vue slot.
+Hence, MarkBind slots can be accessed in a Vue component either through the [named slots](https://v2.vuejs.org/v2/guide/components-slots.html#Named-Slots) or through the [`$slots` API](https://v2.vuejs.org/v2/api/#vm-slots).
+</panel>
+
+<br>
+
+{{ icon_examples }} 
+* As a wrapper for an external library (Modal component)
+* To implement a set of customised behaviours (Quiz component)
+
+### As a Plugin
+
+MarkBind components can be implemented as a plugin as well. 
+This is suitable for more lightweight components where the implementation is largely in processing the node, making it suitable to use MarkBind Plugins' `processNode` or `postRender` interfaces.
+
+{{ icon_examples }} 
+* The `tree` component is implemented as a default plugin
+
+## Testing Components
+
+Automated tests that are relevant to the components include:
+
+* [Functional tests]({{baseUrl}}/devGuide/workflow.html#adding-test-site-content)
+* [Snapshot tests]({{baseUrl}}/devGuide/workflow.html#adding-snapshot-tests-for-components)
+
+The API for Snapshot tests can be found at [Vue Test Utils](https://v1.test-utils.vuejs.org/).
+
+Additionally, it's a good idea to check the deployed PR preview in addition to serving the app locally, to ensure that there are no differences.
+
+## Additional Considerations
+
+Some things you may need to consider when implementing a MarkBind component:
+
+#### Reactivity
+
+_Reactivity_ refers to the ability of a web framework to update your view whenever the application state has changed. 
+It is important to consider reactivity when implementing a component that may have dynamic contents that readers can interact with (e.g. opening a panel, triggering a tooltip to show).
+
+#### SSR
+
+Components should be compatible with SSR. 
+Minimally, there should be no SSR issues (viewable from the browser console), though a lack of warnings does **not** mean that there are no SSR problems. 
+A guide on SSR for MarkBind can be found [here]({{baseUrl}}/devGuide/serverSideRendering.html). 
+
+Vue-component-specific tips for resolving SSR issues:
+* The `mount` and `beforeMount` lifecycle hooks will only be executed on the client, not the server
+* When using `v-if`, ensure that it will evaluate to the same value on both the client and server 
+* Take note of how the Vue component will be compiled, ensure that the HTML is correct and aligns on both client- and server- side
+* Conditionally render data when it has been fully loaded
+
+#### Bundle size
+
+When creating a new component, you may need to import a package or library to support some functionality. 
+Ideally, this should not increase MarkBind's bundle size too much.
+
+#### Dependencies
+
+When choosing to use an external library, it should ideally be well-maintained and not have too many dependencies, especially high-level dependencies. High-level dependencies may lag behind the most recent releases of other libraries, which may become a blocker for MarkBind to migrate to these recent releases as well.
+


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Addresses the 3rd checkbox of #1027 

**Overview of changes:**
Adds a "Writing Components" page to the MarkBind developer docs. This page aims to give a better idea of how MarkBind components work to make it easier for new developers to contribute MarkBind components (creating/modifying), and point out some things to look out for when working with MarkBind components.

Contents:
- Creating components in different ways, with examples of use cases for each way
- Testing components
- Things to look out for

Open to suggestions & feedback! 

**Anything you'd like to highlight / discuss:**
I realise the examples provided may become outdated over time. Would it be a good idea to add permalinks to the codebase? Not sure if it will confuse new developers 

**Testing instructions:**
Preview: https://deploy-preview-1865--markbind-master.netlify.app/devguide/writingcomponents

**Proposed commit message: (wrap lines at 72 characters)**
```
Add Writing Components page to dev docs
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

