### PR TITLE
Fix AnnotatePoint positioning bug

### DIFF
--- a/packages/vue-components/src/__tests__/Annotation.spec.js
+++ b/packages/vue-components/src/__tests__/Annotation.spec.js
@@ -35,6 +35,20 @@ const MARKDOWN_ANNOTATION_POINTS = `
   <a-point x="75%" y="75%" label=":rocket:" />
 `;
 
+beforeAll(() => {
+  global.ResizeObserver = class {
+    constructor() {
+      this.observe = jest.fn();
+      this.unobserve = jest.fn();
+      this.disconnect = jest.fn();
+    }
+  };
+});
+
+afterAll(() => {
+  delete global.ResizeObserver;
+});
+
 describe('Annotation', () => {
   test('with different visual annotation points', async () => {
     const wrapper = mount(Annotation, {

--- a/packages/vue-components/src/annotations/AnnotatePoint.vue
+++ b/packages/vue-components/src/annotations/AnnotatePoint.vue
@@ -124,11 +124,6 @@ export default {
   inject: ['parentWidth', 'parentHeight', 'src'],
   computed: {
     pointPosition() {
-      this.computeImage(() => {
-        this.width = this.parentEl.offsetWidth;
-        this.height = this.parentEl.offsetHeight;
-      });
-
       const relativeX = (this.toDecimal(this.x) - (this.size / 2 / this.width)) * 100;
       const relativeY = (this.toDecimal(this.y) - (this.size / 2 / this.height)) * 100;
 
@@ -216,15 +211,6 @@ export default {
     },
   },
   methods: {
-    // This methods takes in a callback and only runs it when the image is loaded.
-    // Which allows for computation of image size.
-    computeImage(callback) {
-      const image = new Image();
-      image.onload = function () {
-        callback();
-      };
-      image.src = this.src;
-    },
     toDecimal(percent) {
       return parseFloat(percent) / 100;
     },
@@ -233,6 +219,22 @@ export default {
     this.targetEl = this.$el;
     this.isMounted = true;
     this.parentEl = this.$el.parentElement.parentElement.querySelector('.annotate-image');
+    if (!this.parentEl) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const { width, height } = entry.contentRect;
+      this.width = width;
+      this.height = height;
+    });
+
+    observer.observe(this.parentEl);
+    this._resizeObserver = observer;
+  },
+  beforeUnmount() {
+    if (this._resizeObserver) {
+      this._resizeObserver.disconnect();
+    }
   },
 };
 </script>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Fixes #2728

Refer to https://github.com/MarkBind/markbind/issues/2728#issuecomment-3012472366 for detailed explanation of issue and the fix employed

TLDR:
- AnnotatePoint normally computes its position based on its parent element's `offsetWidth` and `offsetHeight`
- However, if the parent element is hidden, `offsetWidth` and `offsetHeight` will return 0
- This will result in invalid results, like `top: -Infinity%, left: -Infinity%` css
- AnnotatePoint does not properly recompute its position when the parent element is no longer hidden

**Anything you'd like to highlight/discuss:**
NIL

**Testing instructions:**
1. Create a test site/page with AnnotatePoints in Annotate, both outside and within Tab, e.g.:
```
<annotate src="{{ baseUrl }}/gitAndGithub/branch/images/branchesAsLabels1.png" height="500">
<a-point x="2%" y="27%" label="[1]" opacity="0"/>
<a-point x="2%" y="47%" label="[2]" opacity="0"/>
<a-point x="35%" y="25%" label="[3]" opacity="0"/>
<a-point x="65%" y="10%" label="[4]" opacity="0"/>
<a-point x="85%" y="10%" label="[5]" opacity="0"/>
</annotate>

<tabs>
  <tab header="CLI">
    Text in the first tab
    <markdown>_some markdown_</markdown>
  </tab>
  <tab header="Sourcetree" >

<annotate src="{{ baseUrl }}/gitAndGithub/branch/images/branchesAsLabels1.png" height="500">
<a-point x="2%" y="27%" label="[1]" opacity="0"/>
<a-point x="2%" y="47%" label="[2]" opacity="0"/>
<a-point x="35%" y="25%" label="[3]" opacity="0"/>
<a-point x="65%" y="10%" label="[4]" opacity="0"/>
<a-point x="85%" y="10%" label="[5]" opacity="0"/>
</annotate>

  </tab>
</tabs>
```
2. Run `markbind serve -d`
3. Verify that the AnnotatePoints positioning is correct for both outside and within a Tab

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Fix AnnotatePoint positioning bug

Add ResizeObserver to recompute and update AnnotatePoint
position whenever the Tab is opened or closed

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
