### PR TITLE
docs: add custom CSS usage and warnings to user guide (#2705)

### DIFF
--- a/docs/userGuide/usingHtmlJavaScriptCss.md
+++ b/docs/userGuide/usingHtmlJavaScriptCss.md
@@ -156,19 +156,24 @@ There are two common ways to add custom CSS in MarkBind:
 
 ### 1. Add a site-wide custom stylesheet
 
-To apply styles across your whole site, create a file called `styles.css` (or similar), and add it to your `site.json` under `head`:
+To apply styles across your whole site, create a file called `styles.css`
+(or similar) in the root of your site (same level as `index.md`), and then
+add it to your `site.json` under the `head` array like so:
 
 ```json
-"head": [
-  {
-    "tagName": "link",
-    "attributes": {
-      "rel": "stylesheet",
-      "href": "/styles.css"
+{
+  "head": [
+    {
+      "tagName": "link",
+      "attributes": {
+        "rel": "stylesheet",
+        "href": "/styles.css"
+      }
     }
-  }
-]
-
+  ]
+}
+```
 
 {% from "njk/common.njk" import previous_next %}
 {{ previous_next('components/advanced', 'tweakingThePageStructure') }}
+


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx
Closes #2705

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

- Adds a new section titled "Using Custom CSS in MarkBind" at the bottom of usingHtmlJavaScriptCss.md

- Explains two methods to add custom styles:
 
- Site-wide styles using site.json
 
- Page-specific inline <style> blocks
 
- Includes warnings about conflicts with MarkBind’s built-in component styles
 
- Provides code examples and best practices



**Anything you'd like to highlight/discuss:**
 
- The section was added just before the {% previous_next %} block to maintain structure
 
- IntelliJ may show false warnings (e.g., unrecognized tags), but site renders fine

- Let me know if you'd like it moved to a different file or split out for better discoverability



**Testing instructions:**

1. Serve the site locally:
npx markbind serve packages/core/docs/userGuide

2. Navigate to "Using HTML, JavaScript, CSS" in the user guide sidebar
 
3. Scroll to the bottom and verify:

- The section on Using Custom CSS is visible
- Code samples are highlighted correctly
- Warnings and tips are clearly displayed



<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

docs: add custom CSS usage and warnings to user guide (#2705)

Adds documentation to explain how users can add site-wide or inline
custom CSS in MarkBind. Also includes best practices and warnings
about overriding MarkBind's default component styles.

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [x] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [x] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
