### PR TITLE
Fix popover padding 

### DIFF
--- a/packages/vue-components/src/Popover.vue
+++ b/packages/vue-components/src/Popover.vue
@@ -29,7 +29,7 @@
         <slot></slot>
       </span>
       <template #popper>
-        <div class="popover-container">
+        <div class="popover-container popover">
           <h3 v-if="hasHeader" class="popover-header">
             <slot name="header"></slot>
           </h3>
@@ -86,6 +86,10 @@ export default {
 </script>
 
 <style>
+    [data-bs-theme="dark"] .popover {
+      --bs-popover-header-color: var(--bs-body-color);
+    }
+
     .popover-container {
         overflow: auto;
         max-height: 50vh;

--- a/packages/vue-components/src/Popover.vue
+++ b/packages/vue-components/src/Popover.vue
@@ -87,16 +87,17 @@ export default {
 
 <style>
     [data-bs-theme="dark"] {
-      /* Bootstrap by default inherits the header color - override with intended dark theme font color */
-      .popover {
-        --bs-popover-header-color: var(--bs-body-color);
-      }
+        /* Bootstrap by default inherits the header color - override with intended dark theme font color */
+        .popover {
+            --bs-popover-header-color: var(--bs-body-color);
+        }
 
-      /* Floating-vue retains a white border in dark mode - override */
-      .v-popper__inner {
-        background: var(--bs-popover-bg);
-        border: 1px solid var(--bs-secondary-bg);
-      }
+        /* Floating-vue retains a white border in dark mode - override */
+        /* stylelint-disable selector-class-pattern */
+        .v-popper__inner {
+            background: var(--bs-popover-bg);
+            border: 1px solid var(--bs-secondary-bg);
+        }
     }
 
     .popover-container {

--- a/packages/vue-components/src/Popover.vue
+++ b/packages/vue-components/src/Popover.vue
@@ -86,8 +86,17 @@ export default {
 </script>
 
 <style>
-    [data-bs-theme="dark"] .popover {
-      --bs-popover-header-color: var(--bs-body-color);
+    [data-bs-theme="dark"] {
+      /* Bootstrap by default inherits the header color - override with intended dark theme font color */
+      .popover {
+        --bs-popover-header-color: var(--bs-body-color);
+      }
+
+      /* Floating-vue retains a white border in dark mode - override */
+      .v-popper__inner {
+        background: var(--bs-popover-bg);
+        border: 1px solid var(--bs-secondary-bg);
+      }
     }
 
     .popover-container {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

Resolves #2896 

**Overview of changes:**
Fixes missing popover padding

**Anything you'd like to highlight/discuss:**
This issue resulted from the Bootstrap v5.3 upgrade. It seems that Bootstrap extracted some values into scoped variables - for the popover, they'd only apply on elements with the `.popover` class. So adding this class to the popover element fixes the problem.

There were some slight issues with the dark theme style, like this white padding here:
<img width="703" height="170" alt="image" src="https://github.com/user-attachments/assets/aacaf2bd-e657-455c-8972-be1fc11a3555" />
So I just overrid some of the styles. Let me know if this looks okay.



**Testing instructions:**

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**

<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->
Fix popover padding

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
