### PR TITLE
Fix multiple `<svg>` and missing content issue

### DIFF
--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -68,8 +68,9 @@ function staticServer(root) {
     if (req.method !== 'GET' && req.method !== 'HEAD') return next();
     const reqpath = isFile ? "" : parse(req.url).pathname;
     var hasNoOrigin = !req.headers.origin;
-    var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>"), new RegExp("</head>", "i")];
+    var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>", "g"), new RegExp("</head>", "i")];
     var injectTag = null;
+    var injectCount = 0;
 
     function directory() {
       var pathname = parse(req.url).pathname;
@@ -79,15 +80,16 @@ function staticServer(root) {
     }
 
     function file(filepath /*, stat*/) {
-      var x = path.extname(filepath).toLocaleLowerCase(), match,
+      var x = path.extname(filepath).toLocaleLowerCase(), matches,
         possibleExtensions = [ "", ".html", ".htm", ".xhtml", ".php", ".svg" ];
       if (hasNoOrigin && (possibleExtensions.indexOf(x) > -1)) {
         // TODO: Sync file read here is not nice, but we need to determine if the html should be injected or not
         var contents = fs.readFileSync(filepath, "utf8");
         for (var i = 0; i < injectCandidates.length; ++i) {
-          match = injectCandidates[i].exec(contents);
-          if (match) {
-            injectTag = match[0];
+          matches = contents.match(injectCandidates[i]);
+          injectCount = matches && matches.length || 0;
+          if (injectCount > 0) {
+            injectTag = matches[0];
             break;
           }
         }
@@ -107,7 +109,7 @@ function staticServer(root) {
     function inject(stream) {
       if (injectTag) {
         // We need to modify the length given to browser
-        var len = INJECTED_CODE.length + res.getHeader('Content-Length');
+        var len = INJECTED_CODE.length * injectCount + res.getHeader('Content-Length');
         res.setHeader('Content-Length', len);
         var originalPipe = stream.pipe;
         stream.pipe = function(resp) {

--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -68,7 +68,7 @@ function staticServer(root) {
     if (req.method !== 'GET' && req.method !== 'HEAD') return next();
     const reqpath = isFile ? "" : parse(req.url).pathname;
     var hasNoOrigin = !req.headers.origin;
-    var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>", "g"), new RegExp("</head>", "i")];
+    var injectCandidates = [ new RegExp("</body>", "i"), new RegExp("</svg>", "gi"), new RegExp("</head>", "i")];
     var injectTag = null;
     var injectCount = 0;
 
@@ -109,7 +109,8 @@ function staticServer(root) {
     function inject(stream) {
       if (injectTag) {
         // We need to modify the length given to browser
-        var len = INJECTED_CODE.length * injectCount + res.getHeader('Content-Length');
+        var contentLength = Number(res.getHeader('Content-Length')) || 0;
+        var len = INJECTED_CODE.length * injectCount + contentLength;
         res.setHeader('Content-Length', len);
         var originalPipe = stream.pipe;
         stream.pipe = function(resp) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #2715

The code updates MarkBind's existing patch of `live-server` to account for the number of `<svg>`s in the HTML file and adjusts the Content-Length header accordingly. 

**Anything you'd like to highlight/discuss:**
Thanks to @gerteck for finding the root cause and a fix for it.

The root cause of the issue was the code injection within the `live-server` package. It would normally detect `<body>`, `<svg>` or `<head>` and inject the `<script>` for live-server there. It would also increase the Content-Length by the length of the injected code.

The issue came about because of the use of `es.replace()`. According to the [`event-stream` npm page](https://www.npmjs.com/package/event-stream#replace-from-to), rather than replacing just the first occurrence, it replaces **all** matching occurrences. This meant that when a file had multiple `<svg>`s, it would inject code into all of them but only increase the Content-Length once. This lead to the resulting HTML response being cutoff and causing missing content.

**Testing instructions:**
1. Run `npm run build:backend`
2. Create a panel such as
```
<panel src="./test.md" />
```
3. In the file `test.md`, include a codeblock, such as:
````
```
Test
```

You should see this
````
4. Add the `codeBlockCopyButtons` and `codeBlockWrapButtons` plugins (or replace the codeblock with >2 `<svg>`s)
5. Verify that all content is shown as expected after the codeblock (or `<svg>`s)
![image](https://github.com/user-attachments/assets/a94fc5c5-f9ea-4b16-98a5-5bb17352e34b)

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix multiple `<svg>` and missing content issue

`live-server` injects code into every `<svg>` occurrence but only
increases the Content-Length value once. This commit fixes this
issue by counting the number of `<svg>` and increasing the
Content-Length accordingly, ensuring that all content is properly
sent.

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
