### PR TITLE
Remove Overridden Question Attributes in Documentation

### DIFF
--- a/docs/userGuide/syntax/questions.md
+++ b/docs/userGuide/syntax/questions.md
@@ -59,7 +59,7 @@ If you require more expressive formatting for your header or hint markup, you ca
 <variable name="highlightStyle">html</variable>
 <variable name="heading">Headers and Hints using slots</variable>
 <variable name="code">
-<question type="checkbox" header="Which of the following is true?" hint="Think out of the box! :fas-box:">
+<question type="checkbox">
   <!-- Header slot -->
   <div slot="header">
 
@@ -86,7 +86,7 @@ If you require more expressive formatting for your header or hint markup, you ca
 </question>
 </variable>
 <variable name="output">
-<question type="checkbox" header="Which of the following is true?" hint="Think out of the box! :fas-box:">
+<question type="checkbox">
   <!-- Header slot -->
   <div slot="header">
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Fixes #2512 
Related to #2511

**Overview of changes:**

Remove `header` and `hint` attributes in question with `header` and `hint` slots.

**Anything you'd like to highlight/discuss:**

The page on the User Guide in question is [this](https://markbind.org/userGuide/components/others.html#questions-and-quizzes). Expand the panel entitled Header and Hint example with **slots**.

This still achieves the purpose of the documentation, which is to show how slots can replace the `header` and `hint` attributes.

**Testing instructions:**

Switch to the branch for PR #2511, navigate to the `docs` directory and run `markbind serve -d`. Logger warnings should appear. Then, make the changes in this PR, and run `markbind serve-d` again. There should not be logger warnings anymore.

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->
```
Remove Overridden Question Attributes in Docs

The docs currently has a question where there are slots overriding
the header attributes. However, when #2511 is merged, logger
warnings about this overriding will be triggered, leading to the
check-docs GitHub action failing.

Let's remove the header attributes so that they will not trigger
the logger warning. Let's also update the sample code to reflect
this change.
```

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
