### PR TITLE
Add inline text expansion

### DIFF
--- a/packages/cli/test/functional/test_site/index.md
+++ b/packages/cli/test/functional/test_site/index.md
@@ -349,6 +349,8 @@ and **this**.
 
 **Test nunjucks raw tags**
 
+<include src="testInlineExpansion.md" />
+
 {% raw %}
 
 <div v-pre>{{ variable interpolation syntax can be used with v-pre }}</div>

--- a/packages/cli/test/functional/test_site/site.json
+++ b/packages/cli/test/functional/test_site/site.json
@@ -71,6 +71,10 @@
       "title": "Thumbnails Test"
     },
     {
+      "src": "testInlineExpansion.md",
+      "title": "Inline Expansion Test"
+    },
+    {
       "src": "testPlantUML.md",
       "title": "PlantUML Test"
     },

--- a/packages/cli/test/functional/test_site/testInlineExpansion.md
+++ b/packages/cli/test/functional/test_site/testInlineExpansion.md
@@ -1,0 +1,11 @@
+## InlineExpansion
+
+<div>
+  <inlineExpansion 
+    collapsedText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris." 
+    expandedText="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Curabitur varius erat non lectus fermentum malesuada." />
+
+  <inlineExpansion  
+    collapsedText="This is some collapsed text." 
+    expandedText="This is the expanded version of the text." />
+</div>

--- a/packages/vue-components/src/InlineExpansion.vue
+++ b/packages/vue-components/src/InlineExpansion.vue
@@ -11,12 +11,10 @@
 </template>
 
 <script>
-
 export default {
   props: {
     expandedText: {
       type: String,
-      default: '',
       required: true,
     },
     collapsedText: {
@@ -33,23 +31,17 @@ export default {
       isExpanded: false,
     };
   },
+  computed: {
+    processedCollapsedText() {
+      const textToProcess = this.collapsedText || this.expandedText || '';
+      return textToProcess.length > this.maxChars
+        ? `${textToProcess.slice(0, this.maxChars - 3)}...`
+        : textToProcess;
+    },
+  },
   methods: {
     toggleExpansion() {
       this.isExpanded = !this.isExpanded;
-    },
-    processedCollapsedText() {
-      // If collapsedText is provided
-      if (this.collapsedText) {
-        return this.collapsedText.length > this.maxChars
-          ? `${this.collapsedText.slice(0, this.maxChars - 3)}...`
-          : this.collapsedText;
-      }
-      // If collapsedText is not provided
-      if (this.expandedText.length > this.maxChars) {
-        return `${this.expandedText.slice(0, this.maxChars - 3)}...`;
-      }
-
-      return this.expandedText;
     },
   },
 };

--- a/packages/vue-components/src/InlineExpansion.vue
+++ b/packages/vue-components/src/InlineExpansion.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <!-- Text Displayed -->
+    <p>{{ isExpanded ? expandedText : processedCollapsedText }}</p>
+
+    <!-- Toggle between Collapsed and Expanded -->
+    <button @click="toggleExpansion">
+      {{ isExpanded ? 'Collapse' : 'Expand' }}
+    </button>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    expandedText: {
+      type: String,
+      default: '',
+      required: true,
+    },
+    collapsedText: {
+      type: String,
+      default: '',
+    },
+    maxChars: {
+      type: Number,
+      default: 20,
+    },
+  },
+  data() {
+    return {
+      isExpanded: false,
+    };
+  },
+  methods: {
+    toggleExpansion() {
+      this.isExpanded = !this.isExpanded;
+    },
+    processedCollapsedText() {
+      // If collapsedText is provided
+      if (this.collapsedText) {
+        return this.collapsedText.length > this.maxChars
+          ? `${this.collapsedText.slice(0, this.maxChars - 3)}...`
+          : this.collapsedText;
+      }
+      // If collapsedText is not provided
+      if (this.expandedText.length > this.maxChars) {
+        return `${this.expandedText.slice(0, this.maxChars - 3)}...`;
+      }
+
+      return this.expandedText;
+    },
+  },
+};
+</script>

--- a/packages/vue-components/src/InlineExpansion.vue
+++ b/packages/vue-components/src/InlineExpansion.vue
@@ -1,11 +1,8 @@
 <template>
   <div>
-    <!-- Text Displayed -->
-    <p>{{ isExpanded ? expandedText : processedCollapsedText }}</p>
-
     <!-- Toggle between Collapsed and Expanded -->
-    <button @click="toggleExpansion">
-      {{ isExpanded ? 'Collapse' : 'Expand' }}
+    <button class="inline-panel" @click="toggleExpansion">
+      {{ isExpanded ? expandedText : processedCollapsedText }}
     </button>
   </div>
 </template>
@@ -46,3 +43,16 @@ export default {
   },
 };
 </script>
+
+<style>
+    .inline-panel {
+        border: 1px solid #ccc;
+        background-color: #f9f9f9;
+        padding: 6px 8px;
+        border-radius: 5px;
+        color: #444;
+        margin: 0 8px 6px 0;
+        display: inline-block;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/packages/vue-components/src/__tests__/InlineExpansion.spec.js
+++ b/packages/vue-components/src/__tests__/InlineExpansion.spec.js
@@ -1,0 +1,114 @@
+import { mount } from '@vue/test-utils';
+import InlineExpansion from '../InlineExpansion.vue';
+
+const defaultProps = {
+  expandedText: 'This is a very long piece of text.',
+  collapsedText: 'Short version',
+  maxChars: 20,
+};
+
+describe('InlineExpansion.vue', () => {
+  it('uses provided collapsedText when available', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: defaultProps,
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('Short version');
+  });
+
+  it('displays truncated collapsedText if it exceeds maxChars', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        expandedText: 'This is a custom expanded text.',
+        collapsedText: 'This is a custom collapsed text',
+        maxChars: 20,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('This is a custom ...');
+  });
+
+  it('falls back to expandedText if collapsedText is not provided', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        expandedText: 'This is a very long piece of text.',
+        collapsedText: undefined,
+        maxChars: 20,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+  });
+
+  it('displays truncated collapsedText if it exceeds maxChars and expandedText is missing', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        collapsedText: 'This is a very long piece of text that exceeds maxChars',
+        maxChars: 20,
+        expandedText: undefined,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+  });
+
+  it('displays collapsedText truncated to maxChars when expandedText is provided', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        collapsedText: 'This is a very long piece of text that exceeds maxChars',
+        maxChars: 20,
+        expandedText: 'This is the expanded version of the text',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+  });
+
+  it('handles missing expandedText gracefully', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        expandedText: undefined,
+        collapsedText: 'Short version',
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('Short version');
+  });
+
+  it('handles missing expandedText and collapsedText gracefully', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        expandedText: undefined,
+        collapsedText: undefined,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('p').text()).toBe('');
+  });
+
+  // Test for Button
+  it('toggles between collapsed and expanded text when button is clicked', async () => {
+    const wrapper = mount(InlineExpansion, {
+      propsData: {
+        collapsedText: 'This is some collapsed text.',
+        expandedText: 'This is the expanded text.',
+        maxChars: 20,
+      },
+    });
+
+    // Initially, we expect the collapsed text to be shown
+    expect(wrapper.find('p').text()).toBe('This is some coll...');
+
+    // Simulate clicking the button to expand the text
+    await wrapper.find('button').trigger('click');
+
+    // Now we expect the expanded text to be shown
+    expect(wrapper.find('p').text()).toBe('This is the expanded text.');
+
+    // Simulate clicking the button to collapse the text again
+    await wrapper.find('button').trigger('click');
+
+    // Expect the collapsed text to show again
+    expect(wrapper.find('p').text()).toBe('This is some coll...');
+  });
+});

--- a/packages/vue-components/src/__tests__/InlineExpansion.spec.js
+++ b/packages/vue-components/src/__tests__/InlineExpansion.spec.js
@@ -13,7 +13,7 @@ describe('InlineExpansion.vue', () => {
       propsData: defaultProps,
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('Short version');
+    expect(wrapper.find('button.inline-panel').text()).toBe('Short version');
   });
 
   it('displays truncated collapsedText if it exceeds maxChars', async () => {
@@ -25,7 +25,7 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('This is a custom ...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is a custom ...');
   });
 
   it('falls back to expandedText if collapsedText is not provided', async () => {
@@ -37,7 +37,7 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is a very lo...');
   });
 
   it('displays truncated collapsedText if it exceeds maxChars and expandedText is missing', async () => {
@@ -49,7 +49,7 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is a very lo...');
   });
 
   it('displays collapsedText truncated to maxChars when expandedText is provided', async () => {
@@ -61,7 +61,7 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('This is a very lo...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is a very lo...');
   });
 
   it('handles missing expandedText gracefully', async () => {
@@ -72,7 +72,7 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('Short version');
+    expect(wrapper.find('button.inline-panel').text()).toBe('Short version');
   });
 
   it('handles missing expandedText and collapsedText gracefully', async () => {
@@ -83,10 +83,10 @@ describe('InlineExpansion.vue', () => {
       },
     });
     await wrapper.vm.$nextTick();
-    expect(wrapper.find('p').text()).toBe('');
+    expect(wrapper.find('button.inline-panel').text()).toBe('');
   });
 
-  // Test for Button
+  // Test for Button Toggle
   it('toggles between collapsed and expanded text when button is clicked', async () => {
     const wrapper = mount(InlineExpansion, {
       propsData: {
@@ -97,18 +97,18 @@ describe('InlineExpansion.vue', () => {
     });
 
     // Initially, we expect the collapsed text to be shown
-    expect(wrapper.find('p').text()).toBe('This is some coll...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is some coll...');
 
     // Simulate clicking the button to expand the text
-    await wrapper.find('button').trigger('click');
+    await wrapper.find('button.inline-panel').trigger('click');
 
     // Now we expect the expanded text to be shown
-    expect(wrapper.find('p').text()).toBe('This is the expanded text.');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is the expanded text.');
 
     // Simulate clicking the button to collapse the text again
-    await wrapper.find('button').trigger('click');
+    await wrapper.find('button.inline-panel').trigger('click');
 
     // Expect the collapsed text to show again
-    expect(wrapper.find('p').text()).toBe('This is some coll...');
+    expect(wrapper.find('button.inline-panel').text()).toBe('This is some coll...');
   });
 });

--- a/packages/vue-components/src/index.js
+++ b/packages/vue-components/src/index.js
@@ -33,6 +33,7 @@ import popover from './Popover.vue';
 import tooltip from './Tooltip.vue';
 import modal from './Modal.vue';
 import scrollTopButton from './ScrollTopButton.vue';
+import inlineExpansion from './InlineExpansion.vue';
 
 const components = {
   box,
@@ -65,6 +66,7 @@ const components = {
   'VPopover': Dropdown,
   'VTooltip': Tooltip,
   scrollTopButton,
+  inlineExpansion,
 };
 
 const directives = {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #33 

**Overview of changes:**
Created an InlineExpansion vue component.

The component will display a shorter version of the text by default and after clicking on it, it will display the longer version of the text.

Completed Unit Testing for InlineExpansion component.

**Anything you'd like to highlight/discuss:**
The test site is not yet working and is in progress (unable to show the component in the test site).

**Testing instructions:**
No manual testing can be carried out yet.

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

---