### PR TITLE
Fix handling of empty segment includes

### DIFF
--- a/packages/core/src/html/includePanelProcessor.ts
+++ b/packages/core/src/html/includePanelProcessor.ts
@@ -235,9 +235,10 @@ export function processInclude(node: DomElement, context: Context, pageSources: 
   // the appropriate children to a wrapped include element
   if (hash) {
     const $ = cheerio.load(actualContent);
-    actualContent = $(hash).html() || '';
+    const actualContentOrNull = $(hash).html();
+    actualContent = actualContentOrNull || '';
 
-    if (actualContent === '' && !isOptional) {
+    if (actualContentOrNull === null && !isOptional) {
       const error = new Error(`No such segment '${hash}' in file: ${actualFilePath}\n`
        + `Missing reference in ${context.cwf}`);
       logger.error(error);

--- a/packages/core/test/unit/html/includePanelProcessor.test.js
+++ b/packages/core/test/unit/html/includePanelProcessor.test.js
@@ -121,6 +121,39 @@ test('includeFile replaces <include src="include.md#exists"> with <div>', async 
   expect(result).toEqual(expected);
 });
 
+test('includeFile replaces an empty segment <include src="include.md#empty"> with <div>', async () => {
+  const indexPath = path.resolve('index.md');
+
+  const index = [
+    '# Index',
+    '<include src="include.md#empty"/>',
+    '',
+  ].join('\n');
+
+  const include = [
+    '# Include',
+    'This is an empty segment:',
+    '<div id="empty"></div>',
+  ].join('\n');
+
+  const json = {
+    'index.md': index,
+    'include.md': include,
+  };
+
+  fs.vol.fromJSON(json, '');
+
+  const nodeProcessor = getNewDefaultNodeProcessor();
+  const result = await nodeProcessor.process(indexPath, index);
+
+  const expected = [
+    '<h1 id="index"><span id="index" class="anchor"></span>Index</h1>',
+    '<div></div>',
+  ].join('\n');
+
+  expect(result).toEqual(expected);
+});
+
 test('includeFile replaces <include src="include.md#exists" inline> with inline content', async () => {
   const indexPath = path.resolve('index.md');
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fix an edge case in handling `include`s for empty segments - the desired result is to allow the empty segment to be included instead of throwing an error.

**Testing instructions:**
Minimal reproduction:
```
<div id="empty"></div>
<include src="#empty">
```

**Proposed commit message: (wrap lines at 72 characters)**
```
Fix handling of empty segment includes

Attempting to include an empty segment will throw a "hash not found"
error on the MarkBind console output.

This is a regression on existing behaviour introduced by refactoring on
includePanelProcessor.

Let's revert the original behaviour of allowing empty hashes to be
included, and add test cases to check for this.
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [ ] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
