### PR TITLE
Remove option to lazy-load images

### DIFF
--- a/docs/userGuide/syntax/annotations.md
+++ b/docs/userGuide/syntax/annotations.md
@@ -145,7 +145,6 @@ This is effectively the same as the options used for the [picture](#pictures) co
 | src    | `string`  |         | **This must be specified.**<br>The URL of the image.<br>The URL can be specified as absolute or relative references. More info in: _[Intra-Site Links]({{baseUrl}}/userGuide/formattingContents.html#intraSiteLinks)_ |
 | height | `string`  |`''`| The height of the image in pixels.                                                                                                                                                                                    |
 | width  | `string`  |`''`| The width of the image in pixels.<br>If both width and height are specified, width takes priority over height. It is to maintain the image's aspect ratio.                                                            |
-| eager  | `boolean` | false   | The `<pic>` component lazy loads its images by default.<br>If you want to eagerly load the images, simply specify this attribute.                                                                                     |
 
 </div>
 

--- a/docs/userGuide/syntax/pictures.md
+++ b/docs/userGuide/syntax/pictures.md
@@ -8,10 +8,6 @@
 <pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo">
   MarkBind Logo
 </pic>
-
-<pic src="https://markbind.org/images/logo-lightbackground.png" width="300" alt="Logo" eager>
-  MarkBind Logo
-</pic>
 </variable>
 </include>
 

--- a/docs/userGuide/syntax/pictures.md
+++ b/docs/userGuide/syntax/pictures.md
@@ -22,7 +22,6 @@ alt | `string` | | **This must be specified.**<br>The alternative text of the im
 height | `string` | | The height of the image in pixels.
 src | `string` | | **This must be specified.**<br>The URL of the image.<br>The URL can be specified as absolute or relative references. More info in: _[Intra-Site Links]({{baseUrl}}/userGuide/formattingContents.html#intraSiteLinks)_
 width | `string` | | The width of the image in pixels.<br>If both width and height are specified, width takes priority over height. It is to maintain the image's aspect ratio.
-eager | `boolean` | false | The `<pic>` component lazy loads its images by default.<br>If you want to eagerly load the images, simply specify this attribute.
 
 <div id="short" class="d-none">
 

--- a/packages/vue-components/src/Pic.vue
+++ b/packages/vue-components/src/Pic.vue
@@ -6,7 +6,6 @@
       :alt="alt"
       :width="computedWidth"
       class="img-fluid rounded"
-      :loading="computedLoadType"
       @load.once="computeWidth"
     />
     <span class="image-caption">
@@ -36,10 +35,6 @@ export default {
       type: String,
       default: '',
     },
-    eager: {
-      type: Boolean,
-      default: false,
-    },
     addClass: {
       type: String,
       default: '',
@@ -57,9 +52,6 @@ export default {
         return this.width;
       }
       return this.widthFromHeight;
-    },
-    computedLoadType() {
-      return this.eager ? 'eager' : 'lazy';
     },
   },
   data() {

--- a/packages/vue-components/src/annotations/Annotate.vue
+++ b/packages/vue-components/src/annotations/Annotate.vue
@@ -6,7 +6,6 @@
       :alt="alt"
       :width="computedWidth"
       class="annotate-image"
-      :loading="computedLoadType"
       @load.once="getWidth"
     />
     <div style="top: 0; left: 0; height: 0;">
@@ -36,10 +35,6 @@ export default {
       type: String,
       default: '',
     },
-    eager: {
-      type: Boolean,
-      default: false,
-    },
     addClass: {
       type: String,
       default: '',
@@ -57,9 +52,6 @@ export default {
         return this.width;
       }
       return this.widthFromHeight;
-    },
-    computedLoadType() {
-      return this.eager ? 'eager' : 'lazy';
     },
   },
   data() {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [x] Others, please explain: feature removal

Removes lazy-loading option introduced in PR #1626.
Closes #2364
- a temporary measure, better solution would be to support lazy-load and scrolling

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Remove option to lazy load images as it results in scrolling issues (see #2364).

`eager` prop is removed from `<pic>` and `<annotate>` components.

 All images are now loaded eagerly.

**Anything you'd like to highlight/discuss:**


**Testing instructions:**

Open a browser (preferably a slower one like Firefox).

Notice that page might not scroll to correct section when you go to https://markbind.org/userGuide/components/imagesAndDiagrams.html and click on 'Thumbnails' on the pagenav. Because the previous sections 'Pictures' and 'Annotations' consist of images which are lazy-loaded.

Whereas for this PR, go to https://deploy-preview-2365--markbind-master.netlify.app/userguide/components/imagesanddiagrams and click on 'Thumbnails'. Page should scroll to the correct section 'Thumbnails'.


<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Remove option to lazy-load images

Lazy-loading option is introduced through the 'eager' prop in <pic> and <annotate> components.

Images are loaded as scrolling occurs, resulting in inaccurate scrolling as seen in issue #2364.

Let's remove 'eager' prop from <pic> and <annotate> components

All images are now loaded eagerly.


<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->
