### PR TITLE
Reset overflow on modal close

### DIFF
--- a/packages/vue-components/src/Modal.vue
+++ b/packages/vue-components/src/Modal.vue
@@ -56,6 +56,7 @@ export default {
   data: () => ({
     show: false,
     isMounted: false,
+    previousOverflow: '',
     zoomEffect: {
       'enter-class': 'modal-zoom',
       'enter-to-class': 'modal-zoom-show',
@@ -93,6 +94,13 @@ export default {
       default: '',
     },
   },
+  watch: {
+    show(newShow) {
+      if (!newShow && this.previousOverflow !== undefined) {
+        document.body.style.overflow = this.previousOverflow;
+      }
+    },
+  },
   computed: {
     hasHeader() {
       return !!this.$slots.header;
@@ -123,6 +131,7 @@ export default {
   },
   mounted() {
     this.isMounted = true;
+    this.previousOverflow = document.body.style.overflow;
   },
 };
 </script>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Possibly fixes #2008, fixes #2025 though it does not fix its root cause

**Overview of changes:**
Manually resets the overflow attribute 

**Anything you'd like to highlight/discuss:**
This fixes the overflow problem, but might not be fixing the root problem - I wasn't able to isolate the reason for this bug

**Testing instructions:**
Build the CS2103 website and visit website/se-book-adapted/print.html 

**Proposed commit message: (wrap lines at 72 characters)**
```
Manually reset overflow on modal close

In some cases, opening and then closing a modal makes the page
unscrollable. This occurs in some cases (not always).

Let's manually reset the overflow attribute to ensure that the page
reverts to its initial scrollable state. 
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
