### PR TITLE
Fix gh-pages deployment cache "path" argument must be of type string undefined.

### DIFF
--- a/packages/core/src/Site/index.ts
+++ b/packages/core/src/Site/index.ts
@@ -1382,9 +1382,11 @@ export class Site {
     };
     options.message = options.message.concat(' [skip ci]');
 
-    // Globally set cache folder to cwd/.cache/gh-pages.
+    // Globally set Cache Directory to /node_modules/.cache for gh-pages
     if (!process.env.CACHE_DIR || ['true', 'false', '1', '0'].includes(process.env.CACHE_DIR)) {
-      process.env.CACHE_DIR = path.join(process.cwd(), '.cache', 'gh-pages');
+      const cacheDirectory = path.join(this.rootPath, 'node_modules', '.cache');
+      fs.emptydirSync(path.join(cacheDirectory, 'gh-pages'));
+      process.env.CACHE_DIR = cacheDirectory;
     }
 
     if (ciTokenVar) {
@@ -1411,7 +1413,7 @@ export class Site {
         };
       } else if (process.env.GITHUB_ACTIONS) {
         // Set cache folder to a location Github Actions can find.
-        process.env.CACHE_DIR = path.join(process.env.GITHUB_WORKSPACE || '.cache', 'gh-pages');
+        process.env.CACHE_DIR = path.join(process.env.GITHUB_WORKSPACE || '.cache');
         repoSlug = Site.extractRepoSlug(options.repo, process.env.GITHUB_REPOSITORY);
 
         options.user = {

--- a/packages/core/src/Site/index.ts
+++ b/packages/core/src/Site/index.ts
@@ -1382,6 +1382,11 @@ export class Site {
     };
     options.message = options.message.concat(' [skip ci]');
 
+    // Globally set cache folder to cwd/.cache/gh-pages.
+    if (!process.env.CACHE_DIR || ['true', 'false', '1', '0'].includes(process.env.CACHE_DIR)) {
+      process.env.CACHE_DIR = path.join(process.cwd(), '.cache', 'gh-pages');
+    }
+
     if (ciTokenVar) {
       const ciToken = _.isBoolean(ciTokenVar) ? 'GITHUB_TOKEN' : ciTokenVar;
       if (!process.env[ciToken]) {
@@ -1406,7 +1411,7 @@ export class Site {
         };
       } else if (process.env.GITHUB_ACTIONS) {
         // Set cache folder to a location Github Actions can find.
-        process.env.CACHE_DIR = path.join(process.env.GITHUB_WORKSPACE || '', 'gh-pages', '.cache');
+        process.env.CACHE_DIR = path.join(process.env.GITHUB_WORKSPACE || '.cache', 'gh-pages');
         repoSlug = Site.extractRepoSlug(options.repo, process.env.GITHUB_REPOSITORY);
 
         options.user = {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2547 

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Fixes CACHE_DIR issue in `markbind deploy`

**Anything you'd like to highlight/discuss:**

Refer to findings from #2547 for further details:

"path" argument must of of type string Bug faced when attempting to run `markbind deploy` without a `package.json` file, or without setting env var `CACHE_DIR` manually:
* This has implications on CI platforms Travis, AppVeyor, Circle as well. 
* A previous PR #2542 laid groundwork for this bug fix (for GitHub actions).
* This bug was likely introduced in #2532 , as `find-cache-dir` dependency was added into `gh-pages` dependency, where the gh-pages version was subsequently bumped. 
* `find-cache-dir` assumes a `package.json` file, and a `node_modules` directory in the project directory. However, both do not exist in a markbind project, causing this bug.

To work around this, let's manually set the cache directory used by `gh-pages` to `node_modules/.cache/gh-pages`, by setting the `CACHE_DIR` environment variable in the deployment workflow.  This follows the cache location detailed in `gh-pages` [changelog](https://github.com/tschaub/gh-pages/blob/main/changelog.md#v310).


**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

1. clone branch 
1. Resetting CACHE_DIR = " ". ($env:CACHE_DIR = "" on powershell / set CACHE_DIR=cache / echo %CACHE_DIR%)
1. Verify that `markbind deploy` works

Unfortunately, unable to test on CI platforms.

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

Fix CACHE_DIR issue in markbind deploy

Manually sets cache directory used by `gh-pages` to 
node_modules/.cache/gh-pages. This is needed as sub-dependency
find-cache-dir dependency in gh-pages assumes presence 
of package.json file and a node_modules directory to deterrmine 
cache, which do not exist in a MarkBind project.

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
