### PR TITLE
Make white tag indicators visible

### DIFF
--- a/packages/vue-components/src/__tests__/CardStack.spec.js
+++ b/packages/vue-components/src/__tests__/CardStack.spec.js
@@ -276,6 +276,25 @@ describe('CardStack', () => {
     expect(tagMapping[1][1].badgeColor).toBe('#dc3545');
   });
 
+  test('should outline the selection indicator for white tags', async () => {
+    const tagConfigs = JSON.stringify([{ name: 'Success', color: '#ffffff' }]);
+    const wrapper = mount(CardStack, {
+      propsData: {
+        dataTagConfigs: tagConfigs.replace(/"/g, '&quot;'),
+      },
+      slots: { default: CARDS_WITH_CUSTOM_TAGS },
+      global: DEFAULT_GLOBAL_MOUNT_OPTIONS,
+    });
+    await wrapper.vm.$nextTick();
+
+    const [tagName, tagConfig] = wrapper.vm.cardStackRef.tagMapping[0];
+    expect(tagName).toBe('Success');
+    expect(tagConfig.badgeColor).toBe('#ffffff');
+
+    const indicator = wrapper.find('.tag-badge .tag-indicator');
+    expect(indicator.classes()).toEqual(expect.arrayContaining(['border', 'border-secondary']));
+  });
+
   test('should convert Bootstrap color names to classes', async () => {
     const tagConfigs = JSON.stringify([
       { name: 'Success', color: 'success' },

--- a/packages/vue-components/src/__tests__/__snapshots__/CardStack.spec.js.snap
+++ b/packages/vue-components/src/__tests__/__snapshots__/CardStack.spec.js.snap
@@ -114,7 +114,7 @@ exports[`CardStack should not hide cards when no filter is provided 1`] = `
         1
       </span>
       <span
-        class="badge bg-light text-dark tag-indicator"
+        class="badge bg-light text-dark tag-indicator border border-secondary"
       >
         <span>
           ✓

--- a/packages/vue-components/src/cardstack/CardStack.vue
+++ b/packages/vue-components/src/cardstack/CardStack.vue
@@ -330,6 +330,7 @@ export default {
         margin: 1px;
         width: 18px;
         height: 100%;
+        padding-inline: 0;
     }
 
     .badge.tag-badge.select-all-toggle {

--- a/packages/vue-components/src/cardstack/CardStack.vue
+++ b/packages/vue-components/src/cardstack/CardStack.vue
@@ -37,7 +37,7 @@
         <span v-if="!disableTagCount" class="badge tag-count bg-light text-dark">
           {{ tagCounts.get(key[0]) || 0 }}
         </span>
-        <span class="badge bg-light text-dark tag-indicator">
+        <span class="badge bg-light text-dark tag-indicator border border-secondary">
           <span v-if="computeShowTag(key[0])">✓</span>
           <span v-else>&nbsp;&nbsp;&nbsp;</span>
         </span>


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [ ] Bug fix
- [x] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2782

**Overview of changes:**

Adds a secondary border to Card Stack tag indicators so white tags remain visible.

**Anything you'd like to highlight/discuss:**

None.

**Testing instructions:**

None.

**Proposed commit message: (wrap lines at 72 characters)**

Make white tag indicators visible

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [X] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.
