### PR TITLE
Add release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -47,12 +47,12 @@ change-template: "* $TITLE (#$NUMBER)"
 version-resolver:
   major:
     labels:
-      - 'r.major'
+      - 'r.Major'
   minor:
     labels:
-      - 'r.minor'
+      - 'r.Minor'
   patch:
     labels:
-      - 'r.patch'
+      - 'r.Patch'
   default: patch
 name-template: v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+template: |
+  # markbind-cli
+  <!-- List out each of the PR for this version in the following format: -->
+  <!-- #ISSUE_NUMBER ISSUE_TITLE (#PR_NUMBER) -->
+  ## User Facing Changes
+
+  ### Breaking Changes
+  <!-- Any feature that is made obsolete -->
+
+  > Also give a brief explanation note about:
+  >   - what was the old feature that was made obsolete
+  >   - any replacement feature (if any), and
+  >   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
+
+  ### Features
+  <!-- Features enable users (authors/readers) to do something new. -->
+
+  ### Enhancements
+  <!-- Enhances any existing features -->
+
+  ### Fixes
+  <!-- Fixes correct a programming error/assumption. -->
+
+  ### Documentation
+  <!-- Pure changes to the documentation, such as typo, restructuring, etc -->
+
+  ## Other Changes
+
+  ### Code Quality
+  <!-- Refactoring, etc. -->
+
+  ### DevOps Changes
+  <!-- Tooling, etc. -->
+
+  ### Dependencies
+  <!-- Dependency version upgrades of the main or any subpackages -->
+
+  ### Miscellaneous
+  <!-- Any other changes -->
+
+  <!-- When it's time to release, move the items below into the respective categories -->
+
+  $CHANGES
+
+tag-template: 'v$RESOLVED_VERSION'
+change-template: "* $TITLE (#$NUMBER)"
+version-resolver:
+  major:
+    labels:
+      - 'r.major'
+  minor:
+    labels:
+      - 'r.minor'
+  patch:
+    labels:
+      - 'r.patch'
+  default: patch
+name-template: v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [x] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #1713

Add the release-drafter action to aid in the drafting of release notes. It does not fully automate the process due to the following reasons:
- in order to know what categories the PR is in, you will either need to codify some rules (e.g based on file changes, but may not be accurate), or enforce labeling on the PR (which, is not very easy to ensure 100% compliance due to forgetfulness)
- it's not easy to tell what "issue" the PR is resolving automatically and release-draft doesn't have the ability to do so, but in our template, we are supposed to fill in the issues targeted by each PR

In conclusion, this inclusion does very limited things, but since it's a very low-risk and low-effort integration, we can try it out and make further improvements in the future. The limited benefits include:
- no need to manually copy the release note template from dev docs
- PRs of the form "title" + "PR number" is already pre-filled, so you just need to fill in the issue number
  - You will also need to move the PR items into the correct category, which is exactly the same as what you need to do now
- as for version control, our release process dictates that we would already know the version number when we want to release. Nonetheless, I have added labels (r.major, r.minor, r.patch) and the respective rules such that release-drafter can help calculate the next version number and use it in the draft release note, if the labels are added to the PRs. If not added, the version will simply defaults to patch. Again, this is optional and can be edited easily.

**Anything you'd like to highlight/discuss:**
Comments on whether you think we should add release-drafter, or not. (and anything else)

TODO: update devdocs if the answer to the above is yes.

**Testing instructions:**
Hard to test in this PR, can check out https://github.com/tlylt/test-release-drafter for example and sample release note
<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
TODO

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
