### PR TITLE
Automatically add line-numbers when soft-wrapping (#2404)

### DIFF
--- a/packages/core/src/plugins/codeBlockWrapButtons.ts
+++ b/packages/core/src/plugins/codeBlockWrapButtons.ts
@@ -42,16 +42,19 @@ function toggleCodeBlockWrap(element) {
   const code = pre.querySelector('code');
   const classList = code.classList; 
 
+  if (code.dataset.originalLineNumbers === undefined) {
+    code.dataset.originalLineNumbers = classList.contains('line-numbers').toString();
+  }
+
   if (classList.contains('wrap')) {
     classList.remove('wrap');
-    if (code.dataset.addedLineNumbers) { 
+    if (code.dataset.originalLineNumbers === 'false') {
       classList.remove('line-numbers');
     }
   } else {
     classList.add('wrap');
-    if (!code.dataset.originalLineNumbers) { 
-      classList.add('line-numbers'); 
-      code.dataset.addedLineNumbers = true;
+    if (code.dataset.originalLineNumbers === 'false') {
+      classList.add('line-numbers');
     }
   }
 }

--- a/packages/core/src/plugins/codeBlockWrapButtons.ts
+++ b/packages/core/src/plugins/codeBlockWrapButtons.ts
@@ -37,16 +37,25 @@ function getButtonHTML() {
 }
 
 const wrapCodeBlockScript = `<script>
-    function toggleCodeBlockWrap(element) {
-      const pre = element.parentElement.parentElement;
-      const classList = pre.querySelector('code').classList; 
-      if (classList.contains('wrap')) {
-          classList.remove('wrap');
-      } else {
-          classList.add('wrap')
-      }
+function toggleCodeBlockWrap(element) {
+  const pre = element.parentElement.parentElement;
+  const code = pre.querySelector('code');
+  const classList = code.classList; 
+
+  if (classList.contains('wrap')) {
+    classList.remove('wrap');
+    if (code.dataset.addedLineNumbers) { 
+      classList.remove('line-numbers');
     }
-    </script>`;
+  } else {
+    classList.add('wrap');
+    if (!code.dataset.originalLineNumbers) { 
+      classList.add('line-numbers'); 
+      code.dataset.addedLineNumbers = true;
+    }
+  }
+}
+</script>`;
 
 export = {
   getScripts: () => [wrapCodeBlockScript],


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Currently, code wrapping is supported through the `codeBlockWrapButton` plugin. A problem with wrapping is that the indention is lost when a line of code is wrapped, which may alter the semantic meaning of the code for certain programming languages (e.g., Python). A workaround is that we automatically add line-numbers for the code when wrapping is applied, regardless of whether it is explicitly specified by the site creator.

**Anything you'd like to highlight/discuss:**
This PR hasn't addressed the printing part of (#2404) yet.

**Testing instructions:**
Add a fenced code block with a really long line in the test site. Activate the `codeBlockWrapButton` plugin by adding 
```
  "plugins": [
    "codeBlockWrapButtons"
  ]
```
in `site.json` of the test site.
<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [ ] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
