### PR TITLE
Use css variables for fixed header style updates

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -21,12 +21,6 @@ function scrollToUrlAnchorHeading() {
   }
 }
 
-function insertCss(cssCode) {
-  const newNode = document.createElement('style');
-  newNode.innerHTML = cssCode;
-  document.getElementsByTagName('head')[0].appendChild(newNode);
-}
-
 function detectAndApplyFixedHeaderStyles() {
   jQuery(':header').each((index, heading) => {
     if (heading.id) {
@@ -40,45 +34,9 @@ function detectAndApplyFixedHeaderStyles() {
     return;
   }
 
-  const headerHeight = headerSelector.height();
-  const bufferHeight = 1;
-  insertCss(`.fixed-header-padding { padding-top: ${headerHeight}px !important; }`);
-  insertCss(
-    `span.anchor {
-    position: relative;
-    top: calc(-${headerHeight}px - ${bufferHeight}rem);
-    }`,
-  );
-  insertCss(`.nav-menu-open { max-height: calc(100% - ${headerHeight}px); }`);
-
-  const adjustHeaderClasses = () => {
+  const updateHeaderHeight = () => {
     const newHeaderHeight = headerSelector.height();
-    const sheets = document.styleSheets;
-
-    for (let i = 0; i < sheets.length; i += 1) {
-      try {
-        const rules = sheets[i].cssRules;
-        // eslint-disable-next-line lodash/prefer-get
-        if (rules && rules[0] && rules[0].selectorText) {
-          switch (rules[0].selectorText) {
-          case '.fixed-header-padding':
-            sheets[i].deleteRule(0);
-            sheets[i].insertRule(`.fixed-header-padding { padding-top: ${newHeaderHeight}px !important; }`);
-            break;
-          case 'span.anchor':
-            rules[0].style.top = `calc(-${newHeaderHeight}px - ${bufferHeight}rem)`;
-            break;
-          case '.nav-menu-open':
-            rules[0].style.maxHeight = `calc(100% - ${newHeaderHeight}px + 50px)`;
-            break;
-          default:
-            break;
-          }
-        }
-      } catch (e) {
-        // cssRules is not accessible for this stylesheet due to CORS, continue to the next stylesheet
-      }
-    }
+    document.documentElement.style.setProperty('--header-height', `${newHeaderHeight}px`);
   };
 
   const toggleHeaderOverflow = () => {
@@ -87,7 +45,7 @@ function detectAndApplyFixedHeaderStyles() {
     // in the header such as search dropdown etc. to overflow
     if (headerMaxHeight === '100%') {
       headerSelector.css('overflow', '');
-      adjustHeaderClasses();
+      updateHeaderHeight();
     }
   };
 
@@ -130,7 +88,7 @@ function detectAndApplyFixedHeaderStyles() {
       headerSelector.css('overflow', 'hidden');
       return;
     }
-    adjustHeaderClasses();
+    updateHeaderHeight();
   });
   resizeObserver.observe(headerSelector[0]);
   headerSelector[0].addEventListener('transitionend', toggleHeaderOverflow);

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -128,7 +128,6 @@ code.hljs.inline {
 /* Header */
 
 header[fixed] {
-    top: 0;
     max-height: 100%;
     position: fixed;
     transition: max-height 0.6s ease-in;

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -145,7 +145,7 @@ span.anchor {
     top: calc(-1 * var(--header-height) - 1rem);
 }
 
-.nav-menu-open {
+header[fixed] .nav-menu-open {
     max-height: calc(-1 * var(--header-height) + 100% + 50px);
 }
 

--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -1,3 +1,7 @@
+:root {
+    --header-height: 0;
+}
+
 a {
     text-decoration: none;
 }
@@ -124,6 +128,7 @@ code.hljs.inline {
 /* Header */
 
 header[fixed] {
+    top: 0;
     max-height: 100%;
     position: fixed;
     transition: max-height 0.6s ease-in;
@@ -134,6 +139,19 @@ header[fixed] {
 header[fixed].hide-header {
     max-height: 0;
     transition: max-height 0.6s ease-out;
+}
+
+span.anchor {
+    position: relative;
+    top: calc(-1 * var(--header-height) - 1rem);
+}
+
+.nav-menu-open {
+    max-height: calc(-1 * var(--header-height) + 100% + 50px);
+}
+
+.fixed-header-padding {
+    padding-top: var(--header-height) !important;
 }
 
 /* #app is treated as the main container */


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] Others, please explain:

Small cleanup / prelude to the ux issue https://github.com/MarkBind/markbind/issues/1560 to make things easier

**Overview of changes:**
`<style>`sheet modifications are replaced in favour of css variables for simplification

**Anything you'd like to highlight / discuss:**
na

**Testing instructions:**
- Fixed headers work
- Anchor paddings should also still work
- As well as `nav-menu-open` (mobile site nav dropdown / overlay)

sidenote: noticed while tackling this that the z-index handling for the mobile overlay is broken in the case of no `header[fixed]`, we can fix this sometime separately from this issue

**Proposed commit message: (wrap lines at 72 characters)**
Use css variables for fixed header style updates

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- Its tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
