### PR TITLE
Catch UncaughtException when serving in non-Markbind directories

### DIFF
--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -52,6 +52,7 @@ function serve(userSpecifiedRoot, options) {
   } catch (error) {
     logger.error(error.message);
     process.exitCode = 1;
+    process.exit();
   }
 
   const logsFolder = path.join(rootFolder, '_markbind/logs');

--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -51,7 +51,8 @@ function serve(userSpecifiedRoot, options) {
     }
   } catch (error) {
     logger.error(error.message);
-    logger.error('This directory does not appear to contain a valid MarkBind site. Check that you are running the command in the correct directory!\n'
+    logger.error('This directory does not appear to contain a valid MarkBind site.'
+              + 'Check that you are running the command in the correct directory!\n'
               + '\n'
               + 'To create a new MarkBind site, run:\n'
               + '   markbind init');

--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -51,7 +51,7 @@ function serve(userSpecifiedRoot, options) {
     }
   } catch (error) {
     logger.error(error.message);
-    logger.error('This directory does not appear to contain a valid MarkBind site.\n'
+    logger.error('This directory does not appear to contain a valid MarkBind site. Check that you are running the command in the correct directory!\n'
               + '\n'
               + 'To create a new MarkBind site, run:\n'
               + '   markbind init');

--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -51,6 +51,10 @@ function serve(userSpecifiedRoot, options) {
     }
   } catch (error) {
     logger.error(error.message);
+    logger.error('This directory does not appear to contain a valid MarkBind site.\n'
+              + '\n'
+              + 'To create a new MarkBind site, run:\n'
+              + '   markbind init');
     process.exitCode = 1;
     process.exit();
   }

--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -51,7 +51,7 @@ function serve(userSpecifiedRoot, options) {
     }
   } catch (error) {
     logger.error(error.message);
-    logger.error('This directory does not appear to contain a valid MarkBind site.'
+    logger.error('This directory does not appear to contain a valid MarkBind site. '
               + 'Check that you are running the command in the correct directory!\n'
               + '\n'
               + 'To create a new MarkBind site, run:\n'


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #2570 

Currently, there is an issue when using the `markbind serve` command in non-Markbind directories, leading to an UncaughtException that is displayed to the user.

The problem seems to be due to be a missing `process.exit()` after catching the error. This leads to the code continuing on despite the rootFolder still being `undefined`. 

The PR also updates the error message to be more user-friendly.

**Anything you'd like to highlight/discuss:**
This PR only fixes the UncaughtException issue, not the underlying issue mentioned in #1825.

**Testing instructions:**
Try using the `markbind serve` command in a non-Markbind directory. The UncaughtException should not show. For example:
![image](https://github.com/user-attachments/assets/6123293a-aafd-4437-b88f-f2a0fac21335)



<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Catch UncaughtException when serving in non-Markbind directories
<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
