### PR TITLE
Fix closeable directive for plain text content

### DIFF
--- a/packages/vue-components/src/__tests__/Closeable.spec.js
+++ b/packages/vue-components/src/__tests__/Closeable.spec.js
@@ -1,0 +1,12 @@
+import closeable from '../directives/Closeable';
+
+describe('Closeable directive', () => {
+  test('preserves plain text content', () => {
+    const element = document.createElement('div');
+    element.textContent = 'Plain text';
+
+    closeable.mounted(element);
+
+    expect(element.querySelector('.content').textContent).toBe('Plain text');
+  });
+});

--- a/packages/vue-components/src/directives/Closeable.js
+++ b/packages/vue-components/src/directives/Closeable.js
@@ -51,7 +51,7 @@ module.exports = {
 
     const content = document.createElement('div');
     content.classList.add('content');
-    Array.from(el.children).forEach(child => content.append(child));
+    Array.from(el.childNodes).forEach(child => content.append(child));
     el.replaceChildren();
     el.append(content);
     el.classList.add('closeable-wrapper');


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes #2662.

**Overview of changes:**

- Move all child nodes, including text nodes, into the closeable content wrapper.
- Add a regression test for plain-text closeable content.

**Anything you'd like to highlight/discuss:**

The directive previously iterated over `Element.children`, which excludes text nodes. It now uses `childNodes` so plain text is preserved alongside element children.

**Testing instructions:**

N/A.

**Proposed commit message: (wrap lines at 72 characters)**

Fix closeable plain text handling

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [x] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
