### PR TITLE
Fix modal positioning in panel headers

### DIFF
--- a/packages/vue-components/src/panels/NestedPanel.vue
+++ b/packages/vue-components/src/panels/NestedPanel.vue
@@ -243,7 +243,7 @@ export default {
     }
 
     .card-title * {
-        margin: 0 !important;
+        margin-bottom: 0 !important;
     }
 
     .caret-wrapper {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes the positioning issues from #1909 

**Overview of changes:**
Fixes the styles from panel headers which was disrupting modal positioning.
- Change `margin: 0` to `margin-bottom: 0` which seems to be the minimal change that retains panel header styling without affecting modal positioning

**Anything you'd like to highlight / discuss:**
The CSS here was inherited from MarkBind/vue-strap, where it was first implemented for [minimal panels](https://github.com/MarkBind/vue-strap/pull/117)

**Testing instructions:**
Modals in panel headers should now be positioned correctly.

**Proposed commit message: (wrap lines at 72 characters)**
```
Fix modal positioning in panel headers
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
