### PR TITLE
Update markdown-it-attrs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15308,7 +15308,9 @@
       }
     },
     "node_modules/markdown-it-attrs": {
-      "version": "4.1.6",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-5.0.1.tgz",
+      "integrity": "sha512-dTP49/FLERwbgqmfIG5LwnC99qecIJYalKQbl3pY+7Hajk+Z+cazeEZaKwofpM9KFxvfRVF0UN9GYxKKAakfNg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22631,7 +22633,7 @@
         "katex": "^0.15.6",
         "lodash": "^4.17.15",
         "markdown-it": "^12.3.2",
-        "markdown-it-attrs": "^4.1.3",
+        "markdown-it-attrs": "^5.0.1",
         "markdown-it-emoji": "^1.4.0",
         "markdown-it-linkify-images": "^3.0.0",
         "markdown-it-mark": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
     "katex": "^0.15.6",
     "lodash": "^4.17.15",
     "markdown-it": "^12.3.2",
-    "markdown-it-attrs": "^4.1.3",
+    "markdown-it-attrs": "^5.0.1",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-linkify-images": "^3.0.0",
     "markdown-it-mark": "^3.0.0",


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [X] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

<!--
  If this pull request is addressing an issue, link to the issue: #xxx

  If this pull request completely addresses an issue, use one of the closing keywords: "Fixes #xxx" or "Resolves #xxx"
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

  Otherwise, elaborate further on the rationale of this pull request as needed
-->

Closes #2905 

**Overview of changes:**
Bumped `markdown-it-attrs` from `^4.1.3` to `^5.0.1`.

Markbind's inline markdown rendering path (`MarkdownProcessor.renderMdInline`, used for include-panel processing) calls `md.renderInline()`. When inline source has a trailing `{.class}` attribute pattern (e.g.`Some text{.text-danger}`), markdown-it-attrs' "end of block" pattern transform walks past end of the token array looking for a surrounding block token, it then throws error and the plugin swallows the error by printing it to `console.error` while silently dropping the attribute.

This issue was fixed upstream in markdown-it-attrs v5.0.1 (arve0/markdown-it-attrs#184), which bounds-checks the token walk and returns early instead of erroring.

v5.0.0 also changed fenced-code-block attribute placement (moves attrs from `<code>` to the outer `<pre>` by default, via a new `fenceAttrsOnPre` option). This does not affect us as markbind registers its own custom `fence` renderer so it overrides the plugin's fence renderer regardless of that option.


**Anything you'd like to highlight/discuss:**


**Testing instructions:**
Render a page/include with inline text containing a trailing `{.class}` attribute (e.g. `Some text{.text-danger}`) through a path that hits `renderInline`. Confirm no error printed and class is applied to the output.

Alternatively, try running `markbind build` on the following repo: [git-mastery.github.io](https://github.com/git-mastery/git-mastery.github.io)

<!--
  Any special testing instructions **not including** our automated tests.
-->

**Proposed commit message: (wrap lines at 72 characters)**
Bump markdown-it-attrs to 5.0.1 to fix renderInline error
<!--
  See this link for more info on how to write a good commit message:
  https://se-education.org/guides/conventions/git.html

  As best as possible, write a succinct commit title in 50 characters

|---------This is the width of 50 chars----------|
|-----------This is the width of 72 chars for your reference-----------|
-->

---

**Checklist:** :ballot_box_with_check:

<!-- Leave non-applicable items unchecked -->

- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [X] Linked all related issues
- [X] No unrelated changes <!-- It's tempting, but increases the reviewer's work, and really pollutes the commit history =( -->

<!--
  We'll try our best to get to your PR within a week.
  If we haven't gotten to it then, or if your pull request resolves an urgent item, feel free to give us a ping!
-->

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
