### PR TITLE
Remove rewrap of `promisify` for `gh-pages` publish

### DIFF
--- a/packages/core/src/Site/SiteDeployManager.ts
+++ b/packages/core/src/Site/SiteDeployManager.ts
@@ -1,8 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import simpleGit, { SimpleGit } from 'simple-git';
-import { promisify } from 'util';
-import ghpages from 'gh-pages';
+import ghpages, { PublishOptions } from 'gh-pages';
 import * as gitUtil from '../utils/git';
 import * as logger from '../utils/logger';
 import { _ } from './constants';
@@ -44,12 +43,11 @@ export class SiteDeployManager {
    * Helper function for deploy(). Returns the ghpages link where the repo will be hosted.
    */
   async generateDepUrl(ciTokenVar: boolean | string, defaultDeployConfig: DeployOptions) {
-    const publish = promisify(ghpages.publish);
     if (!this.siteConfig) {
       throw new Error('Site config not initialized');
     }
 
-    const depOptions = await this.getDepOptions(ciTokenVar, defaultDeployConfig, publish);
+    const depOptions = await this.getDepOptions(ciTokenVar, defaultDeployConfig, ghpages.publish);
     try {
       return await SiteDeployManager.getDepUrl(depOptions);
     } finally {
@@ -61,7 +59,7 @@ export class SiteDeployManager {
    * Helper function for deploy(). Set the options needed to be used by ghpages.publish.
    */
   async getDepOptions(ciTokenVar: boolean | string, defaultDeployConfig: DeployOptions,
-                      publish: (basePath: string, options: DeployOptions) => Promise<unknown>) {
+                      publish: (basePath: string, options: PublishOptions) => Promise<void>) {
     const basePath = this.siteConfig.deploy.baseDir || this.outputPath;
     if (!fs.existsSync(basePath)) {
       throw new Error(

--- a/packages/core/test/unit/Site/SiteDeployManager.test.ts
+++ b/packages/core/test/unit/Site/SiteDeployManager.test.ts
@@ -27,10 +27,13 @@ const mockGhPages = {
 // Mock gh-pages publish
 const ghpages = require('gh-pages');
 
-ghpages.publish = jest.fn((dir: string, options: DeployOptions, callback: (err?: any) => void) => {
+ghpages.publish = jest.fn((dir: string, options: DeployOptions, callback?: (err?: any) => void) => {
   mockGhPages.dir = dir;
   mockGhPages.options = options;
-  callback();
+  if (callback) {
+    callback();
+  }
+  return Promise.resolve();
 });
 ghpages.clean = jest.fn();
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [ ] Feature addition or enhancement
- [x] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

Properly closes #2776

Removing the bluebird dependency exposed that `gh-pages.publish` was wrapped in a promisify despite returning a promise. Type definition for `publish` function can be found [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/gh-pages/index.d.ts).

This PR fixes it by removing the redundant util.promisify call on gh-pages.publish in `SiteDeployManager.ts`, and resolves the  DeprecationWarning because `gh-pages.publish` already returns a Promise in the version currently used by MarkBind.

**Anything you'd like to highlight/discuss:**



**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

Tests run fine

**Proposed commit message: (wrap lines at 72 characters)**

Fix Deprecation Warning in SiteDeployManager

Remove redundant util.promisify call on gh-pages.publish 

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
