### PR TITLE
Fix `markbind serve` regression

### DIFF
--- a/packages/cli/src/cmd/serve.ts
+++ b/packages/cli/src/cmd/serve.ts
@@ -144,7 +144,7 @@ function serve(userSpecifiedRoot: string, options: any) {
         serverConfig.open = serverConfig.open && `${config.baseUrl}/`;
       }
 
-      return site.generate('');
+      return site.generate(undefined);
     })
     .then(() => {
       const watcher = chokidar.watch(rootFolder, {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**

The problem was that a baseUrl defined in the site.json was only working for the entrypoint file - for other files it was mounted as if the baseUrl was not set at all.

Replaced placeholder value passed as parameter during typescript migration that changed behavior of the function with a value that represents how it actually worked before the migration.

**Anything you'd like to highlight/discuss:**
My bad yall - was careless during migration and this sneaky issue came up. We really need the testing suite for CLI to cover those commands as well :sob: 

**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

Fix `markbind serve` regression

When running `markbind serve` with a defined
baseUrl in the site.json, it only serves
the entrypoint file at the baseUrl while
other sites are served as if baseUrl was not
set.

This is not intentional behaviour.

Fix the regression by removing a placeholder
parameter that was introduced during typescript
migration.

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [ ] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
