### PR TITLE
Fix CardStack search box alignment

### DIFF
--- a/packages/vue-components/src/__tests__/CardStack.spec.js
+++ b/packages/vue-components/src/__tests__/CardStack.spec.js
@@ -49,6 +49,19 @@ const CARDS_WITH_CUSTOM_TAGS = `
 `;
 
 describe('CardStack', () => {
+  test('search input should not reuse the wrapper spacing class', () => {
+    const wrapper = mount(CardStack, {
+      propsData: {
+        searchable: true,
+      },
+      global: DEFAULT_GLOBAL_MOUNT_OPTIONS,
+    });
+
+    const searchBar = wrapper.find('.search-bar');
+    expect(searchBar.element.tagName).toBe('SPAN');
+    expect(searchBar.find('input').classes()).not.toContain('search-bar');
+  });
+
   test('should not hide cards when no filter is provided', async () => {
     const wrapper = mount(CardStack, {
       propsData: {
@@ -527,7 +540,7 @@ describe('CardStack', () => {
     expect(wrapper.vm.tagCounts.get('Tag2')).toBe(2);
 
     // Simulate a search for "alpha" which only matches the first card (Tag1)
-    const searchInput = wrapper.find('input.search-bar');
+    const searchInput = wrapper.find('.search-bar input');
     await searchInput.setValue('alpha');
     await searchInput.trigger('input');
     await wrapper.vm.$nextTick();
@@ -710,7 +723,7 @@ describe('CardStack', () => {
     expect(wrapper.vm.matchingCardsCount).toBe(3);
 
     // Search for "alpha beta" - should match only first card
-    const searchInput = wrapper.find('input.search-bar');
+    const searchInput = wrapper.find('.search-bar input');
     await searchInput.setValue('alpha beta');
     await searchInput.trigger('input');
     await wrapper.vm.$nextTick();

--- a/packages/vue-components/src/__tests__/__snapshots__/CardStack.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/CardStack.spec.js.snap
@@ -11,7 +11,7 @@ exports[`CardStack markdown in header, content 1`] = `
       class="search-bar"
     >
       <input
-        class="form-control search-bar"
+        class="form-control"
         placeholder="Search"
         type="text"
       />
@@ -97,7 +97,7 @@ exports[`CardStack should not hide cards when no filter is provided 1`] = `
       class="search-bar"
     >
       <input
-        class="form-control search-bar"
+        class="form-control"
         placeholder="Search"
         type="text"
       />
@@ -231,7 +231,7 @@ exports[`CardStack should not hide cards when no filter is provided 2`] = `
       class="search-bar"
     >
       <input
-        class="form-control search-bar"
+        class="form-control"
         placeholder="Search"
         type="text"
       />

--- a/packages/vue-components/src/cardstack/CardStack.vue
+++ b/packages/vue-components/src/cardstack/CardStack.vue
@@ -6,7 +6,7 @@
           <input
             v-model="value"
             type="text"
-            class="form-control search-bar"
+            class="form-control"
             :placeholder="placeholder"
             @input="update"
           />
@@ -283,7 +283,7 @@ export default {
         justify-content: center;
         align-items: center;
         margin: 0;
-        padding: 5px;
+        padding: 0;
     }
 
     .row {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2779

**Overview of changes:**

- Remove the wrapper-only `search-bar` class from the input element.
- Remove padding from the search wrapper so the input aligns with the cards.
- Add a regression test and update affected snapshots.

**Anything you'd like to highlight/discuss:**

The same class was applied to both the wrapper and the input, so the wrapper padding shifted the input border to the right.

**Testing instructions:**

No special manual setup is required.

**Proposed commit message: (wrap lines at 72 characters)**

```
Fix CardStack search box alignment
```

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
