### PR TITLE
Refactor codeBlockButton Plugins

### DIFF
--- a/packages/core-web/src/styles/markbind.css
+++ b/packages/core-web/src/styles/markbind.css
@@ -284,57 +284,6 @@ li.footnote-item:target {
     outline: none;
 }
 
-/* "Copy" and "wrap text" code block buttons */
-pre {
-    position: relative;
-    display: flex;
-}
-
-button.function-btn {
-    border: 1px solid #d7dadc;
-    border-radius: 5px;
-    color: darkgray;
-    cursor: pointer;
-    display: none;
-    height: 30px;
-    margin: 0.17rem;
-    padding: 0.35rem;
-    position: absolute;
-    right: 0;
-    width: 30px;
-    text-align: center;
-    white-space: nowrap;
-}
-
-button.function-btn + button.function-btn {
-    right: 36px;
-}
-
-pre:hover > .function-btn-container > button.function-btn {
-    display: block;
-}
-
-.function-btn:hover {
-    transition: all 0.5s ease;
-    color: gray;
-}
-
-.function-btn-body {
-    align-items: center;
-    display: flex;
-}
-
-.function-btn svg {
-    fill: currentcolor;
-}
-
-/* Wrap class used for "wrap text" button. */
-code.wrap {
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    word-break: break-all;
-}
-
 /* Octicon sizing */
 .octicon {
     height: 1em;

--- a/packages/core/src/plugins/codeBlockButtonsAssets/codeBlockButtons.css
+++ b/packages/core/src/plugins/codeBlockButtonsAssets/codeBlockButtons.css
@@ -1,0 +1,50 @@
+/* "Copy" and "wrap text" code block buttons */
+pre:has(.function-btn-container) {
+    position: relative;
+    display: flex;
+}
+
+button.function-btn {
+    border: 1px solid #d7dadc;
+    border-radius: 5px;
+    color: darkgray;
+    cursor: pointer;
+    display: none;
+    height: 30px;
+    margin: 0.17rem;
+    padding: 0.35rem;
+    position: absolute;
+    right: 0;
+    width: 30px;
+    text-align: center;
+    white-space: nowrap;
+}
+
+button.function-btn + button.function-btn {
+    right: 36px;
+}
+
+pre:hover > .function-btn-container > button.function-btn {
+    display: block;
+}
+
+.function-btn:hover {
+    transition: all 0.5s ease;
+    color: gray;
+}
+
+.function-btn-body {
+    align-items: center;
+    display: flex;
+}
+
+.function-btn svg {
+    fill: currentcolor;
+}
+
+/* Wrap class used for "wrap text" button. */
+code.wrap {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    word-break: break-all;
+}

--- a/packages/core/src/plugins/codeBlockCopyButtons.ts
+++ b/packages/core/src/plugins/codeBlockCopyButtons.ts
@@ -7,6 +7,8 @@ import {
 } from './codeBlockButtonsAssets/codeBlockButtonsContainer';
 import type { PluginContext } from './Plugin';
 
+const CSS_FILE_NAME = 'codeBlockButtonsAssets/codeBlockButtons.css';
+
 const COPY_ICON = `
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="18" height="18" viewBox="0 0 18 18" version="1.1">
@@ -65,10 +67,13 @@ const copyCodeBlockScript = `<script>
     </script>`;
 
 export = {
+  getLinks: () => [`<link rel="stylesheet" href="${CSS_FILE_NAME}">`],
   getScripts: () => [copyCodeBlockScript],
   processNode: (_: PluginContext, node: MbNode) => {
-    if (node.name === 'pre' && !doesFunctionBtnContainerExistInNode(node)) {
-      cheerio(node).append(CONTAINER_HTML);
+    if (node.name === 'pre' && node.children?.some(child => child.name === 'code')) {
+      if (!doesFunctionBtnContainerExistInNode(node)) {
+        cheerio(node).append(CONTAINER_HTML);
+      }
     } else if (isFunctionBtnContainer(node)) {
       cheerio(node).append(getButtonHTML());
     }

--- a/packages/core/src/plugins/codeBlockWrapButtons.ts
+++ b/packages/core/src/plugins/codeBlockWrapButtons.ts
@@ -9,6 +9,8 @@ import {
 } from './codeBlockButtonsAssets/codeBlockButtonsContainer';
 import type { PluginContext } from './Plugin';
 
+const CSS_FILE_NAME = 'codeBlockButtonsAssets/codeBlockButtons.css';
+
 const WRAP_ICON = `
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   width="18" height="18" viewBox="0 0 18 18" version="1.1">
@@ -49,10 +51,13 @@ const wrapCodeBlockScript = `<script>
     </script>`;
 
 export = {
+  getLinks: () => [`<link rel="stylesheet" href="${CSS_FILE_NAME}">`],
   getScripts: () => [wrapCodeBlockScript],
   processNode: (_: PluginContext, node: MbNode) => {
-    if (node.name === 'pre' && !doesFunctionBtnContainerExistInNode(node)) {
-      cheerio(node).append(CONTAINER_HTML);
+    if (node.name === 'pre' && node.children?.some(child => child.name === 'code')) {
+      if (!doesFunctionBtnContainerExistInNode(node)) {
+        cheerio(node).append(CONTAINER_HTML);
+      }
     } else if (isFunctionBtnContainer(node)) {
       cheerio(node).append(getButtonHTML());
     }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Refactored logic to insert buttons only if pre element contains the code element. Scoped CSS rules (specifically, for `<pre/>` element to minimize side effects. Modularized CSS rules to be included only if plugin is enabled.

Refer to https://github.com/MarkBind/markbind/pull/1043 https://github.com/MarkBind/markbind/pull/1668 to check CSS rules that were added for the code block buttons.

Fixes #2624

**Anything you'd like to highlight/discuss:**


**Testing instructions:**

See #2624 

Enable relevant plugins, and put some sample code into index.md:

```
## Test

[`][`][`]js 
console.log('hello world');
[`][`][`]

<pre>
   /\_/\
  ( o.o )
   > ^ <
</pre>
```

Buttons should not show up beside the cat. It should only show up for the code block above it.

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

Refactor codeBlockButton Plugins

Refactored logic to insert plugin buttons only if
pre element contains the code element as per CommonMark
spec for fenced code blocks. Scoped CSS rules for pre element 
to minimize side effects. Modularized previously global button 
CSS rules to be included only if plugin is enabled.

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
