### PR TITLE
Refactor isValidHost and resolve Codecov issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - run: npm run setup
       - run: npm run test
       - name: Upload coverage report to Codecov
+        if: matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/cli/src/cmd/serve.js
+++ b/packages/cli/src/cmd/serve.js
@@ -18,58 +18,14 @@ const {
   removeHandler,
 } = require('../util/serveUtil');
 
+const {
+  isValidServeHost,
+} = require('../util/ipUtil');
+
 function isIPAddressZero(address) {
   const patternForZero = /^0(\.0)*$/;
 
   return patternForZero.test(address);
-}
-
-/**
- * Referenced from StackOverflow:
- * https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp
- *
- * Credits to Danail Gabenski
- */
-const isIpv4Address = (address) => {
-  const patternForIpV4 = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
-
-  return patternForIpV4.test(address);
-};
-
-/**
- * Referenced from StackOverflow:
- * https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
- *
- * Credits to David M. Syzdek
- */
-const isIpv6Address = (address) => {
-  const patternForIpV6 = new RegExp(
-    '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}'
-    + '|([0-9a-fA-F]{1,4}:){1,7}:'
-    + '|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}'
-    + '|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}'
-    + '|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}'
-    + '|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}'
-    + '|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}'
-    + '|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})'
-    + '|:((:[0-9a-fA-F]{1,4}){1,7}|:)'
-    + '|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}'
-    + '|::(ffff(:0{1,4}){0,1}:){0,1}'
-    + '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}'
-    + '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
-    + '|([0-9a-fA-F]{1,4}:){1,4}:'
-    + '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}'
-    + '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$');
-
-  return patternForIpV6.test(address);
-};
-
-function isValidServeHost(address) {
-  if (address === 'localhost') {
-    return true;
-  }
-
-  return isIpv4Address(address) || isIpv6Address(address);
 }
 
 function questionAsync(question) {
@@ -219,5 +175,4 @@ function serve(userSpecifiedRoot, options) {
 
 module.exports = {
   serve,
-  isValidServeHost,
 };

--- a/packages/cli/src/util/ipUtil.js
+++ b/packages/cli/src/util/ipUtil.js
@@ -1,0 +1,51 @@
+/**
+ * Referenced from StackOverflow:
+ * https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp
+ *
+ * Credits to Danail Gabenski
+ */
+const isIpv4Address = (address) => {
+  const patternForIpV4 = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
+
+  return patternForIpV4.test(address);
+};
+
+/**
+ * Referenced from StackOverflow:
+ * https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses
+ *
+ * Credits to David M. Syzdek
+ */
+const isIpv6Address = (address) => {
+  const patternForIpV6 = new RegExp(
+    '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}'
+    + '|([0-9a-fA-F]{1,4}:){1,7}:'
+    + '|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}'
+    + '|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}'
+    + '|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}'
+    + '|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}'
+    + '|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}'
+    + '|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})'
+    + '|:((:[0-9a-fA-F]{1,4}){1,7}|:)'
+    + '|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}'
+    + '|::(ffff(:0{1,4}){0,1}:){0,1}'
+    + '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}'
+    + '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
+    + '|([0-9a-fA-F]{1,4}:){1,4}:'
+    + '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}'
+    + '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$');
+
+  return patternForIpV6.test(address);
+};
+
+function isValidServeHost(address) {
+  if (address === 'localhost') {
+    return true;
+  }
+
+  return isIpv4Address(address) || isIpv6Address(address);
+}
+
+module.exports = {
+  isValidServeHost,
+};

--- a/packages/cli/test/unit/ipUtil.test.js
+++ b/packages/cli/test/unit/ipUtil.test.js
@@ -1,4 +1,4 @@
-const { isValidServeHost } = require('../../src/cmd/serve');
+const { isValidServeHost } = require('../../src/util/ipUtil');
 
 describe('isValidServeHost', () => {
   test('returns true for localhost', () => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Hotfixes Codecov issue created by #2599
Updates ci.yml to only run upload coverage for ubuntu-latest

This PR moves `isValidHost` and it's related functions to another file, `ipUtil.js`.

Currently, there is an issue with Codecov where the coverage dropped after merging #2599. This is because #2599 introduced functions and tests into `serve.js`, which originally did not have any tests. This meant that the code coverage calculations would now include `serve.js` and other files referenced within as part of its calculation, which led to a sharp drop in code coverage due to the lack of tests for `serve` mentioned in issue #2635.

By moving the functions introduced by #2599 out of `serve.js`, this should mean that Codecov will only consider the new functions and not `serve.js` as part of its code coverage calculations.

The PR also updates ci.yml to only run the upload coverage task for ubuntu-latest. It should be unnecessary to attempt uploading the coverage 3 times per CI run, since 1 report should be enough.

**Anything you'd like to highlight/discuss:**
This PR is only meant to be a hotfix for the drop in code coverage. Ideally, tests are appropriately added for `serve.js` and other `serve` related files/functions.

If need be, we can also merge `ipUtil.js` functions with `serveUtil.js` functions in the future, but as of now `serveUtil.js` also lacks tests.

**Testing instructions:**
Check the codecov report for this PR, it should show that only `ipUtil.js` is considered as part of its calculations and the code coverage should increase back to its original value of 51.89%

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Refactor isValidHost and resolve Codecov issue

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
