### PR TITLE
Add horizontal spacing between the icon and text in the custom icon list #2352

### DIFF
--- a/packages/core/src/html/CustomListIconProcessor.ts
+++ b/packages/core/src/html/CustomListIconProcessor.ts
@@ -9,8 +9,8 @@ interface EmojiData {
 }
 
 const emojiData = emojiDictionary as unknown as EmojiData;
-
-const ICON_ATTRIBUTES = ['icon', 'i-width', 'i-height', 'i-size', 'i-class'];
+// Add new attribute called "i-spacing"
+const ICON_ATTRIBUTES = ['icon', 'i-width', 'i-height', 'i-size', 'i-class', 'i-spacing'];
 
 interface IconAttributes {
   icon?: string;
@@ -18,6 +18,7 @@ interface IconAttributes {
   size?: string;
   width?: string;
   height?: string;
+  spacing?: string; // Add new attribute 'spacing -> i-spacing'
 }
 
 type IconAttributeDetail = {
@@ -67,9 +68,11 @@ function createIconSpan(iconAttrs: IconAttributes): cheerio.Cheerio {
   }
   // Add invisible character to avoid the element from being empty
   spanNode.append('\u200B');
+  // If user doesn't put any i-spacing attribute number, then set default value as 0.35em
+  const iSpacing = iconAttrs.spacing || '0.35em';
   return spanNode.css({
     'line-height': 'unset',
-    'margin-inline-end': '0.35em',
+    'margin-inline-end': iSpacing,
     'align-self': 'flex-start',
     'flex-shrink': '0',
   });
@@ -98,6 +101,8 @@ IconAttributes | null => {
     height: node.attribs['i-height'] !== undefined ? node.attribs['i-height'] : iconAttrsSoFar?.height,
     size: node.attribs['i-size'] !== undefined ? node.attribs['i-size'] : iconAttrsSoFar?.size,
     className: node.attribs['i-class'] !== undefined ? node.attribs['i-class'] : iconAttrsSoFar?.className,
+    // Get spacing attribute
+    spacing: node.attribs['i-spacing'] !== undefined ? node.attribs['i-spacing'] : iconAttrsSoFar?.spacing,
   };
 };
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

This PR resolves issue https://github.com/MarkBind/markbind/issues/2352 by adding i-spacing attribute for modifying horizontal spacing between the icon and text in the custom icon list. 
- This feature enhancement is based on SPWwj's implementation of CustomListIconProcessor.ts.
- Refer issues: #2352, #2316.

**Overview of changes:**
1. By defining "{i-spacing="xem"}" attribute, user can customise the horizontal distance between icon and text. x means numbers.

  - CODE:

  `* **Item 1**: i-spacing is 0.15em {icon="glyphicon-education" i-width="70px" i-spacing="0.15em"}`
  `* **Item 2**: i-spacing is 0.55em{i-width="70px" i-spacing="0.55em"}`
  ` * Item 2.1: no i-spacing attribute, default is 0.35em {icon="fas-question-circle"}`
  `  * Item 2.2: `
  ` * Item 2.3: overwrite i-spacing attribute by 2em {i-spacing="2em"}`
  `* **Item 3**{i-width="70px"}`
  `  * Item 3.1: {icon="glyphicon-book" i-width="70px"}`
  `  * Item 3.2: {icon="/images/AzurLane_roma copy.png" i-size="10px" i-class="rounded"}`
<br>

  - OUTPUT:

<p align="center">
<img width="358" alt="Screenshot 2023-10-29 at 12 02 50 am" src="https://github.com/MarkBind/markbind/assets/105656080/9dfbbdd8-b484-4be7-b036-957f2dbd9e50">
</p>




**Anything you'd like to highlight/discuss:**

Once a i-spacing attribute is assigned to an icon, it will continue apply to icons at the same level (e.g., Item2.3, Item3.1, Item3.2), until it is overridden by a different i-spacing attribute (e.g., from Item 2.1 to Item 2.3).


**Testing instructions:**
1. Confirm that you have the correct branch for this pull request checked out on your local environment.
3. Establish a new MarkBind project using the markbind init command.
4. Experiment with the list using the provided syntax from above.

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Add i-spacing attribute to custom icon list

- Providing an option to adjust spacing between the icon and text for enhanced user experience.

- Add "i-spacing" attribute to ICON_ATTRIBUTES and interface IconAttributes

- Implement logic to check whether the user has defined the i-spacing attribute or not.

- Update createIconSpan function to incorporate i-spacing attribute.

- Update getIconAttributes function to retrieve i-spacing attribute.

- Changes maintains code consistency and cleanliness.

- Refer issues: #2352, #2316.

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---