### PR TITLE
Implement method to process attributes that can be overridden by slots

### DIFF
--- a/packages/core/src/html/MdAttributeRenderer.ts
+++ b/packages/core/src/html/MdAttributeRenderer.ts
@@ -121,7 +121,7 @@ export class MdAttributeRenderer {
    */
 
   processPanelAttributes(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'alt', false, '_alt');
+    this.processSlotAttribute(node, 'alt', false, '_alt');
     this.processSlotAttribute(node, 'header', false);
   }
 

--- a/packages/core/src/html/MdAttributeRenderer.ts
+++ b/packages/core/src/html/MdAttributeRenderer.ts
@@ -109,7 +109,7 @@ export class MdAttributeRenderer {
   }
 
   processTooltip(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'content', true);
+    this.processSlotAttribute(node, 'content', true);
   }
 
   processModalAttributes(node: MbNode) {
@@ -148,7 +148,7 @@ export class MdAttributeRenderer {
    */
 
   processTabAttributes(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'header', true);
+    this.processSlotAttribute(node, 'header', true);
   }
 
   /*
@@ -197,8 +197,8 @@ export class MdAttributeRenderer {
   }
 
   processAnnotationPointAttributes(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'content', false);
-    this.processAttributeWithoutOverride(node, 'header', false);
-    this.processAttributeWithoutOverride(node, 'label', false);
+    this.processSlotAttribute(node, 'content', false);
+    this.processSlotAttribute(node, 'header', false);
+    this.processSlotAttribute(node, 'label', false);
   }
 }

--- a/packages/core/src/html/MdAttributeRenderer.ts
+++ b/packages/core/src/html/MdAttributeRenderer.ts
@@ -75,10 +75,23 @@ export class MdAttributeRenderer {
     return hasAttribute;
   }
 
-  processPopoverAttributes(node: MbNode) {
-    if (!this.hasSlotOverridingAttribute(node, 'header')) {
-      this.processAttributeWithoutOverride(node, 'header', true);
+  /**
+   * Checks if there is a pre-existing slot for the attribute.
+   * If there is a slot, it deletes the attribute and logs a warning.
+   * If there is no slot, it processes the markdown attribute. 
+   * @param node Element to process
+   * @param attribute Attribute name to process
+   * @param isInline Whether to process the attribute with only inline markdown-it rules
+   * @param slotName Name attribute of the <slot> element to insert, which defaults to the attribute name
+   */
+  processSlotAttribute(node: MbNode, attribute: string, isInline: boolean, slotName = attribute) {
+    if (!this.hasSlotOverridingAttribute(node, attribute, slotName)) {
+      this.processAttributeWithoutOverride(node, attribute, isInline, slotName);
     }
+  }
+
+  processPopoverAttributes(node: MbNode) {
+    this.processSlotAttribute(node, 'header', true);
 
     // Warn if there is a content slot overriding the attributes 'content' or 'src'
     const hasSlotAndContentAttribute = this.hasSlotOverridingAttribute(node, 'content', 'content');
@@ -100,9 +113,7 @@ export class MdAttributeRenderer {
   }
 
   processModalAttributes(node: MbNode) {
-    if (!this.hasSlotOverridingAttribute(node, 'header')) {
-      this.processAttributeWithoutOverride(node, 'header', true);
-    }
+    this.processSlotAttribute(node, 'header', true);
   }
 
   /*
@@ -111,9 +122,7 @@ export class MdAttributeRenderer {
 
   processPanelAttributes(node: MbNode) {
     this.processAttributeWithoutOverride(node, 'alt', false, '_alt');
-    if (!this.hasSlotOverridingAttribute(node, 'header')) {
-      this.processAttributeWithoutOverride(node, 'header', false);
-    }
+    this.processSlotAttribute(node, 'header', false);
   }
 
   /*
@@ -121,17 +130,17 @@ export class MdAttributeRenderer {
    */
 
   processQuestion(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'header', false);
-    this.processAttributeWithoutOverride(node, 'hint', false);
-    this.processAttributeWithoutOverride(node, 'answer', false);
+    this.processSlotAttribute(node, 'header', false);
+    this.processSlotAttribute(node, 'hint', false);
+    this.processSlotAttribute(node, 'answer', false);
   }
 
   processQOption(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'reason', false);
+    this.processSlotAttribute(node, 'reason', false);
   }
 
   processQuiz(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'intro', false);
+    this.processSlotAttribute(node, 'intro', false);
   }
 
   /*
@@ -147,8 +156,8 @@ export class MdAttributeRenderer {
    */
 
   processBoxAttributes(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'icon', true);
-    this.processAttributeWithoutOverride(node, 'header', false);
+    this.processSlotAttribute(node, 'icon', true);
+    this.processSlotAttribute(node, 'header', false);
   }
 
   /*
@@ -156,9 +165,7 @@ export class MdAttributeRenderer {
    */
 
   processDropdownAttributes(node: MbNode) {
-    if (!this.hasSlotOverridingAttribute(node, 'header')) {
-      this.processAttributeWithoutOverride(node, 'header', true);
-    }
+    this.processSlotAttribute(node, 'header', true);
   }
 
   /**
@@ -186,7 +193,7 @@ export class MdAttributeRenderer {
   }
 
   processScrollTopButtonAttributes(node: MbNode) {
-    this.processAttributeWithoutOverride(node, 'icon', true);
+    this.processSlotAttribute(node, 'icon', true);
   }
 
   processAnnotationPointAttributes(node: MbNode) {

--- a/packages/core/src/html/MdAttributeRenderer.ts
+++ b/packages/core/src/html/MdAttributeRenderer.ts
@@ -78,7 +78,7 @@ export class MdAttributeRenderer {
   /**
    * Checks if there is a pre-existing slot for the attribute.
    * If there is a slot, it deletes the attribute and logs a warning.
-   * If there is no slot, it processes the markdown attribute. 
+   * If there is no slot, it processes the markdown attribute.
    * @param node Element to process
    * @param attribute Attribute name to process
    * @param isInline Whether to process the attribute with only inline markdown-it rules


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Partially resolves #2476 

**Overview of changes:**

Implement `processSlotAttribute` method and use it for attributes that can be overridden by slots.

**Anything you'd like to highlight/discuss:**

For reference, these are the attributes that can be overridden by slots:
| Component         | Attributes           |
| ----------------- | -------------------- |
| Panel             | Header, Alt               |
| Box               | Icon, Header         |
| Popover           | Header, Content      |
| Modal             | Header               |
| Dropdown          | Header               |
| Scroll-top-button | Icon                 |
| Question          | Header, Hint, Answer |
| Q-Option          | Reason               |
| Quiz              | Intro                |
| Tooltip          | Content          |
| Tab              | Header            |
| A-Point        | Header, Content, Label |

The docs are not correct regarding this.

**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->
```
Implement processSlotAttribute method

There is some duplicated code to process attributes that can
be overridden by slots. In addition, not every attribute that can be
overridden with slots are processed with the 
hasSlotOverridingAttribute method. As such, there will be no
warning in the logger when these attributes are overridden.

Let's put this duplicated code into a method and call it for every
attribute that can be overridden by a slot.
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features (will do in the next PR!)
- [ ] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
