### PR TITLE
Use event listener to restore header on expand window

### DIFF
--- a/packages/core-web/src/index.js
+++ b/packages/core-web/src/index.js
@@ -52,6 +52,13 @@ function detectAndApplyFixedHeaderStyles() {
   let lastOffset = 0;
   let lastHash = window.location.hash;
   const toggleHeaderOnScroll = () => {
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 767 && headerSelector.hasClass('hide-header')) {
+        headerSelector.removeClass('hide-header');
+        headerSelector.css('overflow', '');
+      }
+    });
+
     // prevent toggling of header on desktop site
     if (window.innerWidth > 767) { return; }
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

**Overview of changes:**
Fixes #1922

**Anything you'd like to highlight / discuss:**
I added event listener to listen resize event, as apparently window's innerwidth remains unchanged on clicking the expand window button.

**Testing instructions:**
Navbar reappears on expanding window/pressing expanding window button.

**Proposed commit message: (wrap lines at 72 characters)**
`Fix navbar disappearing on expanding window`
