### PR TITLE
Standardise NodeProcessor.data.ts constant names

### DIFF
--- a/packages/core/test/unit/html/NodeProcessor.data.ts
+++ b/packages/core/test/unit/html/NodeProcessor.data.ts
@@ -38,29 +38,6 @@ export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 
 export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG = "panel has a header slot, 'header' attribute has no effect.";
 
-export const PROCESS_PANEL_HEADER_NO_OVERRIDE = `
-<panel header="# Lorem ipsum" alt="**strong alt**">
-  <div slot="header">
-    This existing header slot should be preserved in favour over header attribute.
-  </div>
-  Header attribute should not be inserted under panel since there is both an alt attribute and header slot,
-  but should be deleted.
-  Alt attribute should be inserted under panel as slot.
-</panel>
-`;
-
-export const PROCESS_PANEL_HEADER_NO_OVERRIDE_EXPECTED = `
-<panel><template #_alt><p><strong>strong alt</strong></p>
-</template>
-  <template #header><div>
-    This existing header slot should be preserved in favour over header attribute.
-  </div></template>
-  Header attribute should not be inserted under panel since there is both an alt attribute and header slot,
-  but should be deleted.
-  Alt attribute should be inserted under panel as slot.
-</panel>
-`;
-
 // Post Process
 
 export const POST_PROCESS_PANEL_ID_ASSIGNED_USING_HEADER_SLOT = `
@@ -92,18 +69,38 @@ export const PROCESS_QUESTION_ATTRIBUTES_EXPECTED = `
 </question>
 `;
 
-export const PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE = `
-<question header="**header**" hint="**hint**" answer="**answer**">
+export const PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY = `
+<question header="**header**">
 <template slot="header"></template>
+</question>
+`;
+
+export const PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
+<question>
+<template #header></template>
+</question>
+`;
+
+export const PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY = `
+<question hint="**hint**">
 <template slot="hint"></template>
+</question>
+`;
+
+export const PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY_EXPECTED = `
+<question>
+<template #hint></template>
+</question>
+`;
+
+export const PROCESS_QUESTION_ANSWER_SLOT_TAKES_PRIORITY = `
+<question answer="**answer**">
 <template slot="answer"></template>
 </question>
 `;
 
-export const PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
+export const PROCESS_QUESTION_ANSWER_SLOT_TAKES_PRIORITY_EXPECTED = `
 <question>
-<template #header></template>
-<template #hint></template>
 <template #answer></template>
 </question>
 `;
@@ -119,13 +116,13 @@ export const PROCESS_QOPTION_ATTRIBUTES_EXPECTED = `
 </q-option>
 `;
 
-export const PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE = `
+export const PROCESS_QOPTION_REASON_SLOT_TAKES_PRIORITY = `
 <q-option reason="**lorem ipsum**">
 <template slot="reason"></template>
 </q-option>
 `;
 
-export const PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
+export const PROCESS_QOPTION_REASON_SLOT_TAKES_PRIORITY_EXPECTED = `
 <q-option>
 <template #reason></template>
 </q-option>
@@ -142,13 +139,13 @@ export const PROCESS_QUIZ_ATTRIBUTES_EXPECTED = `
 </quiz>
 `;
 
-export const PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE = `
+export const PROCESS_QUIZ_INTRO_SLOT_TAKES_PRIORITY = `
 <quiz intro="**lorem ipsum**">
 <template slot="intro"></template>
 </quiz>
 `;
 
-export const PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
+export const PROCESS_QUIZ_INTRO_SLOT_TAKES_PRIORITY_EXPECTED = `
 <quiz>
 <template #intro></template>
 </quiz>
@@ -171,24 +168,35 @@ export const PROCESS_POPOVER_ATTRIBUTES_EXPECTED = `
 </popover>
 `;
 
-export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE = `
-<popover content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel tellus elit." 
-         header="_Lorem ipsum_">
+export const PROCESS_POPOVER_HEADER_SLOT_TAKES_PRIORITY = `
+<popover header="_Lorem ipsum_">
   <div slot="header">Some header slot content that should not be overwritten</div>
-  <div slot="content">Some content slot that should not be overwritten</div>
-  Content and header attributes should not be inserted under panel as slots, but should be deleted.
+  Header attribute should not be inserted under panel as slot, but should be deleted.
 </popover>
 `;
 
-export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_EXPECTED = `
+export const PROCESS_POPOVER_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 <popover>
   <template #header><div>Some header slot content that should not be overwritten</div></template>
-  <template #content><div>Some content slot that should not be overwritten</div></template>
-  Content and header attributes should not be inserted under panel as slots, but should be deleted.
+  Header attribute should not be inserted under panel as slot, but should be deleted.
 </popover>
 `;
 
 export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_HEADER_WARN_MSG = "popover has a header slot, 'header' attribute has no effect.";
+
+export const PROCESS_POPOVER_CONTENT_SLOT_TAKES_PRIORITY = `
+<popover content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel tellus elit.">
+  <div slot="content">Some content slot that should not be overwritten</div>
+  Content attribute should not be inserted under panel as slot, but should be deleted.
+</popover>
+`;
+
+export const PROCESS_POPOVER_CONTENT_SLOT_TAKES_PRIORITY_EXPECTED = `
+<popover>
+  <template #content><div>Some content slot that should not be overwritten</div></template>
+  Content attribute should not be inserted under panel as slot, but should be deleted.
+</popover>
+`;
 export const PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_CONTENT_WARN_MSG = "popover has a content slot, 'content' attribute has no effect.";
 
 /*

--- a/packages/core/test/unit/html/NodeProcessor.data.ts
+++ b/packages/core/test/unit/html/NodeProcessor.data.ts
@@ -19,20 +19,25 @@ export const PROCESS_PANEL_ATTRIBUTES_EXPECTED = `
 `;
 
 export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY = `
-<panel header="# Lorem ipsum">
+<panel header="# Lorem ipsum" alt="**strong alt**">
   <div slot="header">
-    This existing header slot should be preserved in favour over header attribute, with a logger warning for repeated attributes.
+    This existing header slot should be preserved in favour over header attribute.
   </div>
-  Header attribute should be ignored and deleted while header slot is reserved.
+  Header attribute should not be inserted under panel since there is both an alt attribute and header slot,
+  but should be deleted.
+  Alt attribute should be inserted under panel as slot.
 </panel>
 `;
 
 export const PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
-<panel>
+<panel><template #_alt><p><strong>strong alt</strong></p>
+</template>
   <template #header><div>
-    This existing header slot should be preserved in favour over header attribute, with a logger warning for repeated attributes.
+    This existing header slot should be preserved in favour over header attribute.
   </div></template>
-  Header attribute should be ignored and deleted while header slot is reserved.
+  Header attribute should not be inserted under panel since there is both an alt attribute and header slot,
+  but should be deleted.
+  Alt attribute should be inserted under panel as slot.
 </panel>
 `;
 
@@ -70,7 +75,7 @@ export const PROCESS_QUESTION_ATTRIBUTES_EXPECTED = `
 `;
 
 export const PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY = `
-<question header="**header**">
+<question header="**lorem ipsum**">
 <template slot="header"></template>
 </question>
 `;
@@ -82,7 +87,7 @@ export const PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY_EXPECTED = `
 `;
 
 export const PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY = `
-<question hint="**hint**">
+<question hint="**lorem ipsum**">
 <template slot="hint"></template>
 </question>
 `;
@@ -94,7 +99,7 @@ export const PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY_EXPECTED = `
 `;
 
 export const PROCESS_QUESTION_ANSWER_SLOT_TAKES_PRIORITY = `
-<question answer="**answer**">
+<question answer="**lorem ipsum**">
 <template slot="answer"></template>
 </question>
 `;

--- a/packages/core/test/unit/html/NodeProcessor.test.ts
+++ b/packages/core/test/unit/html/NodeProcessor.test.ts
@@ -58,39 +58,42 @@ test('processNode processes panel attributes and inserts into dom as slots corre
   processAndVerifyTemplate(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY,
                            testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_EXPECTED);
   expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG);
-  processAndVerifyTemplate(testData.PROCESS_PANEL_HEADER_NO_OVERRIDE,
-                           testData.PROCESS_PANEL_HEADER_NO_OVERRIDE_EXPECTED);
-  expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_PANEL_HEADER_SLOT_TAKES_PRIORITY_WARN_MSG);
 });
 
 test('processNode processes question attributes and inserts into dom as slots correctly', () => {
   processAndVerifyTemplate(testData.PROCESS_QUESTION_ATTRIBUTES,
                            testData.PROCESS_QUESTION_ATTRIBUTES_EXPECTED);
-  processAndVerifyTemplate(testData.PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE,
-                           testData.PROCESS_QUESTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_QUESTION_HEADER_SLOT_TAKES_PRIORITY_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_QUESTION_HINT_SLOT_TAKES_PRIORITY_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_QUESTION_ANSWER_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_QUESTION_ANSWER_SLOT_TAKES_PRIORITY_EXPECTED);
 });
 
 test('processNode processes q-option attributes and inserts into dom as slots correctly', () => {
   processAndVerifyTemplate(testData.PROCESS_QOPTION_ATTRIBUTES,
                            testData.PROCESS_QOPTION_ATTRIBUTES_EXPECTED);
-  processAndVerifyTemplate(testData.PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE,
-                           testData.PROCESS_QOPTION_ATTRIBUTES_NO_OVERRIDE_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_QOPTION_REASON_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_QOPTION_REASON_SLOT_TAKES_PRIORITY_EXPECTED);
 });
 
 test('processNode processes quiz attributes and inserts into dom as slots correctly', () => {
   processAndVerifyTemplate(testData.PROCESS_QUIZ_ATTRIBUTES,
                            testData.PROCESS_QUIZ_ATTRIBUTES_EXPECTED);
-  processAndVerifyTemplate(testData.PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE,
-                           testData.PROCESS_QUIZ_ATTRIBUTES_NO_OVERRIDE_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_QUIZ_INTRO_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_QUIZ_INTRO_SLOT_TAKES_PRIORITY_EXPECTED);
 });
 
 test('processNode processes popover attributes and inserts into dom as slots correctly', () => {
   const warnSpy = jest.spyOn(logger, 'warn');
   processAndVerifyTemplate(testData.PROCESS_POPOVER_ATTRIBUTES,
                            testData.PROCESS_POPOVER_ATTRIBUTES_EXPECTED);
-  processAndVerifyTemplate(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE,
-                           testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_EXPECTED);
+  processAndVerifyTemplate(testData.PROCESS_POPOVER_HEADER_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_POPOVER_HEADER_SLOT_TAKES_PRIORITY_EXPECTED);
   expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_HEADER_WARN_MSG);
+  processAndVerifyTemplate(testData.PROCESS_POPOVER_CONTENT_SLOT_TAKES_PRIORITY,
+                           testData.PROCESS_POPOVER_CONTENT_SLOT_TAKES_PRIORITY_EXPECTED);
   expect(warnSpy).toHaveBeenCalledWith(testData.PROCESS_POPOVER_ATTRIBUTES_NO_OVERRIDE_CONTENT_WARN_MSG);
 });
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Partially addresses #2476 
**Overview of changes:**
- Standardise test constant names to use `PROCESS_[ELEMENT]_[ATTRIBUTE]_SLOT_TAKES_PRIORITY` format
- Split test constants to test for one slot each
- Update tests to use these new constants
- Remove redundant test caused by #2053

`npm run test -- NodeProcessor.test.ts` has been run and all tests pass. 

**Anything you'd like to highlight/discuss:**

**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->
Standardise NodeProcessor constant names

Currently, there are two naming formats for constant names. This
has led to a redundant test being created in a previous PR.

Let's standardise the naming format to make the purpose of these
constants clearer. Let's also split some constants to test for one
overridden attribute at a time.

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
