### PR TITLE
Prevent log creation when no CLI command runs

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -27,7 +27,10 @@ function printHeader() {
 }
 
 program
-  .hook('preAction', () => preFlightChecks());
+  .hook('preAction', () => {
+    logger.initializeFileLogging();
+    preFlightChecks();
+  });
 
 program
   .addHelpText('beforeAll', printHeader())

--- a/packages/cli/src/util/logger.ts
+++ b/packages/cli/src/util/logger.ts
@@ -34,7 +34,7 @@ function useVerboseConsole(): void {
   consoleTransport.level = 'verbose';
 }
 
-const dailyRotateFileTransport = new DailyRotateFile({
+const dailyRotateFileTransportOptions: DailyRotateFile.DailyRotateFileTransportOptions = {
   format: fileFormat,
   datePattern: 'YYYY-MM-DD',
   dirname: '_markbind/logs',
@@ -43,15 +43,24 @@ const dailyRotateFileTransport = new DailyRotateFile({
   level: 'debug',
   maxFiles: 5,
   auditFile: '_markbind/logs/audit.json',
-});
+};
 
-// Reconfigure the default instance logger winston provides with DailyRotateFile for markbind-cli
+let isFileLoggingInitialized = false;
+
+function initializeFileLogging(): void {
+  if (isFileLoggingInitialized) {
+    return;
+  }
+
+  winston.add(new DailyRotateFile(dailyRotateFileTransportOptions));
+  isFileLoggingInitialized = true;
+}
+
+// Reconfigure the default instance logger winston provides for markbind-cli.
+// File logging is added only when a command is about to run.
 winston.configure({
   exitOnError: false,
-  transports: [
-    consoleTransport,
-    dailyRotateFileTransport,
-  ],
+  transports: [consoleTransport],
 });
 
 export {
@@ -65,6 +74,7 @@ export {
 export {
   useDebugConsole,
   useVerboseConsole,
+  initializeFileLogging,
 };
 
 // eslint-disable-next-line no-console

--- a/packages/cli/test/unit/index.test.ts
+++ b/packages/cli/test/unit/index.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+test('running MarkBind without a command does not create log files', () => {
+  const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'markbind-cli-'));
+  const cliPath = path.resolve(__dirname, '../../dist/index.js');
+
+  const result = spawnSync(process.execPath, [cliPath], { cwd: workingDirectory });
+
+  expect(result.status).toBe(1);
+  expect(fs.existsSync(path.join(workingDirectory, '_markbind'))).toBe(false);
+  fs.removeSync(workingDirectory);
+});


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] DevOps
- [ ] Improve developer experience
- [ ] Others, please explain:

Fixes MarkBind/markbind#2829

**Overview of changes:**

- Defer the rotating file transport until Commander is about to execute a command.
- Keep help and missing-command invocations from creating `_markbind/logs`.
- Add a regression test for invoking MarkBind without a command.

**Anything you'd like to highlight/discuss:**

File logging remains enabled for real commands, and initialization is idempotent.

**Testing instructions:**

N/A; the behavior is covered by the automated CLI tests.

**Proposed commit message: (wrap lines at 72 characters)**

`Delay CLI file logging until command`

---

**Checklist:** :ballot_box_with_check:

- [ ] Updated the documentation for feature additions and enhancements
- [x] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No unrelated changes

---

**Reviewer checklist:**

Indicate the [SEMVER](https://semver.org/) impact of the PR:
- [ ] Major (when you make incompatible API changes)
- [ ] Minor (when you add functionality in a backward compatible manner)
- [ ] Patch (when you make backward compatible bug fixes)

At the end of the review, please label the PR with the appropriate label: `r.Major`, `r.Minor`, `r.Patch`.

Breaking change release note preparation (if applicable):
- To be included in the release note for any feature that is made obsolete/breaking

> Give a brief explanation note about:
>   - what was the old feature that was made obsolete
>   - any replacement feature (if any), and
>   - how the author should modify his website to migrate from the old feature to the replacement feature (if possible).
