### PR TITLE
Add res parameter back to lazyReloadMiddleware

### DIFF
--- a/packages/cli/src/util/serveUtil.js
+++ b/packages/cli/src/util/serveUtil.js
@@ -67,7 +67,7 @@ const removeHandler = (site, onePagePath) => (filePath) => {
   });
 };
 
-const lazyReloadMiddleware = (site, rootFolder, config) => (req, next) => {
+const lazyReloadMiddleware = (site, rootFolder, config) => (req, res, next) => {
   const urlExtension = path.posix.extname(req.url);
 
   const hasEndingSlash = req.url.endsWith('/');


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Adds the `res` parameter to the `lazyReloadMiddleware` function that was omitted during the refactor in #2239.

While this parameter was accidentally removed due to not being used within the function itself, the `res` property is needed for functions passed into the live server (for lazy preview).

Thanks @yucheng11122017 for pointing it out!

**Anything you'd like to highlight/discuss:**

I've done a sanity check once more to make sure that there were no unnecessary changes made to the functions. Here are the list of changes to the functions:

- `syncOpenedPages` has been modified to take in the `site` parameter instead of none (i.e. `() => ...` to `(site => ...`). This is to allow it access to the `site` variable, which it could previously access as it was in the `serve` command declaration. The rest of the function was NOT modified.
- `addHandler`, `changeHandler`, `removeHandler`, and `lazyReloadMiddleware` functions were previously passed in as functions to other functions. They now take an additional set of parameters that return the function itself, done to allow it access to variables in the same manner as `syncOpenedPages` (i.e. `(filePath) => ...` to `(site, onePagePath) => (filePath) => ...`). The returned functions themselves were NOT modified (aside from `lazyReloadMiddleware`.

`lazyReloadMiddleware` was the only exception, as the parameter `res` was flagged as unused and was erroneously removed. This PR adds it back.

The bug was not flagged by the tests as there are currently no pre-existing unit tests for the `markbind serve` command. I will open up an issue to consider implementing unit tests for functions in `serveUtils`, which may have to modify these functions to be tested as needed. Additionally, more functional tests for `serve` should be considered, though they are not trivial to implement.

**Testing instructions:**

Try to serve with `markbind serve -d -o FILENAME`.

Originally: Displays an error saying "next is not a function".

New: Renders correctly.

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Add res parameter back to lazyReloadMiddleware
<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
