### PR TITLE
Fix Searchbar Dropdown Menu 

### DIFF
--- a/packages/vue-components/src/Searchbar.vue
+++ b/packages/vue-components/src/Searchbar.vue
@@ -20,7 +20,6 @@
         {{ placeholder }}
       </div>
     </template>
-    <!-- <div class="relative-position"> -->
     <ul ref="dropdown" :class="dropdownMenuClasses">
       <li
         v-for="(item, index) in items"
@@ -36,7 +35,6 @@
         </a>
       </li>
     </ul>
-    <!-- </div> -->
   </div>
 </template>
 

--- a/packages/vue-components/src/Searchbar.vue
+++ b/packages/vue-components/src/Searchbar.vue
@@ -306,7 +306,7 @@ export default {
     }
 
     .dropdown-menu-hidden {
-      visibility: hidden;
+        visibility: hidden;
     }
 </style>
 

--- a/packages/vue-components/src/Searchbar.vue
+++ b/packages/vue-components/src/Searchbar.vue
@@ -20,6 +20,7 @@
         {{ placeholder }}
       </div>
     </template>
+    <!-- <div class="relative-position"> -->
     <ul ref="dropdown" :class="dropdownMenuClasses">
       <li
         v-for="(item, index) in items"
@@ -35,6 +36,7 @@
         </a>
       </li>
     </ul>
+    <!-- </div> -->
   </div>
 </template>
 
@@ -187,8 +189,8 @@ export default {
       return [
         'dropdown-menu',
         'search-dropdown-menu',
-        { show: this.showDropdown },
-        { 'd-none': !this.showDropdown },
+        { 'show': this.showDropdown },
+        { 'dropdown-menu-hidden': !this.showDropdown },
         { 'dropdown-menu-end': this.menuAlignRight },
       ];
     },
@@ -303,6 +305,10 @@ export default {
         border-bottom: 0;
         visibility: hidden;
         overflow: hidden;
+    }
+
+    .dropdown-menu-hidden {
+      visibility: hidden;
     }
 </style>
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Fixes #2566

To fix the skew of the initial positioning of the dropdown-menu, changes the use of `d-none` (`display:none !important`) which removes the element from the DOM to `visibility:hidden` which instead allows it to persist in DOM even when hidden, such that the dropdown menu position does not get skewed.

**Anything you'd like to highlight/discuss:**

Another solution I came up with was to add a `div` container with relative positioning as a parent to the `dropdown-menu`, as such:

```
+   <div class="relative-position">
      <ul ref="dropdown" :class="dropdownMenuClasses">
        <li
          v-for="(item, index) in items"
          :key="index"
          :class="{ 'table-active': isActive(index) }"
        >
          <a
            class="dropdown-item"
            @mousedown.prevent="hit"
            @mousemove="setActive(index)"
          >
            <searchbar-page-item :item="item" :value="value" />
          </a>
        </li>
      </ul>
+   </div>
```

It could be due to the way Popper.js works, as it helps to retain the DOM structure as if the `dropdown-menu` was there even when it is removed due to `display:none`. However, I thought it might be a hacky solution that could cause confusion later on, making it less ideal, although less invasive and perhaps worth considering.

**Testing instructions:**

Test as per #2566:

> We can recreate this issue on MB's user guide page, [page on search bar](https://markbind.org/userGuide/components/navigation.html#search-bars).
Type in a search term (e.g. 'search bar'), do not do any mouse scroll.
Dropdown menu is rendered, but cannot be seen.
Do a mouse scroll, and the dropdown menu repositions correctly.
To recreate, just click out, click back in, and type another search term
Do a mouse scroll, and the dropdown menu reappears


<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

Fix Searchbar dropdown-menu positioning

Fix initial dropdown-menu positioning by replacing `d-none` 
with `visibility:hidden`. Popper.js cannot calculate the position of 
elements removed from the DOM with `display: none`.  Let's 
replace `d-none` with `visibility:hidden`, keeping the element 
in the DOM, allowing Popper.js to correctly calculate its position. 

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
