### PR TITLE
Disable pop over in a-point if there is no header and content passed by user

### DIFF
--- a/packages/vue-components/src/__tests__/__snapshots__/Annotation.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/Annotation.spec.js.snap
@@ -119,7 +119,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -153,7 +153,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 60px; height: 60px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 60px; height: 60px; cursor: default;"
                 />
                  
                 <div
@@ -187,7 +187,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -221,7 +221,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: red; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: red; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -255,7 +255,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.7; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.7; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -289,7 +289,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -323,7 +323,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: black; opacity: 1; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: black; opacity: 1; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -357,7 +357,7 @@ exports[`Annotation with different visual annotation points 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -407,7 +407,7 @@ exports[`Annotation with markdown in header, content and label 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -441,7 +441,7 @@ exports[`Annotation with markdown in header, content and label 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div
@@ -475,7 +475,7 @@ exports[`Annotation with markdown in header, content and label 1`] = `
               >
                 <button
                   class="hover-point"
-                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: pointer;"
+                  style="background-color: green; opacity: 0.3; width: 40px; height: 40px; cursor: default;"
                 />
                  
                 <div

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -195,7 +195,7 @@ export default {
       return this.legend === 'bottom' || this.legend === 'both';
     },
     hasPopover() {
-      return this.legend === 'popover' || this.legend === 'both';
+      return (this.hasContent || this.hasHeader) && (this.legend === 'popover' || this.legend === 'both');
     },
     computedBottomHeader() {
       if (this.label !== '' && this.header === '') {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2432
<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Disable tooltip if there is no header and no content passed by the user 

**Anything you'd like to highlight/discuss:**
nil

**Testing instructions:**
Try to make a-point with no content and header 
Previously, there will be a tool tip arrow but with no content which looks weird 
Now, there will be no tooltip

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Disable popover in a-point when there is no header and content

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [X] Added tests for bug fixes or features
- [X] Linked all related issues
- [X] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
