### PR TITLE
Ignore macOS metadata in CLI tests

### DIFF
--- a/packages/cli/test/functional/testUtil/compare.ts
+++ b/packages/cli/test/functional/testUtil/compare.ts
@@ -27,12 +27,12 @@ function _readFileSync(...paths: string[]) {
 }
 
 /**
- * Filters out .page-vue-render.js files from the list of file paths.
+ * Filters out .page-vue-render.js and .DS_Store files from the list of file paths.
  * @param {string[]} filePaths - List of file paths
- * @returns {string[]} Filtered list without *.page-vue-render.js files
+ * @returns {string[]} Filtered list without generated render files and macOS metadata
  */
-function filterPageVueRenderFiles(filePaths: string[]) {
-  return filePaths.filter(p => !p.endsWith('.page-vue-render.js'));
+function filterIgnoredFiles(filePaths: string[]) {
+  return filePaths.filter(p => !p.endsWith('.page-vue-render.js') && !p.endsWith('.DS_Store'));
 }
 
 /**
@@ -87,8 +87,8 @@ function compare(root: string, expectedSiteRelativePath = 'expected', siteRelati
   // Vue render JS files (*.page-vue-render.js) are not committed to version control,
   // so we exclude them from the comparison to avoid false positive diffs.
   // Note: Every non-includes .html file has a corresponding js render binary file
-  actualPaths = filterPageVueRenderFiles(actualPaths);
-  expectedPaths = filterPageVueRenderFiles(expectedPaths);
+  actualPaths = filterIgnoredFiles(actualPaths);
+  expectedPaths = filterIgnoredFiles(expectedPaths);
 
   // Check for file existence of ignoredPaths and that they are present in actualPaths
   if (ignoredPaths.length !== 0 && !_.isEqual(_.intersection(ignoredPaths, actualPaths), ignoredPaths)) {
@@ -100,19 +100,18 @@ function compare(root: string, expectedSiteRelativePath = 'expected', siteRelati
   expectedPaths = expectedPaths.filter(p => !ignoredPaths.includes(p));
 
   let error = false;
-  if (expectedPaths.length !== actualPaths.length) {
-    throw new Error('Unequal number of files! '
-      + `Expected: ${expectedPaths.length}, Actual: ${actualPaths.length}`);
+  const missingPaths = _.difference(expectedPaths, actualPaths);
+  const unexpectedPaths = _.difference(actualPaths, expectedPaths);
+  if (missingPaths.length || unexpectedPaths.length) {
+    throw new Error('Different files built!'
+      + `\nMissing files: ${JSON.stringify(missingPaths)}`
+      + `\nUnexpected files: ${JSON.stringify(unexpectedPaths)}`);
   }
 
   /* eslint-disable no-continue */
   for (let i = 0; i < expectedPaths.length; i += 1) {
     const expectedFilePath = expectedPaths[i];
     const actualFilePath = actualPaths[i];
-
-    if (expectedFilePath !== actualFilePath) {
-      throw new Error(`Different files built! Expected: ${expectedFilePath}, Actual: ${actualFilePath}`);
-    }
 
     if (isBinary(expectedFilePath) || TEST_BLACKLIST.ignores(expectedFilePath)) {
       continue;

--- a/packages/cli/test/unit/compare.test.ts
+++ b/packages/cli/test/unit/compare.test.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { compare } from '../functional/testUtil/compare.js';
+
+test('compare ignores nested .DS_Store files and reports path differences', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'markbind-compare-'));
+  const expectedDirectory = path.join(root, 'expected');
+  const actualDirectory = path.join(root, '_site');
+  try {
+    fs.mkdirSync(expectedDirectory);
+    fs.mkdirSync(path.join(actualDirectory, 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(expectedDirectory, 'index.html'), 'same');
+    fs.writeFileSync(path.join(actualDirectory, 'index.html'), 'same');
+    fs.writeFileSync(path.join(actualDirectory, 'nested', '.DS_Store'), 'metadata');
+    expect(() => compare(root)).not.toThrow();
+    fs.writeFileSync(path.join(expectedDirectory, 'missing.html'), '');
+    fs.writeFileSync(path.join(actualDirectory, 'unexpected.html'), '');
+    expect(() => compare(root))
+      .toThrow('Missing files: ["missing.html"]\nUnexpected files: ["unexpected.html"]');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [x] Improve developer experience
- [ ] Others, please explain:

Fixes #2833

**Overview of changes:**

- Exclude `.DS_Store` metadata files from CLI functional-test comparisons at any directory depth.
- Report the exact missing and unexpected paths when generated file sets differ.
- Add a regression test for both behaviors.

**Anything you'd like to highlight/discuss:**

The implementation uses the existing Lodash dependency to calculate path differences.

**Testing instructions:**

N/A; no testing steps beyond the automated tests are required.

**Proposed commit message: (wrap lines at 72 characters)**

`Ignore macOS metadata in CLI tests`

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
