### PR TITLE
Fix issue with 404 page not working locally

### DIFF
--- a/packages/cli/src/lib/live-server/index.js
+++ b/packages/cli/src/lib/live-server/index.js
@@ -100,7 +100,7 @@ function staticServer(root) {
     }
 
     function error(err) {
-      if (err.status === 404) return next();
+      // CHANGED: Removed if condition that checks for 404
       next(err);
     }
 
@@ -259,7 +259,20 @@ LiveServer.start = function(options) {
   });
   app.use(staticServerHandler) // Custom static server
     .use(entryPoint(staticServerHandler, file))
-    .use(serveIndex(root, { icons: true }));
+    .use(serveIndex(root, { icons: true }))
+    // CHANGED: Added error handler to serve 404.html page
+    .use((err, req, res, next) => {
+      if (err.status === 404) {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "text/html");
+        const notFoundPage = path.join(root, "404.html");
+        fs.createReadStream(notFoundPage).pipe(res)
+      } else {
+        console.error(err.stack);
+        res.statusCode = err.status || 500;
+        res.end("Internal Server Error");
+      }
+    });
 
   var server, protocol;
   if (https !== null) {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Partially fixes #2717 

Adds an error handler to explicitly send the `404.html` upon error 404. It removes the previous check for `err.status === 404` and handles the error in a newly added middleware.

**Anything you'd like to highlight/discuss:**
This PR only partially fixes #2717. It ensures that when serving the site locally, any invalid pages without a corresponding file will properly respond with the `404.html` file. It does not fix the current rendering issue with the default `404.html` file causing it to be blank. That issue is related to #2716.

**Testing instructions:**
1. Locally serve a MarkBind site using `markbind serve`
2. Try accessing an invalid page, like `http://127.0.0.1:8080/test`
3. Verify that the `404.html` file is shown as the response (To avoid #2716, this requires adjusting `404.html` such as removing the use of center-align)

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix issue with 404 page not working locally

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
