### PR TITLE
Remove padding top from navbar site logo

### DIFF
--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -364,7 +364,7 @@ export default {
     }
 
     .navbar-brand > img,
-    svg {
+    .navbar-brand > svg {
         display: block;
     }
 

--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -362,7 +362,9 @@ export default {
     .navbar-brand {
         display: inline-block;
     }
-    .navbar-brand > img, svg {
+
+    .navbar-brand > img,
+    svg {
         display: block;
     }
 

--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -362,16 +362,20 @@ export default {
     .navbar-brand {
         display: inline-block;
     }
+    .navbar-brand > img, svg {
+        display: block;
+    }
 
     .navbar-right {
         padding-right: 1rem;
     }
 
     .navbar-left {
-        display: inline-block;
+        align-items: center;
+        display: flex;
         font-size: 1.25rem;
         line-height: inherit;
-        padding: 0 1rem 0.3125rem 0;
+        padding: 0.3125rem 1rem;
         white-space: nowrap;
     }
 

--- a/packages/vue-components/src/Navbar.vue
+++ b/packages/vue-components/src/Navbar.vue
@@ -371,7 +371,7 @@ export default {
         display: inline-block;
         font-size: 1.25rem;
         line-height: inherit;
-        padding: 0.3125rem 1rem;
+        padding: 0 1rem 0.3125rem 0;
         white-space: nowrap;
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

**Overview of changes:**
Resolves #1895

**Anything you'd like to highlight / discuss:**
Remove padding top from .nav-left class selector.

Before:
![image](https://user-images.githubusercontent.com/77185324/169780129-e4e88ee8-0a4a-45a4-8999-e86850d1cfd2.png)
After:
![image](https://user-images.githubusercontent.com/77185324/169824791-b53475e8-2c58-499a-a239-4af90a3605ce.png)

**Testing instructions:**
Inspect navbar site logo and it is now align-center with other navbar elements.

**Proposed commit message: (wrap lines at 72 characters)**
`Remove padding top from site logo`

