### PR TITLE
Lock minimatch version to version before regression in WalkSync package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17103,9 +17103,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -37852,7 +37853,7 @@
       "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
       "requires": {
         "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
+        "minimatch": "3.1.3"
       }
     },
     "material-icons": {
@@ -38159,9 +38160,9 @@
       }
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -43009,7 +43010,7 @@
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
         "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
+        "minimatch": "3.1.3"
       }
     },
     "walk-up-path": {

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "tsx": "^4.21.0",
     "typescript": "^5.3.3",
     "walk-sync": "^2.0.2"
+  },
+  "overrides": {
+    "walk-sync": {
+      "minimatch": "3.1.3"
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,5 +92,10 @@
     "jest": "^29.7.0",
     "memfs": "^3.0.1",
     "ts-jest": "^29.4.6"
+  },
+  "overrides": {
+    "walk-sync": {
+      "minimatch": "3.1.3"
+    }
   }
 }


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

**Overview of changes:**
Urgent Hot-Fix for #2842


Arjun's investigation found that issue was with one of the resolved versions of a package, specifically `minimatch`. This package is used by `walk-sync`. The version that was packaged with npm in 6.2.0 is version 2.1.4, which caused this issue. We could not replicate it locally because likely package lock used v2.1.2.

![telegram-cloud-photo-size-5-6122654001791700693-y](https://github.com/user-attachments/assets/490a6502-a2f4-4c82-b820-ade95ba10d0d)


Referred to: https://github.com/joliss/node-walk-sync/commit/446199ee4153cfbb0701dfbcda44dae1cc5c00dc

For the `^2.0.2 walk-sync` (i.e. v2.2.0) version dependency of minimatch, which is `    "minimatch": "^3.0.4"`

As per https://github.com/isaacs/minimatch issue 284, 3.1.4 has the regression. So, lock to 3.1.3.

**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

Lock minimatch version to v3.1.3

v3.1.4 has a breaking change causing 
walk-sync package to break, and page generation to break
Lock the current version till it is fixed, or we circumvent 
the issue by using native node functionality

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
