### PR TITLE
Test logger calls in tests for NodeProcessor

### DIFF
--- a/packages/core/test/unit/html/NodeProcessor.data.ts
+++ b/packages/core/test/unit/html/NodeProcessor.data.ts
@@ -322,6 +322,6 @@ export const PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 </dropdown>
 `;
 
-export const PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG = "dropdown has a header slot, 'header' attribute has no effect."
+export const PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG = "dropdown has a header slot, 'header' attribute has no effect.";
 
 /* eslint-enable max-len */

--- a/packages/core/test/unit/html/NodeProcessor.data.ts
+++ b/packages/core/test/unit/html/NodeProcessor.data.ts
@@ -188,6 +188,9 @@ export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
 </popover>
 `;
 
+export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_HEADER_WARN_MSG = "popover has a header slot, 'header' attribute has no effect.";
+export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_CONTENT_WARN_MSG = "popover has a content slot, 'content' attribute has no effect.";
+
 /*
  * Tooltips
  */
@@ -318,5 +321,7 @@ export const PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
   Header attribute should be ignored and deleted while header slot is reserved.
 </dropdown>
 `;
+
+export const PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG = "dropdown has a header slot, 'header' attribute has no effect."
 
 /* eslint-enable max-len */

--- a/packages/core/test/unit/html/NodeProcessor.data.ts
+++ b/packages/core/test/unit/html/NodeProcessor.data.ts
@@ -36,6 +36,8 @@ export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 </panel>
 `;
 
+export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG = "panel has a header slot, 'header' attribute has no effect.";
+
 export const PROCESS_PANEL_HEADER_NO_OVERRIDE = `
 <panel header="# Lorem ipsum" alt="**strong alt**">
   <div slot="header">

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -80,10 +80,13 @@ test('processNode processes quiz attributes and inserts into dom as slots correc
 });
 
 test('processNode processes popover attributes and inserts into dom as slots correctly', () => {
+  const warnSpy = jest.spyOn(logger, 'warn');
   processAndVerifyTemplate(testData.PROCESS_POPOVER_ATTRIBUTES,
                            testData.PROCESS_POPOVER_ATTRIBUTES_EXPECTED);
   processAndVerifyTemplate(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE,
                            testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_EXPECTED);
+  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_HEADER_WARN_MSG);
+  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_CONTENT_WARN_MSG);
 });
 
 test('processNode processes tooltip attributes and inserts into dom as slots correctly', () => {
@@ -126,8 +129,10 @@ test('processNode processes dropdown header attribute and inserts into DOM as he
 });
 
 test('processNode processes dropdown with header slot taking priority over header attribute', () => {
+  const warnSpy = jest.spyOn(logger, 'warn');
   processAndVerifyTemplate(testData.PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY,
                            testData.PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_EXPECTED);
+  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_DROPDOWN_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG);
 });
 
 test('markdown coverts inline colour syntax correctly', async () => {

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -11,8 +11,7 @@ import { MbNode, parseHTML } from '../../../src/utils/node';
 jest.mock('../../../src/utils/logger', () => ({
   warn: jest.fn(),
 }));
-
-afterEach(() => {
+beforeEach(() => {
   jest.clearAllMocks();
 });
 

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../src/utils/logger', () => ({
 
 afterEach(() => {
   jest.clearAllMocks();
-})
+});
 
 /**
  * Runs the processNode or postProcessNode method of NodeProcessor on the provided

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -2,10 +2,15 @@ import path from 'path';
 import cheerio from 'cheerio';
 import htmlparser from 'htmlparser2';
 import * as testData from './NodeProcessor.data';
+import * as logger from '../../../src/utils/logger';
 import { Context } from '../../../src/html/Context';
 import { shiftSlotNodeDeeper, transformOldSlotSyntax } from '../../../src/html/vueSlotSyntaxProcessor';
 import { getNewDefaultNodeProcessor } from '../utils/utils';
 import { MbNode, parseHTML } from '../../../src/utils/node';
+
+jest.mock('../../../src/utils/logger', () => ({
+  warn: jest.fn(),
+}));
 
 /**
  * Runs the processNode or postProcessNode method of NodeProcessor on the provided
@@ -42,12 +47,15 @@ const processAndVerifyTemplate = (template: string, expectedTemplate: string, po
 };
 
 test('processNode processes panel attributes and inserts into dom as slots correctly', () => {
+  const warnSpy = jest.spyOn(logger, 'warn');
   processAndVerifyTemplate(testData.PROCESS_PANEL_ATTRIBUTES,
                            testData.PROCESS_PANEL_ATTRIBUTES_EXPECTED);
   processAndVerifyTemplate(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY,
                            testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_EXPECTED);
+  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG);
   processAndVerifyTemplate(testData.PROCESS_PANEL_HEADER_NO_OVERRIDE,
                            testData.PROCESS_PANEL_HEADER_NO_OVERRIDE_EXPECTED);
+  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG);
 });
 
 test('processNode processes question attributes and inserts into dom as slots correctly', () => {

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -12,6 +12,10 @@ jest.mock('../../../src/utils/logger', () => ({
   warn: jest.fn(),
 }));
 
+afterEach(() => {
+  jest.clearAllMocks();
+})
+
 /**
  * Runs the processNode or postProcessNode method of NodeProcessor on the provided
  * template, verifying it with the expected result.

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -11,6 +11,7 @@ import { MbNode, parseHTML } from '../../../src/utils/node';
 jest.mock('../../../src/utils/logger', () => ({
   warn: jest.fn(),
 }));
+
 beforeEach(() => {
   jest.clearAllMocks();
 });


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [x] Others, please explain: Improve tests

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Partially addresses #2099
Related to #2053 

**Overview of changes:**
* Mocked the logger
* Added expectations to test if the logger is called with the correct input
* Added constants for expected logger input

**Anything you'd like to highlight/discuss:**

_Mocking vs Spying_

I chose to mock the logger instead of spy on it so as to decouple the logger from this test. If I had spied on the logger, the actual implementation of the logger would have been used, which may also consume (slightly) more resources. Also, errors from `winston` might also interfere with the test (even though that's very unlikely).

One side-effect of mocking the logger is that the logger output will not be printed in the console, as seen in the screenshot below (left is spied, right is mocked).

<img width="1448" alt="Screenshot 2024-03-15 at 6 58 16 PM" src="https://github.com/MarkBind/markbind/assets/68138671/d114c568-a66c-4d7e-bd6f-66621d83bc42">

If the logger output is still needed to be printed in the console, then a mock implementation of the `warn` method could look something like this
```javascript
jest.mock('../../../src/utils/logger', () => ({
  warn: jest.fn(msg => console.log(`warn: ${msg}`)),
}));
```
and would result in this being printed to the console

<img width="654" alt="Screenshot 2024-03-15 at 9 22 20 PM" src="https://github.com/MarkBind/markbind/assets/68138671/bfae6aa0-63c4-4e57-9ca5-af0713a78dc1">

which does look pretty clunky. Do let me know which approach you prefer. 

_Inconsistent naming in `NodeProcessor.data.ts`_

The naming conventions of the test inputs in `NodeProcessor.data.ts` are inconsistent. Many of the elements there have a test to check if the slots do override the attributes of the elements, but they are named in two separate ways:
1. `PROCESS_[ELEMENT]_ATTRIBUTES_NO_OVERRIDE`
2. `PROCESS_[ELEMENT]_[ATTRIBUTE]_SLOT_TAKES_PRIORITY`

I think that's why the author of #2053 wrote another constant called `PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY` when the constant `PROCESS_PANEL_ATTRIBUTES_NO_OVERRIDE` tests for the exact same thing. That's why I have an `expect` statement after each of these two tests, because in both times the logger is called with the same input. 

A PR could be done to make the naming convention consistent, as well as to remove the unnecessary test.

_Logger warnings still inconsistent_

With the merging of #2053, Panels, Dropdowns, Modals and Popovers print warnings to the console if there are slots overriding the element attributes. However, other elements such as Quizzes and QOptions do not print warnings when this happens. This is because in the code of `MdAttributeRenderer.ts`, not every attribute is checked to see if there is an overriding slot, so the logger will not warn if the unchecked attributes are overridden. 

A simple (though untested) fix could be to have a new method as follows
```javascript
processAttribute(node, attribute, isInline, slotName = attribute) {
    if (!this.hasSlotOverridingAttribute(node, attribute, slotName) {
        this.processAttributeWithoutOverride(node, attribute, isInline, slotName);
    }
}
```
and replace all the `processAttributeWIthoutOverride` methods with this.

**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->
```
Test logging calls in NodeProcessor

Previously, calls to the logger were not tested for in testing
NodeProcessor.

Let's mock the logger and test if it is being called correctly.
```
---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
