### PR TITLE
Bootstrap 5: Close button

### DIFF
--- a/packages/vue-components/src/Modal.vue
+++ b/packages/vue-components/src/Modal.vue
@@ -21,11 +21,10 @@
         </h5>
         <button
           type="button"
-          class="close"
+          class="btn-close"
           aria-label="Close"
           @click="close()"
         >
-          <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">

--- a/packages/vue-components/src/TipBox.vue
+++ b/packages/vue-components/src/TipBox.vue
@@ -52,11 +52,10 @@
         <button
           v-if="dismissible"
           type="button"
-          class="close close-with-heading"
-          data-dismiss="alert"
+          class="btn-close close-with-heading"
+          data-bs-dismiss="alert"
           aria-label="Close"
         >
-          <span aria-hidden="true">&times;</span>
         </button>
       </div>
 
@@ -98,11 +97,10 @@
         <button
           v-if="dismissible && !headerBool()"
           type="button"
-          class="close"
-          data-dismiss="alert"
+          class="btn-close"
+          data-bs-dismiss="alert"
           aria-label="Close"
         >
-          <span aria-hidden="true">&times;</span>
         </button>
       </div>
     </div>
@@ -346,12 +344,18 @@ export default {
     }
 
     .close-with-heading {
-        top: auto;
-        padding: 0 1.25rem;
+        top: 0;
+        right: 0;
+        position: absolute;
+        padding: 1rem;
     }
 
     .close-with-heading > span {
         vertical-align: text-top;
+    }
+
+    .alert-dismissible .btn-close {
+        padding: 1rem ;
     }
 
     .contents > :last-child {

--- a/packages/vue-components/src/TipBox.vue
+++ b/packages/vue-components/src/TipBox.vue
@@ -355,7 +355,7 @@ export default {
     }
 
     .alert-dismissible .btn-close {
-        padding: 1rem ;
+        padding: 1rem;
     }
 
     .contents > :last-child {

--- a/packages/vue-components/src/__tests__/__snapshots__/Modal.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/Modal.spec.js.snap
@@ -51,15 +51,9 @@ exports[`Modal can be centered 1`] = `
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div
@@ -129,15 +123,9 @@ exports[`Modal can be large 1`] = `
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div
@@ -207,15 +195,9 @@ exports[`Modal can be small 1`] = `
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div
@@ -285,15 +267,9 @@ exports[`Modal should be closable by clicking the backdrop by default 1`] = `
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div
@@ -431,15 +407,9 @@ exports[`Modal should not be closable by clicking the backdrop if backdrop is se
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div
@@ -509,15 +479,9 @@ exports[`Modal should not show footer when no footer is given 1`] = `
              
             <button
               aria-label="Close"
-              class="close"
+              class="btn-close"
               type="button"
-            >
-              <span
-                aria-hidden="true"
-              >
-                ×
-              </span>
-            </button>
+            />
           </div>
            
           <div

--- a/packages/vue-components/src/__tests__/__snapshots__/TipBox.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/TipBox.spec.js.snap
@@ -755,16 +755,10 @@ exports[`TipBox with dismissible option renders correctly 1`] = `
        
       <button
         aria-label="Close"
-        class="close"
-        data-dismiss="alert"
+        class="btn-close"
+        data-bs-dismiss="alert"
         type="button"
-      >
-        <span
-          aria-hidden="true"
-        >
-          ×
-        </span>
-      </button>
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

Part of #1702 

**Overview of changes:**
Account for the changes in the close button for Bootstrap 4->5
- Rename from `.close` to `.btn-close`
- Position the button correctly, as the button size has increased

These changes were made in Modals and TipBox, which use the close button.

**Anything you'd like to highlight / discuss:**
Change in UI: The close button is now larger

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/61113575/162201072-ff3b5b9b-1417-4383-8e73-c23bcfb17a2b.png) | ![image](https://user-images.githubusercontent.com/61113575/162200958-819dabba-7ffb-4a93-973f-802abe370a33.png) |
| ![image](https://user-images.githubusercontent.com/61113575/162201382-15a7c408-5467-4410-99d3-8b2770ca1cd2.png) | ![image](https://user-images.githubusercontent.com/61113575/162201429-82d69624-9c62-4b40-acb5-6e8a01d9e688.png) |


**Testing instructions:**
Close buttons that use the `.btn-close` class (previously `.close`) should 
- Work as expected, i.e. can click to close
- Look correct aside from the increase in size, e.g. no weird spacings

**Proposed commit message: (wrap lines at 72 characters)**
```
Migrate close buttons
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->
