### PR TITLE
Fix broken annotation label

### DIFF
--- a/docs/userGuide/syntax/annotations.md
+++ b/docs/userGuide/syntax/annotations.md
@@ -181,7 +181,7 @@ Here we showcase some use cases of the Annotate feature.
 | opacity   | `String` | `'0.3'`     | The opacity of the point.<br>Supports range of values from `0` to `1`. <br> Does not work with customised shapes                                                                                                        |
 | fontSize  | `String` | `'14'`      | The font size of the label.<br>Supports any pixel size smaller than size of the point.                                                                                        |
 | textColor | `String` | `'black'`   | The color of the label.<br>Supports any color in the CSS color format. E.g. `red`, `#ffffff`, `rgb(66, 135, 245)`, etc.                                                       |
-| legend    | `String` | `'popover'` | The position of the Annotate Point content and header.<br>Supports: `popover`, `bottom`, `both`.                                                                              |
+| legend    | `String` | `'popover'` | The position of the Annotate Point content and header.<br> The `label` property must be defined for it to be displayed in the legend.<br>Supports: `popover`, `bottom`, `both`.                                                                              |
 
 ****`<annotate>` Options****
 

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -198,11 +198,12 @@ export default {
       return (this.hasContent || this.hasHeader) && (this.legend === 'popover' || this.legend === 'both');
     },
     computedBottomHeader() {
-      const labelSlotContent = this.$scopedSlots.label == undefined ? undefined : this.$scopedSlots.label();
-      const headerSlotContent = this.$scopedSlots.header == undefined ? undefined : this.$scopedSlots.header();
+      const labelSlotContent = this.$scopedSlots.label === undefined ? undefined : this.$scopedSlots.label();
+      const headerSlotContent = this.$scopedSlots.header === undefined
+        ? undefined : this.$scopedSlots.header();
 
-      const labelText = labelSlotContent == undefined ? undefined : labelSlotContent[0].children[0].text
-      const labelHeader = headerSlotContent == undefined ? undefined :headerSlotContent[0].children[0].text
+      const labelText = labelSlotContent === undefined ? undefined : labelSlotContent[0].children[0].text;
+      const labelHeader = headerSlotContent === undefined ? undefined : headerSlotContent[0].children[0].text;
 
       if (labelText === undefined && labelHeader !== undefined) {
         return labelHeader;

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -198,13 +198,20 @@ export default {
       return (this.hasContent || this.hasHeader) && (this.legend === 'popover' || this.legend === 'both');
     },
     computedBottomHeader() {
-      if (this.label !== '' && this.header === '') {
-        return this.label;
+      const labelSlotContent = this.$scopedSlots.label == undefined ? undefined : this.$scopedSlots.label();
+      const headerSlotContent = this.$scopedSlots.header == undefined ? undefined : this.$scopedSlots.header();
+
+      const labelText = labelSlotContent == undefined ? undefined : labelSlotContent[0].children[0].text
+      const labelHeader = headerSlotContent == undefined ? undefined :headerSlotContent[0].children[0].text
+
+      if (labelText === undefined && labelHeader !== undefined) {
+        return labelHeader;
       }
-      if (this.label === '' && this.header !== '') {
-        return this.header;
+      if (labelText !== undefined && labelHeader === undefined) {
+        return labelText;
       }
-      return `${this.label}: ${this.header}`;
+
+      return `${labelText}: ${labelHeader}`;
     },
   },
   methods: {

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -260,6 +260,10 @@ export default {
         text-align: center;
     }
 
+    .hover-label > * {
+        margin: 0;
+    }
+
     .hover-wrapper {
         z-index: 0;
         background: transparent;

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -204,10 +204,10 @@ export default {
       const labelText = labelSlotContent?.[0]?.children?.[0]?.text;
       const labelHeader = headerSlotContent?.[0]?.children?.[0]?.text;
 
-      if (labelText === undefined && labelHeader !== undefined) {
+      if (labelText === undefined && labelHeader !== undefined) { // Label is not defined
         return labelHeader;
       }
-      if (labelText !== undefined && labelHeader === undefined) {
+      if (labelText !== undefined && labelHeader === undefined) { // Header is not defined
         return labelText;
       }
 

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -198,12 +198,11 @@ export default {
       return (this.hasContent || this.hasHeader) && (this.legend === 'popover' || this.legend === 'both');
     },
     computedBottomHeader() {
-      const labelSlotContent = this.$scopedSlots.label === undefined ? undefined : this.$scopedSlots.label();
-      const headerSlotContent = this.$scopedSlots.header === undefined
-        ? undefined : this.$scopedSlots.header();
+      const labelSlotContent = this.$scopedSlots.label?.();
+      const headerSlotContent = this.$scopedSlots.header?.();
 
-      const labelText = labelSlotContent === undefined ? undefined : labelSlotContent[0].children[0].text;
-      const labelHeader = headerSlotContent === undefined ? undefined : headerSlotContent[0].children[0].text;
+      const labelText = labelSlotContent?.[0]?.children?.[0]?.text;
+      const labelHeader = headerSlotContent?.[0]?.children?.[0]?.text;
 
       if (labelText === undefined && labelHeader !== undefined) {
         return labelHeader;


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->
Closes #2563 

**Overview of changes:**
After investigating #2563, the image annotation started breaking after converting to use the slots API.

According to Vue's documentation, content passed by the slots API are considered to be owned by the parent component that passes them in and so styles do not apply to them. 

A separate CSS rule to target all elements within the div that holds the slot is added to override the parent's styles. This fixed the issue and the problem no longer persists.

Some screenshots: 
![image](https://github.com/user-attachments/assets/4798481e-f59c-40f8-822e-408b033f4309)
![image](https://github.com/user-attachments/assets/bada8285-124a-49dc-b9eb-a5543225b645)



**Anything you'd like to highlight/discuss:**


**Testing instructions:**
Testing can be done locally by navigating to the `docs` folder and running `npm markbind serve -d -o userGuide/components/imagesAndDiagrams.md`
<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix broken annotation label

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [X] Linked all related issues
- [X] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
