### PR TITLE
Support iconColor in box when light/seamless is used

### DIFF
--- a/packages/vue-components/src/Box.vue
+++ b/packages/vue-components/src/Box.vue
@@ -255,7 +255,7 @@ export default {
     },
     customIconColorStyle() {
       if (this.iconColor) {
-        return { color: this.iconColor };
+        return { color: `${this.iconColor}!important` };
       }
       return {};
     },

--- a/packages/vue-components/src/__tests__/Box.spec.js
+++ b/packages/vue-components/src/__tests__/Box.spec.js
@@ -367,4 +367,15 @@ describe('Box', () => {
     });
     expect(wrapper.element).toMatchSnapshot();
   });
+
+  test('with custom icon color and light renders correctly', () => {
+    const wrapper = mount(Box, {
+      propsData: {
+        iconColor: 'red',
+        light: true,
+        type: 'warning',
+      },
+    });
+    expect(wrapper.element).toMatchSnapshot();
+  });
 });

--- a/packages/vue-components/src/__tests__/__snapshots__/Box.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/Box.spec.js.snap
@@ -698,6 +698,41 @@ exports[`Box with custom icon color and header renders correctly 1`] = `
 </div>
 `;
 
+exports[`Box with custom icon color and light renders correctly 1`] = `
+<div
+  class="alert box-container border-warning alert-border-left"
+>
+  <!---->
+   
+  <div
+    class="header-and-body"
+  >
+    <!---->
+     
+    <div
+      class="box-body-wrapper"
+    >
+      <div
+        class="icon-wrapper  text-warning"
+        style="color: red;"
+      >
+        <i
+          class="fas fa-exclamation"
+        />
+      </div>
+       
+      <!---->
+       
+      <div
+        class="contents"
+      />
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Box with custom icon color and no header renders correctly 1`] = `
 <div
   class="alert box-container alert-default"


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2174
<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Add !important to custom icon color to override default colors. 


**Anything you'd like to highlight/discuss:**


**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
```Support iconColor in box when light/seamless is used```
<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [X] Added tests for bug fixes or features
- [X] Linked all related issues
- [X] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
