### PR TITLE
Bootstrap 5: Prevent Navbars from being printed

### DIFF
--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <nav ref="navbar" :class="['navbar', 'navbar-expand-md', themeOptions, addClass, fixedOptions]">
+    <nav ref="navbar" :class="['navbar', 'navbar-expand-md', 'd-print-none', themeOptions, addClass, fixedOptions]">
       <div class="container-fluid">
         <div class="navbar-left">
           <slot name="brand"></slot>

--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <nav ref="navbar" :class="['navbar', 'navbar-expand-md', 'd-print-none', themeOptions, addClass, fixedOptions]">
+    <nav
+      ref="navbar"
+      :class="['navbar', 'navbar-expand-md', 'd-print-none', themeOptions, addClass, fixedOptions]"
+    >
       <div class="container-fluid">
         <div class="navbar-left">
           <slot name="brand"></slot>

--- a/packages/vue-components/src/__tests__/__snapshots__/Navbar.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/Navbar.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Navbar and secondary navbar navbar with page nav button 1`] = `
 <div>
   <nav
-    class="navbar navbar-expand-md navbar-dark bg-primary"
+    class="navbar navbar-expand-md d-print-none navbar-dark bg-primary"
   >
     <div
       class="container-fluid"
@@ -68,7 +68,7 @@ exports[`Navbar and secondary navbar navbar with page nav button 1`] = `
 exports[`Navbar and secondary navbar navbar with site and page nav buttons 1`] = `
 <div>
   <nav
-    class="navbar navbar-expand-md navbar-dark bg-primary"
+    class="navbar navbar-expand-md d-print-none navbar-dark bg-primary"
   >
     <div
       class="container-fluid"
@@ -135,7 +135,7 @@ exports[`Navbar and secondary navbar navbar with site and page nav buttons 1`] =
 exports[`Navbar and secondary navbar navbar with site nav button 1`] = `
 <div>
   <nav
-    class="navbar navbar-expand-md navbar-dark bg-primary"
+    class="navbar navbar-expand-md d-print-none navbar-dark bg-primary"
   >
     <div
       class="container-fluid"
@@ -200,7 +200,7 @@ exports[`Navbar and secondary navbar navbar with site nav button 1`] = `
 exports[`Navbar and secondary navbar navbar without site and page nav buttons 1`] = `
 <div>
   <nav
-    class="navbar navbar-expand-md navbar-dark bg-primary"
+    class="navbar navbar-expand-md d-print-none navbar-dark bg-primary"
   >
     <div
       class="container-fluid"


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

Part of #1702

**Overview of changes:**
Add the `d-print-none` class to navbars so that they will not be printed.

**Anything you'd like to highlight / discuss:**
N/A

**Testing instructions:**
Navbars should not be printed.

**Proposed commit message: (wrap lines at 72 characters)**
```
Prevent Navbars from being printed
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
